### PR TITLE
Add tick and cross for peer reviews

### DIFF
--- a/app/views/assignments/_submission_sidebar.html.erb
+++ b/app/views/assignments/_submission_sidebar.html.erb
@@ -1,4 +1,3 @@
-<% cache(['submission_sidebar_render', @current_user_submission, Time.zone.utc_offset].cache_key) do %>
 <div class="details">
   <h3 style="margin: 0;"><%= t 'titles.submission', "Submission" %></h3>
   <% if @assignment.expects_submission? %>
@@ -84,7 +83,6 @@
     </div>
   </div>
 </div>
-<% end %>
 <% if @assignment.expects_submission? && can_do(@assignment, @current_user, :submit) %>
   <ul class="page-action-list">
     <li>


### PR DESCRIPTION
I have added tick and cross for peer reviews: 
A tick if the review is finished
A cross if it is not. 

It's way better to see the actual state of the review. 

I also had to remove the "cache" function, because of that the peer review state wasn't updated in "real time" (the cache must be re-created to see state changes). 

I'm not sure it is the correct way to solve this update problem. Let me know if there is a better one for your application. 

Test plan: 
- create a course with at least one assignment by activating the "peer_review" functionnality
- add two students to this course
- masquerade a student and fill in the assignment
- assign the peer_review to the other student
- masquerade the other student go to the assignment page to see the list of peer reviews assigned to him
- check that you see a cross because the peer review is not yet complete
- achieve the peer review
- check that you see a tick as the peer review is now finished - if you keep the cache functionnality, the tick won't appear untill the cache is updated...
