### PR TITLE
[Solving Bug] Solving send data truncated bug

### DIFF
--- a/config/initializers/action_pack.rb
+++ b/config/initializers/action_pack.rb
@@ -13,7 +13,7 @@ ActionController::DataStreaming.class_eval do
   alias_method_chain :send_file, :content_length
 
   def send_data_with_content_length(data, options = {})
-    headers.merge!('Content-Length' => data.length.to_s) if data.respond_to?(:length)
+    headers.merge!('Content-Length' => data.bytesize.to_s) if data.respond_to?(:bytesize)
     send_data_without_content_length(data, options)
   end
   alias_method_chain :send_data, :content_length

--- a/spec/controllers/gradebooks_controller_spec.rb
+++ b/spec/controllers/gradebooks_controller_spec.rb
@@ -332,6 +332,18 @@ describe GradebooksController do
           Enrollment.expects(:recompute_final_score).never
           get 'show', :course_id => @course.id, :init => 1, :assignments => 1, :format => 'csv'
         end
+        it "should get all the expected datas even with multibytes characters", :focus => true do
+          @course.assignments.create(:title => "Déjà vu")
+          get 'show', :course_id => @course.id, :init => 1, :assignments => 1, :format => 'csv'
+          raw_csv = @course.gradebook_to_csv({
+            :user => @teacher,
+            :include_priors => false,
+            :include_sis_id => true
+          })
+
+          downloaded_body = response.body.mb_chars.limit(response.header['Content-Length'].to_i)
+          expect(downloaded_body).to eq(raw_csv)
+        end
       end
 
       context "with teacher that prefers Grid View" do


### PR DESCRIPTION
Hi everyone, 

I have discovered a new bug and quite a tricky one. 

How to reproduce it:
* find any action controller that uses the "send_data" method (to export a CSV for instance, like gradebook.csv),
* create data with multibytes characters (in users' names for instance), those data must be included in the ones you want to export, 
* export those data, the file you get should miss some characters at the end of the file, you can check the file you get by comparing it to a CSV that you generate using the ruby console, 

One of my exported files (gradebook.csv) was truncated because of multibytes characters in users' names. 

I did a lot of reverse engineering and I finally discovered that you were somewhat supercharging the send_data method in "config/initializers/action_pack.rb" by defining the "Content-Length" header. 

I did some research and came across this issue: https://rails.lighthouseapp.com/projects/8994/tickets/2661-fix-for-send_data-content-length-header-in-ruby-19

This was related to Ruby On Rails 2.3.4 but it is the exact same issue. Looking at their patch I found that for ruby > 1.9 they are now using "bytesize" method instead of "length" for this header. 

So I'm offering this fix which does exactly that and which solves my truncated data issue. 

Let me know if you need any further information,
Regis

Original PR: #616