### PR TITLE
Fix oembed_retrieve to allow HTTPS oEmbed LTI endpoints

### DIFF
--- a/app/controllers/external_content_controller.rb
+++ b/app/controllers/external_content_controller.rb
@@ -59,9 +59,7 @@ class ExternalContentController < ApplicationController
     endpoint = params[:endpoint]
     url = params[:url]
     uri = URI.parse(endpoint + (endpoint.match(/\?/) ? '&url=' : '?url=') + CGI.escape(url) + '&format=json')
-    http = Net::HTTP.new(uri.host, uri.port);
-    http.use_ssl = true if uri.scheme == 'https'
-    res = http.get(uri.request_uri) rescue "{}"
+    res = Canvas::HTTP.get(uri.to_s) rescue '{}'
     data = JSON.parse(res.body) rescue {}
     if data['type']
       if data['type'] == 'photo' && data['url'].try(:match, /^http/)


### PR DESCRIPTION
Net::HTTP.get(uri) does't support HTTPS URIs; you need to create a
new Net::HTTP object, set use_ssl to true and read the response
object body.
