### PR TITLE
User account associations not being updated properly when updating pseudonym account multiple times

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,7 +206,7 @@ class User < ActiveRecord::Base
     # Look up the current associations, and remove any duplicates.
     associations_hash = {}
     to_delete = {}
-    self.user_account_associations.each do |a|
+    self.user_account_associations.reload.each do |a|
       if !associations_hash[a.account_id]
         associations_hash[a.account_id] = a
         to_delete[a.account_id] = a
@@ -227,7 +227,7 @@ class User < ActiveRecord::Base
       start ||= enrollment.course
       starting_points << start if start
     end
-    starting_points += self.pseudonym_accounts
+    starting_points += self.pseudonym_accounts.reload
     
     # For each Course, Section, and Account, make sure an association exists.
     starting_points.each do |entity|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,7 +98,9 @@ describe User do
   
   it "should update account associations when a user is associated to an account just by pseudonym" do
     account1 = account_model
+    account2 = account_model
     user = user_with_pseudonym
+
     pseudonym = user.pseudonyms.first
     pseudonym.account = account1
     pseudonym.save
@@ -106,8 +108,16 @@ describe User do
     user.reload
     user.associated_accounts.length.should eql(1)
     user.associated_accounts.first.should eql(account1)
-    
-    account2 = account_model
+
+    # Make sure that multiple sequential updates also work
+    pseudonym.account = account2
+    pseudonym.save
+    pseudonym.account = account1
+    pseudonym.save
+    user.reload
+    user.associated_accounts.length.should eql(1)
+    user.associated_accounts.first.should eql(account1)
+
     account1.parent_account = account2
     account1.save!
     


### PR DESCRIPTION
This issue happens rarely, but I noticed it happen a couple of times on psuedonym#create when the pseudonym account is set to `Account.default` before then being updated to another account.

To fix it I had to force reload some of the associations(`user_account_associations` and `pseudonym_accounts`) in the `User#update_account_associations` method to make sure it loads the proper accounts. I also updated one of the existing tests to test for this issue.

Without this fix user account association updating breaks when the pseudonym account gets updated multiple times in a row.

For ex.

```
pseudonym.account = account1
pseudonym.save
pseudonym.account = account2
pseudonym.save

user.associated_accounts.first # => account1
```

After running the code above the current update_account_associations code updates the user association to point to the first account instead of the second account.
