### PR TITLE
Fixed error handling copying forumla question

### DIFF
--- a/public/javascripts/gradebook_uploads.js
+++ b/public/javascripts/gradebook_uploads.js
@@ -142,9 +142,7 @@ define([
             if($(this).val() > 0) {  //if the thing that was selected is an id( not ignore or add )
               $("#" + thing + "_resolution_template select option").removeAttr("disabled");
               $("#" + thing + "_resolution_template select").each(function(){
-                 if($(this).val() != "ignore" ) {
-                 	$("#" + thing + "_resolution_template select").not(this).find("option[value='" + $(this).val() + "']").attr("disabled", true);
-                 }
+                $("#" + thing + "_resolution_template select").not(this).find("option[value='" + $(this).val() + "']").attr("disabled", true);
               });
             }
             else if ( $(this).val() === "new" ) {


### PR DESCRIPTION
Fixed an error in handling copying forumla question types with an error margin expressed in percentage. When this question type is copied to another course, the field is run through .to_f() which truncates the percent sign, so an error margin of 10% becomes an error margin of 10.  CalculatedInteraction uses .to_f for most of its text to float conversion, but a special case needs to be introduced for this expression. This change intercepts a field that ends with a percent sign and divides it by 100.  Since the importer expects a numerical value as well (also using .to_f for the import) it seems logical to do the conversion here.  This will work to a percision of two decimal places and up to 100%.

Test Plan:
- Create two courses, CourseA and CourseB.
- In CourseA, create a quiz which contains a formula question type.
- Set the error margin to a percentage (e.g. 1%) and add the question.
- In CourseB, copy the quiz from CourseA using “Import Content” with a content type of “Copy a Canvas Course” and at least selecting quizzes.
- Observe in CourseB that the imported quiz will have a tolerance of 1 instead of 1% or 0.01.

For this fix, using this same example, you would see “1%” in CourseA and “0.01” for CourseB.
