### PR TITLE
set return type of sis_course_id to string from integer

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -58,7 +58,7 @@
 #         "sis_course_id": {
 #           "description": "The unique SIS identifier for the course in which the section belongs. This field is only included if the user has permission to view SIS information.",
 #           "example": 7,
-#           "type": "integer"
+#           "type": "string"
 #         },
 #         "start_at": {
 #           "description": "the start date for the section, if applicable",


### PR DESCRIPTION
It is possible/probably to have a sis_course_id that is not an integer. This change fixes the issue for pandarus.
