### PR TITLE
Fix inability to upload files without Flash

### DIFF
--- a/public/javascripts/full_files.js
+++ b/public/javascripts/full_files.js
@@ -2151,6 +2151,9 @@ define([
           onInit: function() {
             $add_file_link.text(I18n.t('links.add_files', "Add Files")).triggerHandler('show');
           },
+          onFallback: function() {
+            $swfupload_holder.hide(); // hide to allow click-through to Add File link when Flash is unavailable
+          },
           onSelect: fileUpload.swfFileQueue,
           onCancel: fileUpload.swfCancel,
           onUploadError: fileUpload.swfFileError,


### PR DESCRIPTION
When Flash is unavailable, the fallback Add File link is not clickable, because the invisible `div#swfupload_holder` is blocking it. Hide to fix.

Test plan:
- Use a browser with no Flash installed (or Flash disabled)
- Go to the Files page in any course
- Click on the Add File link
- Confirm that the basic HTML file uploader appears below

---

_NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file._
