### PR TITLE
Fixed a conversion from params to sym in course_controller update method

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1966,7 +1966,13 @@ class CoursesController < ApplicationController
       end
 
       if params[:course][:event] && @course.grants_right?(@current_user, session, :change_course_state)
-        event = params[:course].delete(:event)
+  	 # John Stauffacher (john.stauffacher@gmail.com) - prevents a nasty conversion from params to_sym 
+         if !["claim", "offer"].include? params[:course][:event]
+            flash[:error] = t('errors.unknownevent','Course event type unknown')
+            params[:course].delete(:event)
+            redirect_to(course_url(@course)) and return
+         end
+	event = params[:course].delete(:event)
         event = event.to_sym
         if event == :claim && !@course.unpublishable?
           flash[:error] = t('errors.unpublish', 'Course cannot be unpublished if student submissions exist.')


### PR DESCRIPTION
Fixed a nasty situation where we course[event] was getting cast to symbol and could potentially pollute the symbol table and consume all running memory. Symbols are not GCd