### PR TITLE
Properly escape filenames with slashes on local storage

### DIFF
--- a/app/controllers/gradebook_csvs_controller.rb
+++ b/app/controllers/gradebook_csvs_controller.rb
@@ -24,7 +24,7 @@ class GradebookCsvsController < ApplicationController
     if authorized_action(@context, @current_user, [:manage_grades, :view_all_grades])
       current_time = Time.zone.now.to_formatted_s(:short)
       name = t('grades_filename', "Grades") + "-" + @context.short_name.to_s
-      filename = "#{current_time}_#{name}.csv".gsub(%r{/| }, '_')
+      filename = "#{current_time}_#{name}.csv".gsub(/ /, '_')
 
       csv_options = {
         include_sis_id: @context.grants_any_right?(@current_user, session, :read_sis, :manage_sis),

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -758,18 +758,6 @@ class Attachment < ActiveRecord::Base
     end
   end
 
-  alias_method :original_sanitize_filename, :sanitize_filename
-  def sanitize_filename(filename)
-    if self.root_attachment && self.root_attachment.filename
-      filename = self.root_attachment.filename
-    else
-      filename = Attachment.truncate_filename(filename, 255) do |component, len|
-        CanvasTextHelper.cgi_escape_truncate(component, len)
-      end
-    end
-    filename
-  end
-
   def save_without_broadcasting
     begin
       @skip_broadcasts = true

--- a/gems/attachment_fu/lib/attachment_fu/backends/file_system_backend.rb
+++ b/gems/attachment_fu/lib/attachment_fu/backends/file_system_backend.rb
@@ -54,12 +54,23 @@ module AttachmentFu # :nodoc:
       end
 
       def filename=(value)
+        value = sanitize_filename(value)
         if self.new_record?
-          write_attribute(:filename, value)
+          write_attribute :filename, value
         else
           @old_filename = full_filename unless filename.nil? || @old_filename
-          write_attribute :filename, sanitize_filename(value)
+          write_attribute :filename, value
         end
+      end
+
+      def sanitize_filename(filename)
+        if self.respond_to?(:root_attachment) && self.root_attachment && self.root_attachment.filename
+          filename = self.root_attachment.filename
+        else
+          filename = Attachment.truncate_filename(filename, 255)
+          filename.gsub!(%r{/| }, '_')
+        end
+        filename
       end
 
       def bucket_name; "no-bucket"; end

--- a/gems/attachment_fu/lib/attachment_fu/backends/s3_backend.rb
+++ b/gems/attachment_fu/lib/attachment_fu/backends/s3_backend.rb
@@ -155,6 +155,18 @@ module AttachmentFu # :nodoc:
         write_attribute :filename, sanitize_filename(value)
       end
 
+      def sanitize_filename(filename)
+        if self.respond_to?(:root_attachment) && self.root_attachment && self.root_attachment.filename
+          filename = self.root_attachment.filename
+        else
+          filename = Attachment.truncate_filename(filename, 255) do |component, len|
+            CanvasTextHelper.cgi_escape_truncate(component, len)
+          end
+        end
+        filename
+      end
+
+
       # The attachment ID used in the full path of a file
       def attachment_path_id
         ((respond_to?(:parent_id) && parent_id) || id).to_s

--- a/spec/lib/file_in_context_spec.rb
+++ b/spec/lib/file_in_context_spec.rb
@@ -26,7 +26,7 @@ describe FileInContext do
     @course.save!
     @course.reload
   end
-  
+
   context "#attach" do
     it "should create files with the supplied filename escaped for s3" do
       # This horrible hack is because we need Attachment to behave like S3 in this case, as far as filename
@@ -35,6 +35,7 @@ describe FileInContext do
       # to test S3), we fake out just the part we care about. Also, we can't use Mocha because we need the
       # argument of the method. This will be fixed when we've refactored Attachment to allow dynamically
       # switching between S3 and local.
+      s3_storage!
       unbound_method = Attachment.instance_method(:filename=)
       class Attachment; def filename=(new_name); write_attribute :filename, sanitize_filename(new_name); end; end
       filename = File.expand_path(File.join(File.dirname(__FILE__), %w(.. fixtures files escaping_test[0].txt)))

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1453,4 +1453,21 @@ describe Attachment do
       end
     end
   end
+
+  describe 'local storage' do
+    it 'should properly sanitie a filename containing a slash' do
+      local_storage!
+      course
+      a = attachment_model(filename: 'ENGL_100_/_ENGL_200.csv')
+      expect(a.filename).to eql('ENGL_100___ENGL_200.csv')
+    end
+
+    it 'should still properly escape the same filename on s3' do
+      s3_storage!
+      course
+      a = attachment_model(filename: 'ENGL_100_/_ENGL_200.csv')
+      expect(a.filename).to eql('ENGL_100_%2F_ENGL_200.csv')
+    end
+  end
+
 end


### PR DESCRIPTION
When using local storage instead of S3, having a course short name with
a slash in it will cause an error (No such file or directory @
rb_sysopen) when trying to export the Gradebook as a CSV. attachment_fu
is receiving the slash as part of the file path, and erroring out
because it can't find the file.

This change moves the sanitize_filename method out of the attachment
model and into s3_backend. It also addes a different, local-storage
specific sanitize_filename method to file_system_backend.

This change also reverts cf341a4, which fixed this bug in
gradebook_csvs_controller (#640).

A CLA is on file under my employer, Simon Fraser University
(github.com/sfu).

Test plan:

enable local storage for canvas
create a course with a slash in the short name (e.g. CHEM 121 / CHEM
122)
attempt to export the gradebook
ensure the gradebook file was exported and downlaoded correctly
