### PR TITLE
Fix inability to preview deleted/re-uploaded file

### DIFF
--- a/vendor/plugins/attachment_fu/lib/technoweenie/attachment_fu/backends/file_system_backend.rb
+++ b/vendor/plugins/attachment_fu/lib/technoweenie/attachment_fu/backends/file_system_backend.rb
@@ -47,7 +47,6 @@ module Technoweenie # :nodoc:
 
 
         def authenticated_s3_url(*args)
-          return root_attachment.authenticated_s3_url(*args) if self.respond_to?(:root_attachment) && root_attachment
           if args[0].is_a?(Hash) && !args[0][:secure].nil?
             protocol = args[0][:secure] ? 'https://' : 'http://'
           end


### PR DESCRIPTION
_This is an attempt to fix Issue #180. By not recursively fetching the URL from the `root_attachment` (if any), the preview URL will work even if the `root_attachment` was deleted. Thoughts or comments?_

The problem affects an instance using local storage and Google Docs Preview. When previewing a file that was previously deleted, an error message saying "unable to find the document at the original source" will be displayed in Google Docs Preview. This is because the preview URL is no longer valid. In fact, it redirects to the login page.

Test Plan:
- Disable Scribd but enable Google Docs Preview
- Upload a brand new file to a course
- Preview the file
- Delete it, and re-upload the same file
- Confirm that the file can still be previewed

---

_NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file._
