### PR TITLE
fix unhandled exception in db:initial_setup

### DIFF
--- a/lib/tasks/db_load_data.rake
+++ b/lib/tasks/db_load_data.rake
@@ -1028,7 +1028,7 @@ namespace :db do
         Account.default.add_user(user, 'AccountAdmin')
         user
       rescue => e
-        STDERR.puts "Problem creating administrative account, please try again: " + e
+        STDERR.puts "Problem creating administrative account, please try again: #{e}"
         nil
       end
     end


### PR DESCRIPTION
Runnning rake db:initial_setup was blowing up from with in the rescue block. It was because I had too short a password but the error wasn't being printed

On my setup the following code generates a error like "can't convert RuntimeError into String"

I'm using ruby 1.9.3p327 (2012-11-10) [x86_64-darwin12.2.0]

begin
  raise RuntimeError.new "error"
rescue e
  puts "Some string" + e
end

This code however passes

begin
  raise RuntimeError.new "error"
rescue e
  puts "Some string #{e}"
end

I realize this is like a deeper issue than my cheap fix, but I don't have time to get it into. I hope you find this helpful. Below is the command and full stack trace.

matthew.thorley@i26503 canvas-lms$ bundle exec rake db:initial_setup --trace
*\* Invoke db:initial_setup (first_time)
*\* Invoke db:generate_security_key (first_time)
*\* Execute db:generate_security_key
*\* Invoke db:migrate (first_time)
*\* Invoke environment (first_time)
*\* Execute environment
*\* Execute db:migrate
*\* Invoke db:schema:dump (first_time)
*\* Invoke environment
*\* Execute db:schema:dump
*\* Execute db:initial_setup
*\* Invoke db:load_initial_data (first_time)
*\* Invoke db:configure_admin (first_time)
*\* Invoke db:load_environment (first_time)
*\* Invoke db:generate_security_key
*\* Invoke environment
*\* Execute db:load_environment
*\* Execute db:configure_admin
What email address will the site administrator account use? > matthew.thorley@domain.com
Please confirm > matthew.thorley@domain.com
What password will the site administrator use? > ****
Please confirm > ****
rake aborted!
can't convert RuntimeError into String
/Users/matthew.thorley/src/canvas-lms/vendor/plugins/rails_xss/lib/rails_xss/string_ext.rb:26:in `+'
/Users/matthew.thorley/src/canvas-lms/vendor/plugins/rails_xss/lib/rails_xss/string_ext.rb:26:in`add_with_safety'
/Users/matthew.thorley/src/canvas-lms/lib/tasks/db_load_data.rake:1034:in `rescue in create_admin'
/Users/matthew.thorley/src/canvas-lms/lib/tasks/db_load_data.rake:1008:in`create_admin'
/Users/matthew.thorley/src/canvas-lms/lib/tasks/db_load_data.rake:1061:in `block (2 levels) in <top (required)>'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:228:in`call'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:228:in `block in execute'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:223:in`each'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:223:in `execute'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:166:in`block in invoke_with_call_chain'
/Users/matthew.thorley/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:159:in`invoke_with_call_chain'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:187:in `block in invoke_prerequisites'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:185:in`each'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:185:in `invoke_prerequisites'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:165:in`block in invoke_with_call_chain'
/Users/matthew.thorley/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:159:in`invoke_with_call_chain'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:152:in `invoke'
/Users/matthew.thorley/src/canvas-lms/lib/tasks/db_load_data.rake:1137:in`block (2 levels) in <top (required)>'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:228:in `call'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:228:in`block in execute'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:223:in `each'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:223:in`execute'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:166:in `block in invoke_with_call_chain'
/Users/matthew.thorley/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/monitor.rb:211:in`mon_synchronize'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:159:in `invoke_with_call_chain'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/task.rb:152:in`invoke'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/application.rb:143:in `invoke_task'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/application.rb:101:in`block (2 levels) in top_level'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/application.rb:101:in `each'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/application.rb:101:in`block in top_level'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/application.rb:110:in `run_with_threads'
/Users/matthew.thorley/.rvm/gems/ruby-1.9.3-p327@canvas-lms/gems/rake-0.9.6/lib/rake/application.rb:95:in`top_level
