### PR TITLE
Feature: Add support for Gmail Actions

### DIFF
--- a/app/messages/_layout.email.html.erb
+++ b/app/messages/_layout.email.html.erb
@@ -60,5 +60,19 @@
     </tr>
   </table>
 </center>
+<% if content(:footer_link) %>
+  <script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "EmailMessage",
+    "action": {
+      "@type": "ViewAction",
+      "url": "<%= content(:link) %>",
+      "name": "View in Canvas"
+    },
+    "description": "View this event in Canvas"
+  }
+  </script>
+<% end %>
 </body>
 </html>


### PR DESCRIPTION
This allows Gmail users to be able to click on a message's action
button directly, without having to open the email and press the link
in the footer.

![image](https://cloud.githubusercontent.com/assets/1649260/4515552/f7adb4e2-4bc3-11e4-8ccf-d9303e8420db.png)

https://developers.google.com/gmail/actions/

This reduces the amount of time and cognitive workload involved in common
tasks, such as checking grades or viewing new assignments.

This also encourages students to enter the Canvas website and view their
courses more frequently.

If this feature is desired, I will send in a signed contributor agreement.

Any questions, justifications, or improvements, feel free to send my way.

Thanks!
