### PR TITLE
Add 'mark done' module progression constraint (Take 5)

### DIFF
--- a/app/coffeescripts/bundles/assignment_show.coffee
+++ b/app/coffeescripts/bundles/assignment_show.coffee
@@ -6,9 +6,14 @@ require [
   'compiled/views/PublishButtonView',
   'compiled/views/assignments/SpeedgraderLinkView',
   'compiled/util/vddTooltip',
+  'compiled/util/markAsDone'
   'compiled/jquery/ModuleSequenceFooter'
   'jquery.instructure_forms'
-], (INST, I18n, $, Assignment, PublishButtonView, SpeedgraderLinkView, vddTooltip) ->
+], (INST, I18n, $, Assignment, PublishButtonView, SpeedgraderLinkView, vddTooltip, MarkAsDone) ->
+
+  $ ->
+    $('#mark-as-done-checkbox').click ->
+      MarkAsDone.toggle(this)
 
   $ ->
     $el = $('#assignment_publish_button')

--- a/app/coffeescripts/bundles/wiki_page_show.coffee
+++ b/app/coffeescripts/bundles/wiki_page_show.coffee
@@ -2,8 +2,13 @@ require [
   'jquery'
   'compiled/models/WikiPage'
   'compiled/views/wiki/WikiPageView'
+  'compiled/util/markAsDone'
   'compiled/jquery/ModuleSequenceFooter'
-], ($, WikiPage, WikiPageView) ->
+], ($, WikiPage, WikiPageView, MarkAsDone) ->
+
+  $ ->
+    $('#mark-as-done-checkbox').click ->
+      MarkAsDone.toggle(this)
 
   $('body').addClass('show')
 

--- a/app/coffeescripts/util/markAsDone.coffee
+++ b/app/coffeescripts/util/markAsDone.coffee
@@ -1,0 +1,16 @@
+define [
+  'jquery'
+  'jquery.ajaxJSON'
+], ($) ->
+  toggle: (button) ->
+    data = $(button).data.bind($(button))
+    $.ajaxJSON(
+      (data 'url'),
+      if data 'isChecked' then 'DELETE' else 'PUT',
+      {},
+      ->
+        data 'isChecked', !(data 'isChecked')
+        $(button).toggleClass 'btn-success'
+        $('i', button).toggleClass 'icon-empty icon-complete'
+        $('.mark-done-labels span', button).toggleClass 'visible'
+    )

--- a/app/coffeescripts/views/wiki/WikiPageView.coffee
+++ b/app/coffeescripts/views/wiki/WikiPageView.coffee
@@ -79,6 +79,7 @@ define [
 
     afterRender: ->
       super
+      $(".header-bar-outer-container .header-bar-right").append($("#mark-as-done-checkbox"))
       @navigateToLinkAnchor()
       @reloadView = new WikiPageReloadView
         el: @$pageChangedAlert

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -148,6 +148,9 @@ class AssignmentsController < ApplicationController
 
       @assignment_menu_tools = external_tools_display_hashes(:assignment_menu)
 
+
+      @mark_done = MarkDonePresenter.new(self, @context, params["module_item_id"], @current_user)
+
       respond_to do |format|
         if @assignment.submission_types == 'online_quiz' && @assignment.quiz
           format.html { redirect_to named_context_url(@context, :context_quiz_url, @assignment.quiz.id) }
@@ -158,6 +161,7 @@ class AssignmentsController < ApplicationController
         elsif @assignment.submission_types == 'external_tool' && @assignment.external_tool_tag && @unlocked
           tag_type = params[:module_item_id].present? ? :modules : :assignments
           format.html { content_tag_redirect(@context, @assignment.external_tool_tag, :context_url, tag_type) }
+
         else
           format.html { render }
         end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -98,6 +98,7 @@ class WikiPagesController < ApplicationController
 
       js_env :wiki_page_menu_tools => external_tools_display_hashes(:wiki_page_menu)
 
+      @mark_done = MarkDonePresenter.new(self, @context, params["module_item_id"], @current_user)
       @padless = true
     end
   end

--- a/app/models/content_tag.rb
+++ b/app/models/content_tag.rb
@@ -373,6 +373,10 @@ class ContentTag < ActiveRecord::Base
   def context_module_action(user, action, points=nil)
     self.context_module.update_for(user, action, self, points) if self.context_module
   end
+
+  def progression_for_user(user)
+    context_module.context_module_progressions.where(user_id: user.id).first
+  end
   
   def content_asset_string
     @content_asset_string ||= "#{self.content_type.underscore}_#{self.content_id}"

--- a/app/models/context_module.rb
+++ b/app/models/context_module.rb
@@ -327,8 +327,8 @@ class ContextModule < ActiveRecord::Base
 
     tags = self.content_tags.not_deleted.index_by(&:id)
     requirements.select do |req|
-      if req[:id] && tag = tags[req[:id]]
-        if %w(must_view must_contribute).include?(req[:type])
+      if req[:id] && (tag = tags[req[:id]])
+        if %w(must_view must_mark_done must_contribute).include?(req[:type])
           true
         elsif %w(must_submit min_score max_score).include?(req[:type])
           true if tag.scoreable?
@@ -520,6 +520,8 @@ class ContextModule < ActiveRecord::Base
       case requirement[:type]
       when 'must_view'
         action == :read || action == :contributed
+      when 'must_mark_done'
+        action == :done
       when 'must_contribute'
         action == :contributed
       when 'must_submit'
@@ -538,6 +540,8 @@ class ContextModule < ActiveRecord::Base
     case req[:type]
     when 'must_view'
       t('requirements.must_view', "must view the page")
+    when 'must_mark_done'
+      t("must mark as done")
     when 'must_contribute'
       t('requirements.must_contribute', "must contribute to the page")
     when 'must_submit'

--- a/app/models/context_module_progression.rb
+++ b/app/models/context_module_progression.rb
@@ -53,6 +53,12 @@ class ContextModuleProgression < ActiveRecord::Base
     self.save
   end
 
+  def uncomplete_requirement(id)
+    requirement = requirements_met.find {|r| r[:id] == id}
+    requirements_met.delete(requirement)
+    mark_as_outdated
+  end
+  
   class CompletedRequirementCalculator
     attr_accessor :requirements_met, :view_requirements
 
@@ -148,7 +154,7 @@ class ContextModuleProgression < ActiveRecord::Base
 
       if req[:type] == 'must_view'
         calc.view_requirement(req)
-      elsif req[:type] == 'must_contribute'
+      elsif %w(must_contribute must_mark_done).include? req[:type]
         calc.requirement_met(req, false)
       elsif req[:type] == 'must_submit'
         sub = get_submission_or_quiz_submission(tag)

--- a/app/presenters/mark_done_presenter.rb
+++ b/app/presenters/mark_done_presenter.rb
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2012 - 2015 Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+class MarkDonePresenter
+
+  def initialize(ctrl, context, module_item_id, user)
+    @ctrl = ctrl
+    @context = context
+    @item = ContentTag.find(module_item_id.to_i) if module_item_id
+    @module = @item.context_module if @item
+    @user = user
+  end
+
+  def has_requirement?
+    return false unless @module
+    return false unless @context.grants_any_right?(@user, @ctrl.session, :participate_as_student)
+    requirements = @module.completion_requirements
+    requirement = requirements.find {|i| i[:id] == @item.id}
+    return false unless requirement
+    requirement[:type] == 'must_mark_done'
+  end
+
+  def checked?
+    return false unless has_requirement?
+    progression = @module.context_module_progressions.find{|p| p[:user_id] == @user.id}
+    return false unless progression
+    !!progression.requirements_met.find {|r| r[:id] == @item.id && r[:type] == "must_mark_done" }
+  end
+
+  def api_url
+    @ctrl.api_v1_course_context_module_item_done_path(:course_id => @context.id,
+                                                      :module_id => @item.context_module_id,
+                                                      :id => @item.id)
+  end
+end

--- a/app/stylesheets/bundles/assignments.scss
+++ b/app/stylesheets/bundles/assignments.scss
@@ -1,5 +1,6 @@
 @import "base/environment";
 @import "pages/assignments/assignments.scss";
 @import "pages/shared/grading_standards.scss";
+@import "pages/shared/mark_as_done.scss";
 @import "vendor/embed_content.scss";
 

--- a/app/stylesheets/bundles/wiki_page.scss
+++ b/app/stylesheets/bundles/wiki_page.scss
@@ -1,0 +1,2 @@
+@import "pages/shared/mark_as_done.scss";
+

--- a/app/stylesheets/components/_g_context_modules.scss
+++ b/app/stylesheets/components/_g_context_modules.scss
@@ -366,6 +366,12 @@ $context_module_bg_color: #f2f3f4;
       display: block;
     }
   }
+  &.must_mark_done_requirement {
+    .completion_requirement,
+    .must_mark_done_requirement {
+      display: block;
+    }
+  }
   &.must_contribute_requirement {
     .completion_requirement,
     .must_contribute_requirement {

--- a/app/stylesheets/pages/shared/_mark_as_done.scss
+++ b/app/stylesheets/pages/shared/_mark_as_done.scss
@@ -1,0 +1,10 @@
+.mark-done-labels {
+    span {
+        display: none;
+    }
+
+    .visible {
+        display: inline;
+    }
+}
+

--- a/app/views/assignments/show.html.erb
+++ b/app/views/assignments/show.html.erb
@@ -55,9 +55,17 @@
     </div>
   <% else %>
     <!--Student View-->
-    <h1 class="title">
-      <%= @assignment.title %>
-    </h1>
+    <div class='assignment-title'>
+      <div class='title-content'>
+        <h1 class="title">
+          <%= @assignment.title %>
+        </h1>
+      </div>
+      <div class="edit-content">
+        <%= render "shared/mark_as_done" %>
+      </div>
+    </div>
+
     <ul class='student-assignment-overview'>
       <li>
         <span class='title'><%= t :due_at, 'Due' %></span>

--- a/app/views/context_modules/_content_next.html.erb
+++ b/app/views/context_modules/_content_next.html.erb
@@ -475,6 +475,7 @@ TEXT
     <span style="padding: 0 4px;">
       <select class="type assignment_requirement_picker">
         <option class="any" value="must_view"><%= t('requirements.must_view', %{view the item}) %></option>
+        <option class="assignment wiki_page" value="must_mark_done"><%= t(%{mark as done}) %></option>
         <option class="wiki_page discussion_topic" value="must_contribute"><%= t('requirements.must_contribute', %{contribute to the page}) %></option>
         <option class="assignment quiz graded" value="must_submit"><%= t('requirements.must_submit', %{submit the assignment}) %></option>
         <option class="assignment quiz graded" value="min_score"><%= t('requirements.must_score_at_least', %{score at least}) %></option>
@@ -542,4 +543,3 @@ TEXT
     </li>
   </ul>
 <% end %>
-

--- a/app/views/context_modules/_module_item_next.html.erb
+++ b/app/views/context_modules/_module_item_next.html.erb
@@ -82,6 +82,10 @@
           <span class="unfulfilled"><%= t('must_view.unfulfilled', %{must view the page}) %></span>
           <span class="fulfilled"><%= t('must_view.fulfilled', %{viewed the page}) %></span>
         </span>
+        <span class="requirement_type must_mark_done_requirement">
+          <span class="unfulfilled"><%= t 'must mark as done' %></span>
+          <span class="fulfilled"><%= t 'marked done' %></span>
+        </span>
         <span class="requirement_type must_contribute_requirement">
           <span class="unfulfilled"><%= t('must_contribute.unfulfilled', %{must contribute to the content of the page}) %></span>
           <span class="fulfilled"><%= t('must_contribute.fulfilled', %{contributed to the content of the page}) %></span>

--- a/app/views/shared/_mark_as_done.html.erb
+++ b/app/views/shared/_mark_as_done.html.erb
@@ -1,0 +1,12 @@
+<% if @mark_done and @mark_done.has_requirement? %>
+  <div id="mark-as-done-container">
+    <button id="mark-as-done-checkbox" class="btn <%= @mark_done.checked? ? "btn-success" : '' %>"
+         data-url="<%= @mark_done.api_url %>" data-is-checked="<%= @mark_done.checked? %>">
+      <i class="<%= @mark_done.checked? ? "icon-complete" : "icon-empty"%>"> </i>
+      <span class="mark-done-labels">
+        <span class="<%= @mark_done.checked? ? "visible" : "" %>"><%= t('Done') %></span>
+        <span class="<%= @mark_done.checked? ? "" : "visible"%>"><%= t('Mark as done')%></span>
+      </span>
+    </button>
+  </div>
+<% end %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -1,5 +1,8 @@
 <%
   content_for :page_title, join_title(@page.title.to_s, @context.name)
   js_bundle :wiki_page_show
+  jammit_css :wiki_page
 %>
+
+<%= render "shared/mark_as_done" %>
 <div id="wiki_page_show"></div>

--- a/config/assets_real.yml
+++ b/config/assets_real.yml
@@ -160,6 +160,8 @@ stylesheets:
     - public/stylesheets/compiled/bundles/external_tool_full_width.css
   terms:
     - public/stylesheets/compiled/bundles/terms.css
+  wiki_page:
+    - public/stylesheets/compiled/bundles/wiki_page.css
   # Client Apps:
   canvas_quizzes:
     - public/stylesheets/compiled/bundles/canvas_quizzes.css

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1318,6 +1318,8 @@ CanvasRails::Application.routes.draw do
     scope(controller: :context_module_items_api) do
       get "courses/:course_id/modules/:module_id/items", action: :index, as: 'course_context_module_items'
       get "courses/:course_id/modules/:module_id/items/:id", action: :show, as: 'course_context_module_item'
+      put "courses/:course_id/modules/:module_id/items/:id/done", action: :mark_as_done, as: 'course_context_module_item_done'
+      delete "courses/:course_id/modules/:module_id/items/:id/done", action: :mark_as_not_done, as: 'course_context_module_item_not_done'
       get "courses/:course_id/module_item_redirect/:id", action: :redirect, as: 'course_context_module_item_redirect'
       get "courses/:course_id/module_item_sequence", action: :item_sequence
       post "courses/:course_id/modules/:module_id/items", action: :create, as: 'course_context_module_items_create'

--- a/public/javascripts/context_modules.js
+++ b/public/javascripts/context_modules.js
@@ -611,6 +611,7 @@ define([
         .removeClass('min_score_requirement')
         .removeClass('max_score_requirement')
         .removeClass('must_view_requirement')
+        .removeClass('must_mark_done_requirement')
         .removeClass('must_submit_requirement')
         .removeClass('must_contribute_requirement')
         .find('.criterion').removeClass('defined');

--- a/spec/models/context_module_progression_spec.rb
+++ b/spec/models/context_module_progression_spec.rb
@@ -216,4 +216,21 @@ describe ContextModuleProgression do
     expect(progression2).to be_locked
     expect(progression3).to be_locked
   end
+
+  describe "#uncomplete_requirement" do
+    it "should uncomplete the requirement" do
+      setup_modules
+      progression = @tag.context_module_action(@user, :read)
+      progression.uncomplete_requirement(@tag.id)
+      expect(progression.requirements_met.length).to be(0)
+
+    end
+
+    it "should not change anything when given an ID that does not exist" do
+      setup_modules
+      progression = @tag.context_module_action(@user, :read)
+      progression.uncomplete_requirement(-1)
+      expect(progression.requirements_met.length).to be(1)
+    end
+  end
 end

--- a/spec/presenters/mark_done_presenter_spec.rb
+++ b/spec/presenters/mark_done_presenter_spec.rb
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2015 Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe MarkDonePresenter do
+
+  before :each do
+    course_with_student
+  end
+
+  let(:the_module) { @course.context_modules.create(:name => "mark_as_done_module") }
+  let(:wiki_page) { @course.wiki.wiki_pages.create(:title => "mark_as_done page", :body => "") }
+
+  def add_wiki_page_to_module
+    the_module.add_item(:id => wiki_page.id, :type => 'wiki_page')
+  end
+
+  def create_presenter(tag)
+    MarkDonePresenter.new(nil, @course, tag.id, @user)
+  end
+
+  def add_mark_done_requirement(tag)
+    the_module.completion_requirements = {
+      tag.id => { :type => 'must_mark_done' },
+    }
+    the_module.save!
+  end
+
+  def mark_page_as_done(tag)
+    tag.context_module_action(@user, :done)
+  end
+
+  describe "#has_requirement?" do
+
+    it "should be false when there is no mark as done requirement" do
+      tag = add_wiki_page_to_module
+      subject = create_presenter tag
+      expect(subject).not_to have_requirement
+    end
+
+    it "should be true when there is a mark as done requirement" do
+      tag = add_wiki_page_to_module
+      add_mark_done_requirement tag
+      subject = create_presenter tag
+      expect(subject).to have_requirement
+    end
+  end
+
+  describe "#checked?" do
+
+    it "should be true when the mark as done requirement is fulfilled" do
+      tag = add_wiki_page_to_module
+      add_mark_done_requirement tag
+      mark_page_as_done tag
+      subject = create_presenter tag
+      expect(subject).to be_checked
+    end
+
+    it "should be false when the mark as done requirement is not fulfilled" do
+      tag = add_wiki_page_to_module
+      add_mark_done_requirement tag
+      subject = create_presenter tag
+
+      expect(subject).not_to be_checked
+    end
+  end
+end


### PR DESCRIPTION
In module based courses, to make it easier for students to keep
track of their progress. This commit adds support for 'mark as
done' requirements to the module progressions. This to better
cater to students who needs multiple reading sessions before they
feel they are done with a module item (i.e wiki pages).

This requirement can also be used on assignments that are purely
for self studying.

Test plan:
  - In a course with modules
  - Make sure there is one wiki page and one assignment associated with a module
  - Add 'mark as done' as module completion requirements to both module items
  - As a student of the course, go to the modules page
  - Oberve that both module items are labeled as "must mark as done"
  - Visit the module items each in turn and click the "mark as done" button.
  - On the modules page, oberve that both module items are now labeled as "marked done".