### PR TITLE
Hide self registration URL if feature is off

### DIFF
--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -261,11 +261,13 @@ TEXT
           <div class="course_form_more_options" style="display: none; padding-left: 20px;">
             <% if @context.self_enrollment_allowed? %>
               <%= f.check_box :self_enrollment, :class => 'self_enrollment_checkbox' %>
-              <% if @context.root_account.self_registration? %>
-                <%= f.label :self_enrollment, :en => "Let students self-enroll by sharing with them a secret URL or code" %><br/>
-              <% else %>
-                <%= f.label :self_enrollment_without_code, :en => "Let students self-enroll by sharing with them a secret URL" %><br/>
-              <% end %>
+              <label for="course_self_enrollment">
+                <% if @context.root_account.self_registration? %>
+                  <%= t :self_enrollment, "Let students self-enroll by sharing with them a secret URL or code" %>
+                <% else %>
+                  <%= t :self_enrollment_without_code, "Let students self-enroll by sharing with them a secret URL" %>
+                <% end %>
+              </label><br/>
               <div class="open_enrollment_holder" style="display: none;">
               <%= f.check_box :open_enrollment %>
               <%= f.label :open_enrollment, :en => "Add a \"Join this Course\" link to the course home page" %><br/>


### PR DESCRIPTION
`register_url` is only useful if self registration is turned on, so don't mention it unless it is on.

Test Plan:
- Turn self registration off
- Go to a course and enable self enrollment
- Look at self enroll instructions at the bottom of Course Details
- The self register URL should be hidden
- The self enrollment checkbox should not mention a code
- Turn self registration back on
- The self register URL should be visible
- The self enrollment checkbox should mention the code

---

_NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file._
