### PR TITLE
Sort terms drop-down lists by start date

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -258,7 +258,7 @@ class UsersController < ApplicationController
           else
             @enrollment_terms = []
             if @root_account == @context
-              @enrollment_terms = @context.enrollment_terms.active.sort_by{|t| t.start_at || Time.parse("Jan 1 2000")}
+              @enrollment_terms = @context.enrollment_terms.active.order(EnrollmentTerm.nulls(:first, :start_at))
             end
             format.html
           end

--- a/app/views/accounts/_add_course_or_user.html.erb
+++ b/app/views/accounts/_add_course_or_user.html.erb
@@ -88,7 +88,7 @@
         <td><%= f.select :account_id, @account.sub_accounts_as_options, :selected => @term && @term.id %></td>
       </tr><tr>
         <td><%= f.label :enrollment_term_id, :en => "Enrollment Term" %></td>
-        <td><%= f.select :enrollment_term_id, @root_account.enrollment_terms.active.sort_by{|t| t.start_at || Time.parse("Jan 1 2000")}.map{|t| [t.name, t.id] }, :selected => @term && @term.id %></td>
+        <td><%= f.select :enrollment_term_id, @root_account.enrollment_terms.active.order(EnrollmentTerm.nulls(:first, :start_at)).map{|t| [t.name, t.id] }, :selected => @term && @term.id %></td>
       </tr><tr>
         <td colspan="2">
           <div class="button-container">

--- a/app/views/accounts/_courses_right_side.html.erb
+++ b/app/views/accounts/_courses_right_side.html.erb
@@ -8,7 +8,7 @@
           <label for="enrollment_term"><%= before_label(t(:enrollment_term_label, "Show courses from the term")) %></label><br />
           <select name="enrollment_term_id">
             <option value="" <%= 'selected' unless @term %>><%= t(:all_terms, "All Terms") %></option>
-            <% @root_account.enrollment_terms.active.sort_by{|t| t.start_at || Time.parse("Jan 1 2000")}.each do |term| %>
+            <% @root_account.enrollment_terms.active.order(EnrollmentTerm.nulls(:first, :start_at)).each do |term| %>
               <option value="<%= term.id %>" <%= 'selected' if term == @term %>><%= term.name %></option>
             <% end %>
           </select>


### PR DESCRIPTION
Terms are easier to select when they are sorted consistently.

Test Plan:
- Create 3+ terms in a different order than their start dates
- Verify terms are sorted in chronological order by start date:
  - `/account/###` _(right sidebar under Course Filtering)_
  - `/account/###` _(click Add a New Course; in the dialog)_
  - `/account/###/users` _(right sidebar under Choose Term)_
- Terms should be sorted the same way as the drop-down list in:
  - Course Settings > Edit Course Details

---

_NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file._
