### PR TITLE
Make Inbox/Conversations show display name

### DIFF
--- a/lib/messageable_user.rb
+++ b/lib/messageable_user.rb
@@ -17,7 +17,7 @@
 #
 
 class MessageableUser < User
-  COLUMNS = ['id', 'name', 'avatar_image_url', 'avatar_image_source'].map{ |col| "users.#{col}" }
+  COLUMNS = ['id', 'short_name', 'name', 'avatar_image_url', 'avatar_image_source'].map{ |col| "users.#{col}" }
   SELECT = COLUMNS.join(", ")
   AVAILABLE_CONDITIONS = "users.workflow_state IN ('registered', 'pre_registered')"
 


### PR DESCRIPTION
Inbox used to show display names of users, but started showing full names since https://github.com/instructure/canvas-lms/commit/7137d14d213de5e4727678e7b07a2c49b9b25326.

Test plan:
  * Go to Inbox
  * Verify that display names are used in existing conversations
  * Open the recipient finder
  * Verify that search results are display names

Related bug report: #695635 Full name shown in Conversations

---

*NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file.*