### PR TITLE
Fixed documentation example in SIS import api

### DIFF
--- a/app/controllers/sis_imports_api_controller.rb
+++ b/app/controllers/sis_imports_api_controller.rb
@@ -31,8 +31,8 @@
 #           "type": "string"
 #         },
 #         "supplied_batches": {
-#           "description": "Which file were included in the SIS import",
-#           "example": "[\"term\", \"course\", \"section\", \"user\", \"enrollment\"]",
+#           "description": "Which files were included in the SIS import",
+#           "example": ["term", "course", "section", "user", "enrollment"],
 #           "type": "array",
 #           "items": { "type": "string" }
 #         },


### PR DESCRIPTION
- Fixed a typo.
- Changed the array example from a string representation of an array to an array.