### PR TITLE
Say "web browser" instead of "internet browser"

### DIFF
--- a/app/views/context_modules/url_show.html.erb
+++ b/app/views/context_modules/url_show.html.erb
@@ -15,17 +15,17 @@
     <div>
       <a id="open_url_button" target="_blank" role="link" class="btn external"
          href="<%= @tag.url %>"
-         title="<%= t('open_url_button', "Open %{title} in a new window", :title => @tag.title) %>"
-         aria-label="<%= t('open_url_button', "Open %{title} in a new window", :title => @tag.title) %>">
-        <%= t('open_url_button', "Open %{title} in a new window", :title => @tag.title) %>
+         title="<%= t("Open %{title} in a new window", :title => @tag.title) %>"
+         aria-label="<%= t("Open %{title} in a new window", :title => @tag.title) %>">
+        <%= t("Open %{title} in a new window", :title => @tag.title) %>
       </a>
     </div>
   <% else %>
     <% if @tag.url.start_with?('http://') %>
       <div class="alert alert-error" id="insecure_content_msg">
         <p>
-          <%= t('tool_insecure_warning', 'You are trying to launch insecure content from within a
-            secure site (canvas).  Some internet browsers may prevent this content from loading.') %>
+          <%= t('You are trying to launch insecure content from within a secure site (canvas).
+            Some internet browsers may prevent this content from loading.') %>
         </p>
       </div>
     <% end %>

--- a/app/views/context_modules/url_show.html.erb
+++ b/app/views/context_modules/url_show.html.erb
@@ -25,7 +25,7 @@
       <div class="alert alert-error" id="insecure_content_msg">
         <p>
           <%= t('You are trying to launch insecure content from within a secure site (canvas).
-            Some internet browsers may prevent this content from loading.') %>
+            Some web browsers may prevent this content from loading.') %>
         </p>
       </div>
     <% end %>

--- a/app/views/lti/_lti_message.html.erb
+++ b/app/views/lti/_lti_message.html.erb
@@ -7,7 +7,7 @@
 
 <% if @lti_launch.resource_url.start_with?('http://') %>
     <div class="alert alert-error" id="insecure_content_msg">
-        <p><%= t('You are trying to launch insecure content from within a secure site (canvas).  Some internet browsers may prevent this content from loading.') %></p>
+        <p><%= t('You are trying to launch insecure content from within a secure site (canvas).  Some web browsers may prevent this content from loading.') %></p>
         <p id="load_failure" class="hide"><%= t('It looks like your content might not load.  You can use this button to try launching it in a new tab.') %></p>
     </div>
 <% end %>

--- a/app/views/lti/_lti_message.html.erb
+++ b/app/views/lti/_lti_message.html.erb
@@ -7,8 +7,8 @@
 
 <% if @lti_launch.resource_url.start_with?('http://') %>
     <div class="alert alert-error" id="insecure_content_msg">
-        <p><%= t('tool_insecure_warning', 'You are trying to launch insecure content from within a secure site (canvas).  Some internet browsers may prevent this content from loading.') %></p>
-        <p id="load_failure" class="hide"><%= t('tool_load_failure', 'It looks like your content might not load.  You can use this button to try launching it in a new tab.') %></p>
+        <p><%= t('You are trying to launch insecure content from within a secure site (canvas).  Some internet browsers may prevent this content from loading.') %></p>
+        <p id="load_failure" class="hide"><%= t('It looks like your content might not load.  You can use this button to try launching it in a new tab.') %></p>
     </div>
 <% end %>
 


### PR DESCRIPTION
The term "Internet browser" is not used professionally because is it not
technically correct. Many programs use the Internet: E-mail clients such
as Thunderbird and Outlook, instant messangers, smartphone apps, game
consoles, and much more. Web browsers are just another kind of program
that uses the Internet; they use it specifically to access the
collection of URI-accessible documents known as the World Wide Web.