### PR TITLE
Warn about setting the password of a SSO user in an SIS import

### DIFF
--- a/doc/api/sis_csv.md
+++ b/doc/api/sis_csv.md
@@ -63,8 +63,9 @@ from the remote system.</td>
 <td>password</td>
 <td>text</td>
 <td><p>If the account is configured to use LDAP or an SSO protocol then
-this isn't needed. Otherwise this is the password that will be used to
-login to Canvas along with the 'login_id' above.</p>
+this should NEVER be set as it will reset users sessions. Otherwise this 
+is the password that will be used to login to Canvas along with the 
+'login_id' above.</p>
 <p>If the user already has a password (from previous SIS import or
 otherwise) it will <em>not</em> be overwritten</p></td>
 </tr>


### PR DESCRIPTION
Setting the password on a user when you are using a SSO or LDAP will reset the users session when the SIS import happens.
Per 715541 zendesk ticket.