### PR TITLE
Fix content tags

### DIFF
--- a/app/models/context_module_sub_header.rb
+++ b/app/models/context_module_sub_header.rb
@@ -17,5 +17,5 @@
 #
 
 class ContextModuleSubHeader < Tableless
-  
+  column :id, :integer, 0
 end

--- a/app/models/external_url.rb
+++ b/app/models/external_url.rb
@@ -17,5 +17,5 @@
 #
 
 class ExternalUrl < Tableless
-  
+  column :id, :integer, 0
 end


### PR DESCRIPTION
Currently, if you try to pre-load Content when fetching ContentTag objects, e.g.:

```
ContentTag.all(:include => :content)
```

you will sometimes receive a deprecation notice:

```
activerecord-2.3.11/lib/active_record/association_preload.rb:336:
warning: Object#type is deprecated; use Object#class
```

This happens when you have one or more "tableless" content tags (such as ExternalUrl or ContextModuleSubHeader).  I've attached a pull request that fixes the issue.
