### PR TITLE
Always run config file through ERB

### DIFF
--- a/lib/config_file.rb
+++ b/lib/config_file.rb
@@ -41,12 +41,8 @@ module ConfigFile
     config = nil
     path = File.join(Rails.root, 'config', "#{config_name}.yml")
     if File.exists?(path)
-      if Rails.env.test?
-        config_string = ERB.new(File.read(path))
-        config = YAML.load(config_string.result)
-      else
-        config = YAML.load_file(path)
-      end
+      config_string = ERB.new(File.read(path))
+      config = YAML.load(config_string.result)
 
       if config.respond_to?(:with_indifferent_access)
         config = config.with_indifferent_access


### PR DESCRIPTION
I am setting up Canvas in a Docker environment, and so I need to be able to use environment variables in configuration files. I was unable to do that in `config/outgoing_mail.yml`. This patch enables this by always running config files, that gets loaded by `lib/config_file.rb`, through ERB.
