### PR TITLE
Pluck appointment ids in update_appointments

### DIFF
--- a/app/models/appointment_group.rb
+++ b/app/models/appointment_group.rb
@@ -384,12 +384,12 @@ class AppointmentGroup < ActiveRecord::Base
     end
 
     if changed.present?
-      CalendarEvent.where(:parent_calendar_event_id => appointments.except(:order), :workflow_state => ['active', 'locked']).update_all(changed)
+      CalendarEvent.where(:parent_calendar_event_id => appointments.except(:order).pluck(:id), :workflow_state => ['active', 'locked']).update_all(changed)
     end
 
     if desc
       appointments.where(:description => description_was).update_all(:description => desc)
-      CalendarEvent.where(:parent_calendar_event_id => appointments.except(:order), :workflow_state => ['active', 'locked'], :description => description_was).update_all(:description => desc)
+      CalendarEvent.where(:parent_calendar_event_id => appointments.except(:order).pluck(:id), :workflow_state => ['active', 'locked'], :description => description_was).update_all(:description => desc)
     end
 
     @new_appointments.each(&:reload) if @new_appointments.present?


### PR DESCRIPTION
Issue: 
When creating an appointment in the calendar, we get a "You can't specify target table 'calendar_events' for update in FROM clause" mysql error. The update_appointments after_save hook generates subqueries in the update statement.

We pre-select the appointment_ids instead of generating a sql sub-query.
