### PR TITLE
Remove duplicate nicknames in generated Swagger documentation

### DIFF
--- a/doc/api/fulldoc/html/swagger/method_view.rb
+++ b/doc/api/fulldoc/html/swagger/method_view.rb
@@ -66,7 +66,7 @@ class MethodView < HashView
       RouteView.new(raw_route, self)
     end.select do |route|
       route.api_path !~ /json$/
-    end
+    end.uniq { |route| route.swagger_path }
   end
 
   def swagger_type
@@ -84,10 +84,82 @@ class MethodView < HashView
     }
   end
 
+  def unique_nickname_suffix route
+    if routes.size == 1
+      ''
+    else
+      unless @nickname_suffix
+        url_list = []
+        routes.each do |r|
+          url_list << r.swagger_path.split("/")
+        end
+        @nickname_suffix = {}
+        calculate_unique_nicknames url_list, 0, []
+      end
+      if @nickname_suffix[route.swagger_path].length > 0
+        "_#{@nickname_suffix[route.swagger_path]}"
+      else
+        ''
+      end
+    end
+  end
+
 protected
   def select_tags(tag_name)
     @method.tags.select do |tag|
       tag.tag_name.downcase == tag_name
     end
+  end
+
+  # Scan through a collection of paths to determine the set of path segments
+  # that uniquely identifies each. Every invocation of the method compares a given
+  # segment in each path; if they match the method is recursively called to compare
+  # the next segment, and if they differ it is called once for each prefix. We assume
+  # that there are no identical URLs.
+  # Once all calls are complete, the outcome is stored in the @nickname_suffix map,
+  # with each URL mapping to its unique nickname.
+  #
+  # The url_list parameter contains a list of the URLs to be compared, with each URL
+  #   formatted as a list of path segments.
+  # The idx parameter indicates the segment in each URL to be compared.
+  # The prefix parameter contains a list of strings that tracks the path segments that
+  #   distinguish the current method invocation.
+  def calculate_unique_nicknames url_list, idx, prefix
+      segments = {}
+      # Check the given segment for each URL, and save all possible values in the
+      # segments map.
+      url_list.each do |url|
+        if url.size == idx 
+          # This URL terminates before the selected segment. Store a null value.
+          segments[:none] = [url]
+        end
+        if url.size > idx
+          # Associate this URL with an entry in the segments map.
+          segments[url[idx]] = [] unless segments[url[idx]]
+          segments[url[idx]] << url
+        end
+      end
+
+      # Do the recursive call based on whether the current segment matches or
+      # differs across all URLs.
+      if segments.size == 1
+        # There is only one option (ie, the segments match). Call this method on the
+        # next segment.
+        calculate_unique_nicknames url_list, idx + 1, prefix
+      end
+      if segments.size > 1
+        # There are at least two possible values for this segment. Handle each option.
+        segments.each do |option, urls|
+          # The path option forms part of the unique prefix, so add it to the prefix list.
+          p = option == :none ? prefix : prefix + [option.gsub(/\{|\}/i, '')]
+          if urls.length == 1
+            # If there was only one URL with this value, we've found that URL's unique nickname.
+            @nickname_suffix[urls.join("/")] = p.join("_")
+          else
+            # Otherwise recurse on the method with all URLs that have this prefix.
+            calculate_unique_nicknames urls, idx + 1, p
+          end
+        end
+      end
   end
 end

--- a/doc/api/fulldoc/html/swagger/route_view.rb
+++ b/doc/api/fulldoc/html/swagger/route_view.rb
@@ -72,20 +72,8 @@ class RouteView < HashView
     arguments.map { |arg| arg.to_swagger }
   end
 
-  def unique_nickname_suffix
-    if method_view.routes.size == 1
-      ''
-    else
-      # This is a hack, and should probably be fixed in future. Rather than
-      # arbitrarily choosing the second segment of the path, we should use an
-      # algorithm to detect what part of the path makes this a unique route
-      # and use that.
-      '_' + api_path.scan(%r{/(\w+)}).map{ |v| v.first }[2]
-    end
-  end
-
   def nickname
-    method_view.nickname + unique_nickname_suffix
+    method_view.nickname + method_view.unique_nickname_suffix(self)
   end
 
   def operation


### PR DESCRIPTION
Fixes #398, which describes how the current Swagger documentation contains
a handful of instances where multiple API operations have the same
nicknames. This occurs when multiple routes with the same third path
segment resolve to a single method.

This change resolves the issue by calculating a unique nickname for each
route, and ensuring that duplicate routes are only documented once.
