### PR TITLE
Course Settings API - Grading Standard visibility

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -916,7 +916,9 @@ class CoursesController < ApplicationController
   #   {
   #     "allow_student_discussion_topics": true,
   #     "allow_student_forum_attachments": false,
-  #     "allow_student_discussion_editing": true
+  #     "allow_student_discussion_editing": true,
+  #     "grading_standard_enabled": true,
+  #     "grading_standard_id": 137
   #   }
   def settings
     get_context

--- a/lib/api/v1/course.rb
+++ b/lib/api/v1/course.rb
@@ -26,6 +26,8 @@ module Api::V1::Course
     settings[:allow_student_discussion_topics] = course.allow_student_discussion_topics?
     settings[:allow_student_forum_attachments] = course.allow_student_forum_attachments?
     settings[:allow_student_discussion_editing] = course.allow_student_discussion_editing?
+    settings[:grading_standard_enabled] = course.grading_standard_enabled?
+    settings[:grading_standard_id] = course.grading_standard_id
     settings
   end
 

--- a/spec/lib/api/v1/course_spec.rb
+++ b/spec/lib/api/v1/course_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2014 Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper.rb')
+
+describe Api::V1::Course do
+  include Api::V1::Course
+
+  describe "#course_settings_json" do
+  	it "should return course settings hash" do
+  		course
+  		grading_standard = grading_standard_for(@course)
+  		@course.grading_standard = grading_standard
+  		@course.save
+  		course_settings = course_settings_json(@course)
+  		expect(course_settings[:allow_student_discussion_topics]).to eq true
+  		expect(course_settings[:allow_student_forum_attachments]).to eq false
+  		expect(course_settings[:allow_student_discussion_editing]).to eq true
+  		expect(course_settings[:grading_standard_enabled]).to eq true
+  		expect(course_settings[:grading_standard_id]).to eq grading_standard.id
+  	end
+  end
+end


### PR DESCRIPTION
- Adds visibility for grading_standard_id and grading_standard_enabled boolean to Course Settings API
- Updates documentation for Course Settings API within CoursesController
