### PR TITLE
Tooltips bugs in module sequence footer content when they are too big

### DIFF
--- a/app/views/jst/jquery/ModuleSequenceFooter.handlebars
+++ b/app/views/jst/jquery/ModuleSequenceFooter.handlebars
@@ -2,14 +2,14 @@
 <div class='module-sequence-footer clearfix'>
   <div class="module-sequence-footer-content">
     {{#if previous.show}}
-      <a href="{{previous.url}}" role="button" class="pull-left" data-tooltip data-tooltip-title="{{previous.tooltip}}" aria-describedby="msf{{instanceNumber}}-previous-desc">
+      <a href="{{previous.url}}" role="button" class="pull-left" data-tooltip="right" data-tooltip-title="{{previous.tooltip}}" aria-describedby="msf{{instanceNumber}}-previous-desc">
         <i class="icon-mini-arrow-left"></i>{{#t 'previous'}}Previous{{/t}}
         <span id="msf{{instanceNumber}}-previous-desc" class="hidden" hidden>{{previous.tooltipText}}</span>
       </a>
     {{/if}}
 
     {{#if next.show}}
-      <a href="{{next.url}}" role="button" class="pull-right bordered" data-tooltip data-tooltip-title="{{next.tooltip}}" aria-describedby="msf{{instanceNumber}}-next-desc">
+      <a href="{{next.url}}" role="button" class="pull-right bordered" data-tooltip="left" data-tooltip-title="{{next.tooltip}}" aria-describedby="msf{{instanceNumber}}-next-desc">
         {{#t 'next'}}Next{{/t}}<i class="icon-mini-arrow-right"></i>
         <span id="msf{{instanceNumber}}-next-desc" class="hidden" hidden>{{next.tooltipText}}</span>
       </a>


### PR DESCRIPTION
Hi

Today I'm offering a new bug report and a very quick fix concerning tooltips that show up when you put your mouse over previous/next buttons in module sequence footer content. 
### :1234: Test plan
- Create a course, and 3 pages,
- Put very, very long titles for thoses pages, like this one: "I am a very long title for a very interesting content, and I have to be detailed so that people really get why I am the title of this content" (<= this one should be long enough), 
- Then create a module and add those 3 pages as module items,
- Don't forget to publish the pages if you have the draft state enabled,
- Finally, enter the second page, and put your mouse over previous/next button
- You should see a very big tooltip that shows up over the buttons and prevent users from clicking on them (as the tooltips catch the click)
### :ballot_box_with_check: The fix

My fix is quite easy, I did a little bit of investigation and found that we can specify the position of the tooltip. Instead of the "top" default, I put right, for the previous button and left for the next button so that those tooltips no longer bother people when they want to click on those buttons. 

I did not put right for the next button to prevent the tooltip from showing up outside of small screens. 

I hope this quick fix will be accepted, :blush:

Kulgar. 
