### PR TITLE
fix loading of hair_trigger gem rake tasks

### DIFF
--- a/lib/tasks/hair_trigger.rake
+++ b/lib/tasks/hair_trigger.rake
@@ -1,2 +1,9 @@
 $VERBOSE = nil
-Dir["#{Gem.searcher.find('hair_trigger').full_gem_path}/lib/tasks/*.rake"].each { |ext| load ext }
+
+if Gem.respond_to?(:searcher)
+  gem_path = Gem.searcher.find('hairtrigger').full_gem_path
+else
+  gem_path = Gem::Specification.find_by_name('hairtrigger').full_gem_path
+end
+
+Dir["#{gem_path}/lib/tasks/*.rake"].each { |ext| load ext }


### PR DESCRIPTION
The `hair_trigger.rake` file is attempting to load the hairtrigger gem by an invalid name. This change also avoids future errors from using `Gem.searcher`.
- update the loading of tasks to work with Gem::Specification
- fix gem name and properly load hairtrigger by it's name
