### PR TITLE
Locked assignment : bug in the show view?

### DIFF
--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -3,7 +3,7 @@
   content_for :right_side, render(:partial => "assignment_sidebar")
 %>
 
-<% if @locked && !@locked[:due_at] %>
+<% if @locked && !@locked[:lock_at] %>
   <% js_bundle :module_sequence_footer %>
     
   <h2><%= @assignment.title %></h2>


### PR DESCRIPTION
Hi! 

I am not sure if it's a bug or if I missed something but it seems that "due_at" is never set as a key for the @locked object in this view (I've checked the controller, the views, helpers and models, did not find any place where the key due_at might be set...). 

Here is what I think is the bug:

When an assignment is locked, students cannot see the description of the task any longer which is quite annoying when they have to do some peer reviews. 
## :1234: Test plan
- Create a course, 
- Create a task and select a locked data, (Time.now + 1.minute for instance),
- Add a student to the course, and masquerade him, you can submit the task (or not, it doesn't really matter),
- Masquerade the student (or connect using his logins),
- Go to the task, you should see "This assignment was locked at..." with nothing more
## :ballot_box_with_check: The fix

As I said I'm not sure it is a bug or not... Maybe I just missed something. It seems that as the "due_at" key is never set, the test "!@locked[:due_at]" is always true. If you set it to ":lock_at" as I did, you will see the description of the task AND the message "This assignment was locked at..." as (I think) it is expected. 

Maybe you wanted to do another test here? Such as: "@assignment.due_at.nil?" ?

If you have any insights about this problem, I'll be glad to hear. 
Thanks!

Regis. 
