### PR TITLE
fix thumbnails over https on local storage

### DIFF
--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -31,7 +31,7 @@ class Thumbnail < ActiveRecord::Base
                    :keep_profile => true
 
     def authenticated_s3_url(*args)
-      "http://#{HostUrl.context_host(attachment.context)}/images/thumbnails/show/#{id}/#{uuid}"
+      "#{HostUrl.protocol}://#{HostUrl.context_host(attachment.context)}/images/thumbnails/show/#{id}/#{uuid}"
     end
   else
     has_attachment :content_type => :image,


### PR DESCRIPTION
When using local storage, thumbnails would always come over http even if you were using https for the rest of the site.  This is a small patch to fix that. 

I have emailed in the signed agreement.
