### PR TITLE
Hide deleted users from conversations auto-complete list

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -529,7 +529,7 @@ class ConversationsController < ApplicationController
 
     recipients = []
     if (params[:context] || params[:search]) && ['user', 'context', nil].include?(params[:type])
-      options = {:search => params[:search], :context => params[:context], :limit => limit, :offset => offset}
+      options = {:search => params[:search], :context => params[:context], :limit => limit, :offset => offset, :only_active => true}
 
       contexts = params[:type] != 'user' ? matching_contexts(options.merge(:exclude_ids => exclude.grep(/\A(course|group)_\d+\z/))) : []
       participants = params[:type] != 'context' ? matching_participants(options.merge(:exclude_ids => exclude.grep(/\A\d+\z/).map(&:to_i))) : []

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1738,6 +1738,7 @@ class User < ActiveRecord::Base
     user_conditions = []
     user_conditions << "users.id IN (#{options[:ids].map(&:to_i).join(', ')})" if options[:ids].present?
     user_conditions << "users.id NOT IN (#{options[:exclude_ids].map(&:to_i).join(', ')})" if options[:exclude_ids].present?
+    user_condition_sql << " AND users.workflow_state = 'registered'" if options[:only_active].present? && options[:only_active] == true
     if options[:search] && (parts = options[:search].strip.split(/\s+/)).present?
       parts.each do |part|
         user_conditions << "(#{wildcard('users.name', 'users.short_name', part)})"


### PR DESCRIPTION
Solves issue #106

Since admins can message everyone, all the deleted users showed up on the conversation auto-complete list. It's kind of annoying - since we _don't want_ to message deleted users anyway - so I added a flag to the "messageable_users" method to filter anything but registered users. The filter is only used by the find_recipients method on the conversations controller, so the deleted users still get collected where they are indeed needed.

I'm happy to modify it if it doesn't fit some code convention of canvas, but it'd really like to see this (or some variation) in the stable branch (opposed to seeing all my test users in my university's canvas instance :P).
