### PR TITLE
Fixed error handling copying formula question

### DIFF
--- a/vendor/plugins/qti_exporter/lib/qti/calculated_interaction.rb
+++ b/vendor/plugins/qti_exporter/lib/qti/calculated_interaction.rb
@@ -12,10 +12,9 @@ class CalculatedInteraction < AssessmentItemConverter
     imported_formula = @doc.at_css('calculated formula')
     @question[:imported_formula] = CGI.unescape(imported_formula.text) if imported_formula
     get_calculated_property('answer_tolerance')
-    #check to see if the tolerance is expressed as a percentage
-    if /((^(100(?:\.0{1,2})?))|(?!^0*$)(?!^0*\.0*$)^\d{1,2}(\.\d{1,2})?)%$/.match(@question[:answer_tolerance])
-    	 @question[:answer_tolerance] = (@question[:answer_tolerance].to_f)/100
-	else @question[:answer_tolerance] = @question[:answer_tolerance].to_f if @question[:answer_tolerance]
+    #check to see if the tolerance is expressed as a percentage, if so no need to try to cast it to float.
+	unless /((^(100(?:\.0{1,2})?))|(?!^0*$)(?!^0*\.0*$)^\d{1,2}(\.\d{1,2})?)%$/.match(@question[:answer_tolerance])
+    	  @question[:answer_tolerance] = @question[:answer_tolerance].to_f if @question[:answer_tolerance]
     end
     get_calculated_property('unit_points_percent')
     @question[:unit_points_percent] = @question[:unit_points_percent].to_f if @question[:unit_points_percent]


### PR DESCRIPTION
Fixed an error in handling copying formula question types with an error margin expressed in percentage. When this question type is copied to another course, the field is run through .to_f() which truncates the percent sign, so an error margin of 10% becomes an error margin of 10.  CalculatedInteraction uses .to_f for most of its text to float conversion, but a special case needs to be introduced for this expression. This change intercepts a field that ends with a percent sign (and looks like a percentage) skips the conversion. This will work to a percision of two decimal places and up to 100%.

Test Plan:
- Create two courses, CourseA and CourseB.
- In CourseA, create a quiz which contains a formula question type.
- Set the error margin to a percentage (e.g. 1%) and add the question.
- In CourseB, copy the quiz from CourseA using “Import Content” with a content type of “Copy a Canvas Course” and at least selecting quizzes.
- Observe in CourseB that the imported quiz will have a tolerance of 1 instead of 1%.
