### PR TITLE
Fix permissions check for interaction alerts

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -20,7 +20,7 @@ class AlertsController < ApplicationController
   before_filter :require_context
 
   def create
-    if authorized_action(@context, @current_user, :manage_alerts)
+    if authorized_action(@context, @current_user, :manage_interaction_alerts)
       @alert = @context.alerts.build(params[:alert])
       if @alert.save
         headers['Location'] = named_context_url(@context, :context_alert_url, @alert.id)
@@ -32,7 +32,7 @@ class AlertsController < ApplicationController
   end
 
   def update
-    if authorized_action(@context, @current_user, :manage_alerts)
+    if authorized_action(@context, @current_user, :manage_interaction_alerts)
       @alert = @context.alerts.find(params[:id])
       if @alert.update_attributes(params[:alert])
         headers['Location'] = named_context_url(@context, :context_alert_url, @alert.id)
@@ -44,7 +44,7 @@ class AlertsController < ApplicationController
   end
 
   def destroy
-    if authorized_action(@context, @current_user, :manage_alerts)
+    if authorized_action(@context, @current_user, :manage_interaction_alerts)
       @alert = @context.alerts.find(params[:id])
       @alert.destroy
       render :json => @alert.to_json


### PR DESCRIPTION
The code should be authorizing against `:manage_interaction_alerts` (a.k.a. Manage Alerts).

Test plan:
1. Enable Alerts (beta) in Account Settings
2. Enable Manage Alerts for Teachers
3. With the old code, enroll a teacher into a course
4. As the teacher, go to course Settings > Alerts, then Add Alert
5. Upon save, "user not authorized to perform that action" will show
6. Now, repeat step 4 with the new code
7. The alert will be created successfully without any error
8. Still with the new code, disable Manage Alerts for Teachers
9. Repeat step 4 one more time (*)
10. The not authorized error will show; this is expected (*)

(*) This assumes the page from step 4 is still open, because after step 8, the Alerts tab will disappear.
