### PR TITLE
Update etherpad_validator to be less restrictive

### DIFF
--- a/lib/canvas/plugins/validators/etherpad_validator.rb
+++ b/lib/canvas/plugins/validators/etherpad_validator.rb
@@ -26,7 +26,7 @@ module Canvas::Plugins::Validators::EtherpadValidator
         false
       else
         settings.slice(:domain, :name)
-        settings[:domain] = settings[:domain].sub(/https?:/, '').gsub(/\//, '')
+        settings[:domain] = settings[:domain].sub(/https?:/, '').gsub(/(^\/+)|(\/)+$/,'')
         settings[:name] ||= "EtherPad"
         settings
       end


### PR DESCRIPTION
Only strips slashes from start/end of domains.

Most of the Etherpad providers require sub-directories in their URLs to create new documents, the previous regex made that impossible.
