### PR TITLE
Use "danger button" for Reset Course Content

### DIFF
--- a/app/views/courses/_settings_sidebar.html.erb
+++ b/app/views/courses/_settings_sidebar.html.erb
@@ -78,7 +78,7 @@
           <button type="button" class="btn cancel_button">
             <%= t('#buttons.cancel', 'Cancel') %>
           </button>
-          <button type="submit" class="btn btn-primary submit_button">
+          <button type="submit" class="btn btn-danger submit_button">
             <%= t('buttons.reset', 'Reset Course Content') %>
           </button>
         </div>


### PR DESCRIPTION
Due to the destructive nature of resetting course content, the red _danger button_ does a better job of reflecting just that.

Test Plan:
- Go to a course, click Settings, then Reset Course Content
- Verify that the confirmation button in the dialog is now red
