### PR TITLE
Remove double quotes in generated sql query in assignment_context_scope, which fails in mysql.

### DIFF
--- a/app/controllers/calendar_events_api_controller.rb
+++ b/app/controllers/calendar_events_api_controller.rb
@@ -621,12 +621,12 @@ class CalendarEventsApiController < ApplicationController
     sql = []
     conditions = []
     unless view_unpublished.empty?
-      sql << '("assignments"."context_code" IN (?))'
+      sql << '(assignments.context_code IN (?))'
       conditions << view_unpublished.map(&:asset_string)
     end
 
     unless other.empty?
-      sql << '("assignments"."context_code" IN (?) AND "assignments"."workflow_state" = ?)'
+      sql << '(assignments.context_code IN (?) AND assignments.workflow_state = ?)'
       conditions << other.map(&:asset_string)
       conditions << 'published'
     end


### PR DESCRIPTION
Description:
visit: /api/v1/calendar_events?type=assignment&context_codes...&per_page=50

The double quotes in table and column names gives a mysql syntax error:

(Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '."context_code" IN (','
