### PR TITLE
render href link in collaboration email template

### DIFF
--- a/app/messages/collaboration_invitation.email.html.erb
+++ b/app/messages/collaboration_invitation.email.html.erb
@@ -27,4 +27,4 @@
          "If that's the wrong email address for this type of collaboration, you'll need to change your profile settings or register with %{service}.",
          :service => asset.collaboration.service_name %></p>
 
-<p><a href="%{link}"><%= t :link, "You can see the details here" %></a></p>
+<p><a href="<%= content :link %>"><%= t :link, "You can see the details here" %></a></p>


### PR DESCRIPTION
Fixed HREF link in collaboration email template that was not rendering.
