### PR TITLE
Allow more than 1 student to be ignored on upload

### DIFF
--- a/public/javascripts/gradebook_uploads.js
+++ b/public/javascripts/gradebook_uploads.js
@@ -142,7 +142,9 @@ define([
             if($(this).val() > 0) {  //if the thing that was selected is an id( not ignore or add )
               $("#" + thing + "_resolution_template select option").removeAttr("disabled");
               $("#" + thing + "_resolution_template select").each(function(){
-                $("#" + thing + "_resolution_template select").not(this).find("option[value='" + $(this).val() + "']").attr("disabled", true);
+                 if($(this).val() != "ignore" ) {
+                 	$("#" + thing + "_resolution_template select").not(this).find("option[value='" + $(this).val() + "']").attr("disabled", true);
+                 }
               });
             }
             else if ( $(this).val() === "new" ) {


### PR DESCRIPTION
Fixed an error where upon uploading a file to the grade book, you could
only select one student to ignore. The option would be unavailable for
selection after choosing it for one individual. 

Test Plan: Upload a grade book file that includes at least 2 unmatched
students (no sis_id or other identifier besides name). On the
resolution screen, you should be able to choose to ignore more than one
student. The other entries should still correctly grey out once
selected and become available is selected away from.
