### PR TITLE
Remove username from test and dev db envs

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -4,7 +4,6 @@ test:
   encoding: utf8
   database: canvas_test
   host: localhost
-  username: canvas
   timeout: 5000
 
 test-in-memory:
@@ -18,14 +17,12 @@ development:
   encoding: utf8
   database: canvas_development
   host: localhost
-  username: canvas
   timeout: 5000
   queue:
     adapter: postgresql
     encoding: utf8
     database: canvas_queue_development
     host: localhost
-    username: canvas
     timeout: 5000
     
 production:


### PR DESCRIPTION
The docs quoted below do not "just work" on OSX.

Database configuration
Now we need to set up your database configuration...

~/canvas$ cp config/database.yml.example config/database.yml
~/canvas$ createdb canvas_development
~/canvas$ createdb canvas_queue_development

The reason being the config/database.yml specifies the db username as "canvas" and there is not any instructions to the create this user.

The simple solution is to remove the username from the db yml for test and dev. This works on OSX but may not in other environments. Alternatively it may be better to just update the docs with instructions to create the user.
