### PR TITLE
Fix routes for quiz submission files

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -846,7 +846,7 @@ CanvasRails::Application.routes.draw do
 
   post 'selection_test' => 'external_content#selection_test'
 
-  resources :quiz_submissions do
+  scope '/quizzes/quiz_submissions/:quiz_submission_id', as: 'quiz_submission' do
     concerns :files
   end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -61,6 +61,15 @@ describe Attachment do
       attachment_with_context(@course)
       expect(@attachment.authenticated_s3_url(:secure => true)).to match(/^https:\/\//)
     end
+
+    context "for a quiz submission upload" do
+      it "should return a routable url", :type => :routing do
+        quiz = @course.quizzes.create
+        submission = Quizzes::SubmissionManager.new(quiz).find_or_create_submission(user_model)
+        attachment = attachment_with_context(submission)
+        expect(get(attachment.authenticated_s3_url)).to be_routable
+      end
+    end
   end
 
   def configure_crocodoc


### PR DESCRIPTION
Quiz submissions are [namespaced](https://github.com/instructure/canvas-lms/commit/d85c1006b498d10cf79d331cd1bfa5a871fe7b98), but the routes for their files weren't. If the Canvas installation is backed by a local file system, users will get a *Page Not Found* error when attempting to view or download the file, because the link generated by `Attachment#local_storage_path`

    quizzes/quiz_submissions/:quiz_id/files/:attachment_id/download?verifier=:verifier

does not match any routes. This fix addresses #611 by scoping all quiz submission file routes with the `/quizzes` prefix, so the link works once again.

Test plan:

* Create a quiz with a File Upload question
* As a student, complete the quiz by uploading a file
* As a teacher, view the submission and click the file link
* Verify the file downloads successfully with no errors

---

*NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file.*