### PR TITLE
Permit new HTML5 elements figure and figcaption

### DIFF
--- a/vendor/plugins/sanitize_field/lib/sanitize_field.rb
+++ b/vendor/plugins/sanitize_field/lib/sanitize_field.rb
@@ -78,7 +78,7 @@ module Instructure #:nodoc:
         'a', 'b', 'blockquote', 'br', 'caption', 'cite', 'code', 'col',
         'hr', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7', 'h8',
         'del', 'ins', 'iframe',
-        'colgroup', 'dd', 'div', 'dl', 'dt', 'em', 'i', 'img', 'li', 'ol', 'p', 'pre',
+        'colgroup', 'dd', 'div', 'dl', 'dt', 'em', 'figure', 'figcaption', 'i', 'img', 'li', 'ol', 'p', 'pre',
         'q', 'small', 'span', 'strike', 'strong', 'sub', 'sup', 'table', 'tbody', 'td',
         'tfoot', 'th', 'thead', 'tr', 'u', 'ul', 'object', 'embed', 'param'],
 


### PR DESCRIPTION
Allows the new HTML5 elements figure and figcaption to bypass scrubbing by the user input sanitizer.

The HTML5lib sanitizer allows these elements
http://code.google.com/p/html5lib/source/browse/python3/html5lib/sanitizer.py

Specification for figure
http://dev.w3.org/html5/markup/figure.html

Specification for figcaption
http://dev.w3.org/html5/markup/figcaption.html
