### PR TITLE
Fixed "out_of" Submission Cell number input

### DIFF
--- a/app/coffeescripts/gradebook2/Gradebook.coffee
+++ b/app/coffeescripts/gradebook2/Gradebook.coffee
@@ -518,7 +518,14 @@ define [
     # conjunction with a click listener on <body />. When we 'blur' the grid
     # by clicking outside of it, save the current field.
     onGridBlur: (e) =>
-      return if e.target.className.match(/cell|slick/) or !@gradeGrid.getActiveCell?
+      if e.target.className.match(/cell|slick/) or !@gradeGrid.getActiveCell
+        return
+
+      if e.target.className is 'grade' and @gradeGrid.getCellEditor() instanceof SubmissionCell.out_of 
+        # We can assume that a user clicked the up or down arrows on the
+        # number input, we want to allow them to keep doing that.
+        return
+      
       @gradeGrid.getEditorLock().commitCurrentEdit()
 
     onGridInit: () ->


### PR DESCRIPTION
There was an issue when you would click on the up and down arrows of the number input, that it would reset the cell.  The blur handler would fire, even if you are just clicking the input controls.

Rather than reset the field, this fix allows them to continue to click up or down as many times, as well as use the input field as normal.
