### PR TITLE
Solving 'unlock_at' edition bug for modules

### DIFF
--- a/app/views/context_modules/_context_module.html.erb
+++ b/app/views/context_modules/_context_module.html.erb
@@ -97,6 +97,7 @@
       <span class="progression_state" style="<%= hidden if editable || !context_module || ((context_module.prerequisites || []).empty? && (context_module.completion_requirements || []).empty?) %>"></span>
       <div class="unlock_details" style="<%= hidden unless context_module && context_module.to_be_unlocked %>">
         <%= t 'module_will_unlock_at', 'Will unlock *%{unlock_date}*', :wrapper => "<span class=\"unlock_at\" #{context_sensitive_datetime_title(context_module.try_rescue(:unlock_at), @context)}>\\1</span>", :unlock_date => (datetime_string(context_module.try_rescue(:unlock_at)) || nbsp) %>
+      	<span class="unlock_at_untranslated hidden"><%= context_module.try_rescue(:unlock_at) || nbsp %></span>
       </div>
     </div><!-- progression_container -->
 

--- a/app/views/context_modules/_context_module_next.html.erb
+++ b/app/views/context_modules/_context_module_next.html.erb
@@ -119,6 +119,7 @@
         <span class="progression_state" style="<%= hidden if editable || !context_module || ((context_module.prerequisites || []).empty? && (context_module.completion_requirements || []).empty?) %>"></span>
         <div class="unlock_details" style="<%= hidden unless context_module && context_module.to_be_unlocked %>">
           <%= t 'module_will_unlock_at', 'Will unlock *%{unlock_date}*', :wrapper => "<span class=\"unlock_at\" #{context_sensitive_datetime_title(context_module.try_rescue(:unlock_at), @context)}>\\1</span>", :unlock_date => (datetime_string(context_module.try_rescue(:unlock_at)) || nbsp) %>
+          <span class="unlock_at_untranslated hidden"><%= context_module.try_rescue(:unlock_at) || nbsp %></span>
         </div>
       </div><!-- progression_container -->
 

--- a/public/javascripts/context_modules.js
+++ b/public/javascripts/context_modules.js
@@ -251,7 +251,8 @@ define([
       editModule: function($module) {
         var $form = $("#add_context_module_form");
         $form.data('current_module', $module);
-        var data = $module.getTemplateData({textValues: ['name', 'unlock_at', 'require_sequential_progress', 'publish_final_grade']});
+        var data = $module.getTemplateData({textValues: ['name', 'unlock_at_untranslated', 'require_sequential_progress', 'publish_final_grade']});
+        data['unlock_at'] = data['unlock_at_untranslated'];
         $form.fillFormData(data, {object_name: 'context_module'});
         var isNew = false;
         if($module.attr('id') == 'context_module_new') {
@@ -266,7 +267,7 @@ define([
           $form.attr('method', 'PUT');
           $form.find(".submit_button").text(I18n.t('buttons.update', "Update Module"));
         }
-        $form.find("#unlock_module_at").prop('checked', data.unlock_at).change()
+        $form.find("#unlock_module_at").prop('checked', data.unlock_at).change();
         $form.find("#require_sequential_progress").attr('checked', data.require_sequential_progress == "true" || data.require_sequential_progress == "1");
         $form.find("#publish_final_grade").attr('checked', data.publish_final_grade == "true" || data.publish_final_grade == "1");
         $form.find(".prerequisites_entry").showIf($("#context_modules .context_module").length > 1);
@@ -508,6 +509,7 @@ define([
 
     // -------- BINDING THE UPDATE EVENT -----------------
     $(".context_module").bind('update', function(event, data) {
+      unformatted_unlock_at = data.context_module.unlock_at;
       data.context_module.unlock_at = $.datetimeString(data.context_module.unlock_at);
       var $module = $("#context_module_" + data.context_module.id);
       $module.attr('aria-label', data.context_module.name);
@@ -521,7 +523,8 @@ define([
         hrefValues: ['id']
       });
 
-      $module.find(".unlock_details").showIf(data.context_module.unlock_at && Date.parse(data.context_module.unlock_at) > new Date());
+      $module.find(".unlock_details").showIf(data.context_module.unlock_at && Date.parse(unformatted_unlock_at) > new Date());
+      $module.find(".unlock_at_untranslated").html(unformatted_unlock_at);
       $module.find(".footer .prerequisites").empty();
 
       for(var idx in data.context_module.prerequisites) {


### PR DESCRIPTION
Hi :)

A new bug to begin this wonderful week! ^^
This concerns the "unlock_at" date for modules and translations. I'm offering a pull request but I'm not sure it is the right way to solve this bug (but it does work). 

## :1234: Test plan

* Create a course, add a module,
* Change your language to whatever... (French for instance, as I use French most of the time),
* Edit the module and check the "unlock this module" checkbox, 
* Add an unlock at date (in the future) and save
* Edit again the module, you should see something like "this isn't a date" (or in French: Merci de choisir une date)
* If you edit something else and save (maybe after refreshing the page), the 'unlock at' date will disappear and thus the module won't unlock at the first inserted date! 

This is due to date translations & date formatting. French format (and I think other languages too) is not recognized when the date is saved, but as you fill in the form using the footer of the module, you fill it with the translation of the date and thus it creates the bug. 

## My fix

I added a new hidden span in the views where I insert the unformatted and untranslated date. Then I get it back from "context_modules.js" when we edit the module and fill in the form using that value instead of the one stored in the "unlock_at" span. 

I also get the untranslated value when we are comparing the date with the actual date for the show/hide "unlock details" information of the footer, because, again, the French translated date (and other translated dates) is not recognized by the Date.parse javascript function (it returns "null" so the test always fails). 

Let me know if I can improve my solution. :)

Kulgar. 