### PR TITLE
Add course and term names under group listings

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -40,7 +40,7 @@
           <%= group_name %>
         </span>
         <span class="subtitle ellipsis"><%= group.context.name %></span>
-        <% unless group.context.enrollment_term.default_term? %>
+        <% if group.context_type == 'Course' && !group.context.enrollment_term.default_term? %>
           <span class="subtitle ellipsis"><%= group.context.enrollment_term.name %></span>
         <% end %>
         </a>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -13,7 +13,7 @@
     <li>
       <%= link_to group.name, group_path(group) %>
       <span class="subtitle"><%= group.context.name %></span>
-      <% unless group.context.enrollment_term.default_term? %>
+      <% if group.context_type == 'Course' && !group.context.enrollment_term.default_term? %>
         <span class="subtitle"><%= group.context.enrollment_term.name %></span>
       <% end %>
     </li>


### PR DESCRIPTION
By including course and term, users can more easily tell the difference between multiple groups with the same name.

Also fixed a problem with the group name tooltip.

---

_NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file._
