### PR TITLE
Add computed_final_score_with_muted field to submissions API

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -53,6 +53,7 @@ require 'set'
 #           role: StudentEnrollment,
 #           computed_final_score: 41.5,
 #           computed_current_score: 90,
+#           computed_final_score_with_muted: 90
 #           computed_final_grade: 'A-'
 #         }
 #       ],

--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -128,6 +128,7 @@ class SubmissionsApiController < ApplicationController
         if includes.include?('total_scores') && params[:grouped].present?
           hash.merge!(
             :computed_final_score => enrollment.computed_final_score,
+            :computed_final_score_with_muted => enrollment.computed_final_score_with_muted,
             :computed_current_score => enrollment.computed_current_score)
         end
         hash

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -742,6 +742,10 @@ class Enrollment < ActiveRecord::Base
     self.course.score_to_grade(self.computed_final_score)
   end
 
+  def computed_final_grade_with_muted
+    self.course.score_to_grade(self.computed_final_score_with_muted)
+  end
+
   def self.students(opts={})
     with_scope :find => opts do
       find(:all, :conditions => {:type => 'Student'}).map(&:user).compact
@@ -907,7 +911,7 @@ class Enrollment < ActiveRecord::Base
     end
   end
 
-  def self.serialization_excludes; [:uuid,:computed_final_score, :computed_current_score]; end
+  def self.serialization_excludes; [:uuid,:computed_final_score, :computed_current_score, :computed_final_score_with_muted]; end
 
   # enrollment term per-section is deprecated; a section's term is inherited from the
   # course it is currently tied to

--- a/db/migrate/20121210182911_add_computed_final_score_with_muted_to_enrollments.rb
+++ b/db/migrate/20121210182911_add_computed_final_score_with_muted_to_enrollments.rb
@@ -1,0 +1,11 @@
+class AddComputedFinalScoreWithMutedToEnrollments < ActiveRecord::Migration
+  tag :predeploy
+
+  def self.up
+    add_column :enrollments, :computed_final_score_with_muted, :float
+  end
+
+  def self.down
+    remove_column :enrollments, :computed_final_score_with_muted
+  end
+end


### PR DESCRIPTION
I had to make a change to the submissions API to allow it to show final computed grades, including grades for muted assignments. I'd love to see this merged into the trunk. Thanks.
