### PR TITLE
Delete attached quiz/topic when assignment destroyed

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -448,11 +448,12 @@ class Assignment < ActiveRecord::Base
   alias_method :destroy!, :destroy
   def destroy
     self.workflow_state = 'deleted'
-    self.discussion_topic.destroy if self.discussion_topic && !self.discussion_topic.deleted?
-    self.quiz.destroy if self.quiz && !self.quiz.deleted?
     ContentTag.delete_for(self)
     @grades_affected = true
-    self.save
+    res = self.save
+    self.discussion_topic.destroy if self.discussion_topic && self.discussion_topic.reload && !self.discussion_topic.deleted?
+    self.quiz.destroy if self.quiz && self.quiz.reload && !self.quiz.deleted?
+    res
   end
 
   def time_zone_edited

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -949,6 +949,19 @@ describe Assignment do
       @quiz.state.should eql(:created)
     end
 
+    it "should delete the quiz when destroyed" do
+      assignment_model(:submission_types => "online_quiz")
+      @a.reload
+      @a.submission_types.should eql('online_quiz')
+      @quiz = @a.quiz
+      @quiz.should_not be_nil
+      @quiz.assignment_id.should eql(@a.id)
+      @a.quiz.reload
+      @a.destroy
+      @quiz.reload
+      @quiz.state.should eql(:deleted)
+    end
+
     it "should create a discussion_topic if none exists and specified" do
       assignment_model(:submission_types => "discussion_topic")
       @a.submission_types.should eql('discussion_topic')
@@ -1024,6 +1037,17 @@ describe Assignment do
       @a.state.should eql(:published)
       @topic.reload
       @topic.state.should eql(:active)
+    end
+
+    it "should delete the topic when destroyed" do
+      assignment_model(:submission_types => "discussion_topic")
+      @a.submission_types.should eql('discussion_topic')
+      @topic = @a.discussion_topic
+      @topic.should_not be_nil
+      @topic.assignment_id.should eql(@a.id)
+      @a.destroy
+      @topic.reload
+      @topic.state.should eql(:deleted)
     end
   end
 


### PR DESCRIPTION
When an assignment attached to a quiz or discussion topic is deleted, the corresponding quiz/topic remains.

This can lead to bugs.  For example, after deleting a discussion topic assignment, the _Edit Assignment Settings_ button on the discussion page results in an exception because the assignment no longer exists.

This pull requests fixes the `Assignment.destroy` behavior and adds corresponding specs.

As a side note, is this the correct behavior?  The existing code implies the corresponding quiz/topic **should** be deleted, however It seems reasonable that a professor might actually want to remove the assignment associated with a topic/quiz **without** removing the actual topic/quiz.  Thoughts?
