### PR TITLE
LTI: add assignment dates as custom parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1163,7 +1163,8 @@ class ApplicationController < ActionController::Base
 
         adapter = Lti::LtiOutboundAdapter.new(@tool, @current_user, @context).prepare_tool_launch(@return_url, launch_url: @resource_url, link_code: @opaque_id, overrides: {'resource_link_title' => @resource_title})
         if @assignment
-          @tool_settings = adapter.generate_post_payload_for_assignment(@assignment, lti_grade_passback_api_url(@tool), blti_legacy_grade_passback_api_url(@tool))
+          assignment = AssignmentOverrideApplicator.assignment_overridden_for(@assignment, @current_user)
+          @tool_settings = adapter.generate_post_payload_for_assignment(assignment, lti_grade_passback_api_url(@tool), blti_legacy_grade_passback_api_url(@tool))
         else
           @tool_settings = adapter.generate_post_payload
         end

--- a/app/controllers/external_tools_controller.rb
+++ b/app/controllers/external_tools_controller.rb
@@ -217,6 +217,7 @@ class ExternalToolsController < ApplicationController
       }
 
       if assignment
+        assignment = AssignmentOverrideApplicator.assignment_overridden_for(assignment, @current_user)
         launch_settings['tool_settings'] = adapter.generate_post_payload_for_assignment(assignment, lti_grade_passback_api_url(@tool), blti_legacy_grade_passback_api_url(@tool))
       else
         launch_settings['tool_settings'] = adapter.generate_post_payload

--- a/app/models/lti/lti_assignment_creator.rb
+++ b/app/models/lti/lti_assignment_creator.rb
@@ -19,6 +19,11 @@ module Lti
       lti_assignment.points_possible = @assignment.points_possible
       lti_assignment.return_types = -> { @assignment.submission_types_array.map { |type| SUBMISSION_TYPES_MAP[type] }.flatten.compact }
       lti_assignment.allowed_extensions = @assignment.allowed_extensions
+
+      lti_assignment.due_at = @assignment.due_at
+      lti_assignment.lock_at = @assignment.lock_at
+      lti_assignment.unlock_at = @assignment.unlock_at
+
       lti_assignment
     end
   end

--- a/gems/lti_outbound/lib/lti_outbound/lti_assignment.rb
+++ b/gems/lti_outbound/lib/lti_outbound/lti_assignment.rb
@@ -1,5 +1,6 @@
 module LtiOutbound
   class LTIAssignment < LTIModel
-    proc_accessor :id, :source_id, :title, :points_possible, :return_types, :allowed_extensions
+    proc_accessor :id, :source_id, :title, :points_possible, :return_types, :allowed_extensions, 
+                  :unlock_at, :due_at, :lock_at
   end
 end

--- a/gems/lti_outbound/lib/lti_outbound/tool_launch.rb
+++ b/gems/lti_outbound/lib/lti_outbound/tool_launch.rb
@@ -140,9 +140,30 @@ module LtiOutbound
 
       hash['custom_canvas_assignment_title'] = '$Canvas.assignment.title'
       hash['custom_canvas_assignment_points_possible'] = '$Canvas.assignment.pointsPossible'
+      hash['custom_canvas_assignment_unlock_at'] = '$Canvas.assignment.unlockAt'
+      hash['custom_canvas_assignment_due_at'] = '$Canvas.assignment.dueAt'
+      hash['custom_canvas_assignment_lock_at'] = '$Canvas.assignment.lockAt'
       @variable_substitutor.add_substitution('$Canvas.assignment.id', assignment.id)
       @variable_substitutor.add_substitution('$Canvas.assignment.title', assignment.title)
       @variable_substitutor.add_substitution('$Canvas.assignment.pointsPossible', assignment.points_possible)
+
+      if assignment.unlock_at
+        @variable_substitutor.add_substitution('$Canvas.assignment.unlockAt', assignment.unlock_at.iso8601)
+      else
+        @variable_substitutor.add_substitution('$Canvas.assignment.unlockAt', "")
+      end
+
+      if assignment.due_at
+        @variable_substitutor.add_substitution('$Canvas.assignment.dueAt', assignment.due_at.iso8601)
+      else
+        @variable_substitutor.add_substitution('$Canvas.assignment.dueAt', "")
+      end
+
+      if assignment.lock_at
+        @variable_substitutor.add_substitution('$Canvas.assignment.lockAt', assignment.lock_at.iso8601)
+      else
+        @variable_substitutor.add_substitution('$Canvas.assignment.lockAt', "")
+      end
     end
 
     def set_resource_type_keys

--- a/gems/lti_outbound/spec/lti_outbound/lti_assignment_spec.rb
+++ b/gems/lti_outbound/spec/lti_outbound/lti_assignment_spec.rb
@@ -25,4 +25,7 @@ describe LtiOutbound::LTIAssignment do
   it_behaves_like 'it has a proc attribute setter and getter for', :points_possible
   it_behaves_like 'it has a proc attribute setter and getter for', :return_types
   it_behaves_like 'it has a proc attribute setter and getter for', :allowed_extensions
+  it_behaves_like 'it has a proc attribute setter and getter for', :unlock_at
+  it_behaves_like 'it has a proc attribute setter and getter for', :due_at
+  it_behaves_like 'it has a proc attribute setter and getter for', :lock_at
 end

--- a/gems/lti_outbound/spec/lti_outbound/tool_launch_spec.rb
+++ b/gems/lti_outbound/spec/lti_outbound/tool_launch_spec.rb
@@ -68,6 +68,9 @@ describe LtiOutbound::ToolLaunch do
       assignment.points_possible = 100
       assignment.return_types = ['url', 'text']
       assignment.allowed_extensions = ['jpg', 'pdf']
+      assignment.unlock_at = DateTime.parse("2011-04-13 00:00:00")
+      assignment.due_at = DateTime.parse("2011-05-13 00:00:00")
+      assignment.lock_at = DateTime.parse("2011-06-13 00:00:00")
     end
 
     @variable_substitutor = LtiOutbound::VariableSubstitutor.new()#user:@user)
@@ -330,6 +333,9 @@ describe LtiOutbound::ToolLaunch do
       expect(hash['custom_canvas_assignment_title']).to eq 'assignment1'
       expect(hash['custom_canvas_assignment_points_possible']).to eq '100'
       expect(hash['custom_canvas_assignment_id']).to eq 'assignment_id'
+      expect(hash['custom_canvas_assignment_unlock_at']).to eq DateTime.parse("2011-04-13 00:00:00").iso8601
+      expect(hash['custom_canvas_assignment_due_at']).to eq DateTime.parse("2011-05-13 00:00:00").iso8601
+      expect(hash['custom_canvas_assignment_lock_at']).to eq DateTime.parse("2011-06-13 00:00:00").iso8601
     end
 
     it 'includes assignment outcome service params for teacher' do

--- a/spec/models/lti/lti_assignment_creator_spec.rb
+++ b/spec/models/lti/lti_assignment_creator_spec.rb
@@ -25,6 +25,9 @@ describe Lti::LtiAssignmentCreator do
     assignment.title = 'name'
     assignment.points_possible = 10
     assignment.allowed_extensions = 'csv,txt'
+    assignment.unlock_at = DateTime.parse("2011-04-13 00:00:00")
+    assignment.due_at = DateTime.parse("2011-05-13 00:00:00")
+    assignment.lock_at = DateTime.parse("2011-06-13 00:00:00")
 
     lti_assignment = Lti::LtiAssignmentCreator.new(assignment, 'source_id').convert
     lti_assignment.should be_a LtiOutbound::LTIAssignment
@@ -33,6 +36,9 @@ describe Lti::LtiAssignmentCreator do
     lti_assignment.title.should == 'name'
     lti_assignment.points_possible.should == 10
     lti_assignment.allowed_extensions.should == ['csv', 'txt']
+    lti_assignment.unlock_at.should == DateTime.parse("2011-04-13 00:00:00")
+    lti_assignment.due_at.should == DateTime.parse("2011-05-13 00:00:00")
+    lti_assignment.lock_at.should == DateTime.parse("2011-06-13 00:00:00")
   end
 
   it "sets the correct return type for lti assignment launches" do


### PR DESCRIPTION
By sending assignment dates if specified, LTI tool providers can use those dates to e. g. change the behaviour of the tool after the due date.

I didn't provide a test plan as is, but I'm happy to provide one if necessary.