### PR TITLE
Ignore RVM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 .bundle/
 /.yardoc/
+/.ruby-gemset
+/.ruby-version
 /app/coffeescripts/ember/*/main.coffee
 /app/views/info/styleguide.html.erb
 /config/*.yml


### PR DESCRIPTION
I believe that these files should either:
a) be gitignored to discourage specififying a ruby management system, or
b) added to the repo for ease of spin-up

As RVM tends to be a contentious issue, I assumed the core team would
want to choose "a".

(Signed ICA was sent ~1 minute ago)