### PR TITLE
Add full & sortable name fields to SIS User Import

### DIFF
--- a/doc/api/sis_csv.md
+++ b/doc/api/sis_csv.md
@@ -79,9 +79,21 @@ otherwise) it will <em>not</em> be overwritten</p></td>
 <td>Last name of the user.</td>
 </tr>
 <tr>
+<td>full_name</td>
+<td>text</td>
+<td>Full name of the user. Omit first_name and last_name if this is provided.</td>
+</tr>
+<tr>
+<td>sortable_name</td>
+<td>text</td>
+<td>Sortable name of the user. This is normally inferred from the user's name,
+but you can customize it here.</td>
+</tr>
+<tr>
 <td>short_name</td>
 <td>text</td>
-<td>Display name of the user.</td>
+<td>Display name of the user. This is normally inferred from the user's name,
+but you can customize it here.</td>
 </tr>
 <tr>
 <td>email</td>
@@ -95,6 +107,9 @@ still be provided.</td>
 <td><b>Required field</b>. active, deleted</td>
 </tr>
 </table>
+
+<p>The user's name (either first_name and last_name, or full_name) should always
+be provided. Otherwise, the name will be blanked out.</p>
 
 <p>When a student is 'deleted' all of its enrollments will also be deleted and
 they won't be able to log in to the school's account. If you still want the

--- a/lib/sis/csv/user_importer.rb
+++ b/lib/sis/csv/user_importer.rb
@@ -33,7 +33,7 @@ module SIS
             update_progress
 
             begin
-              importer.add_user(row['user_id'], row['login_id'], row['status'], row['first_name'], row['last_name'], row['email'], row['password'], row['ssha_password'], nil, row['short_name'])
+              importer.add_user(row['user_id'], row['login_id'], row['status'], row['first_name'], row['last_name'], row['email'], row['password'], row['ssha_password'], nil, row['short_name'], row['full_name'], row['sortable_name'])
             rescue ImportError => e
               messages << "#{e}"
             end

--- a/lib/sis/user_importer.rb
+++ b/lib/sis/user_importer.rb
@@ -62,14 +62,14 @@ module SIS
         @users_to_update_account_associations = []
       end
 
-      def add_user(user_id, login_id, status, first_name, last_name, email=nil, password=nil, ssha_password=nil, integration_id=nil, short_name=nil)
-        @logger.debug("Processing User #{[user_id, login_id, status, first_name, last_name, email, password, ssha_password, integration_id, short_name].inspect}")
+      def add_user(user_id, login_id, status, first_name, last_name, email=nil, password=nil, ssha_password=nil, integration_id=nil, short_name=nil, full_name=nil, sortable_name=nil)
+        @logger.debug("Processing User #{[user_id, login_id, status, first_name, last_name, email, password, ssha_password, integration_id, short_name, full_name, sortable_name].inspect}")
 
         raise ImportError, "No user_id given for a user" if user_id.blank?
         raise ImportError, "No login_id given for user #{user_id}" if login_id.blank?
         raise ImportError, "Improper status for user #{user_id}" unless status =~ /\A(active|deleted)/i
 
-        @batched_users << [user_id.to_s, login_id, status, first_name, last_name, email, password, ssha_password, integration_id, short_name]
+        @batched_users << [user_id.to_s, login_id, status, first_name, last_name, email, password, ssha_password, integration_id, short_name, full_name, sortable_name]
         process_batch if @batched_users.size >= @updates_every
       end
 
@@ -86,7 +86,7 @@ module SIS
           while !@batched_users.empty? && tx_end_time > Time.now
             user_row = @batched_users.shift
             @logger.debug("Processing User #{user_row.inspect}")
-            user_id, login_id, status, first_name, last_name, email, password, ssha_password, integration_id, short_name = user_row
+            user_id, login_id, status, first_name, last_name, email, password, ssha_password, integration_id, short_name, full_name, sortable_name = user_row
 
             pseudo = @root_account.pseudonyms.find_by_sis_user_id(user_id.to_s)
             pseudo_by_login = @root_account.pseudonyms.active.by_unique_id(login_id).first
@@ -106,9 +106,14 @@ module SIS
               end
 
               user = pseudo.user
-              user.name = "#{first_name} #{last_name}" unless user.stuck_sis_fields.include?(:name)
+              unless user.stuck_sis_fields.include?(:name)
+                user.name = "#{first_name} #{last_name}"
+                user.name = full_name if full_name.present?
+              end
               unless user.stuck_sis_fields.include?(:sortable_name)
                 user.sortable_name = last_name.present? && first_name.present? ? "#{last_name}, #{first_name}" : "#{first_name}#{last_name}"
+                user.sortable_name = nil if full_name.present? # force User model to infer sortable name from the full name
+                user.sortable_name = sortable_name if sortable_name.present?
               end
               unless user.stuck_sis_fields.include?(:short_name)
                 user.short_name = short_name if short_name.present?
@@ -116,7 +121,10 @@ module SIS
             else
               user = User.new
               user.name = "#{first_name} #{last_name}"
+              user.name = full_name if full_name.present?
               user.sortable_name = last_name.present? && first_name.present? ? "#{last_name}, #{first_name}" : "#{first_name}#{last_name}"
+              user.sortable_name = nil if full_name.present? # force User model to infer sortable name from the full name
+              user.sortable_name = sortable_name if sortable_name.present?
               user.short_name = short_name if short_name.present?
             end
 


### PR DESCRIPTION
Both fields are **optional**. If absent, the user's `name` and `sortable_name` will be set in the same manner as before.

The `full_name` field takes precedence over `first_name` and `last_name`. The `sortable_name` field takes precedence over the inferred value.

This is a follow-up of https://github.com/instructure/canvas-lms/pull/438, which added `short_name`.

---

_NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file._
