### PR TITLE
Expose delayed jobs as an API route

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -23,7 +23,7 @@ class JobsController < ApplicationController
           @job_tags_refresh_seconds  = Setting.get('job_tags_refresh_seconds', 10.seconds.to_s).to_f
         end
 
-        format.js do
+        format.json do
           case params[:only]
           when 'running'
             render :json => {running: Delayed::Job.running_jobs.map{ |j| j.as_json(include_root: false, except: [:handler, :last_error]) }}
@@ -53,6 +53,7 @@ class JobsController < ApplicationController
 
     if params[:job_ids].present?
       opts[:ids] = params[:job_ids]
+      opts[:flavor] = params[:flavor] if params[:flavor] == 'failed'
     elsif params[:flavor].present?
       opts[:flavor] = params[:flavor]
       opts[:query] = params[:q]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1743,6 +1743,18 @@ CanvasRails::Application.routes.draw do
     end
   end
 
+  # this is not a "normal" api endpoint in the sense that it is not documented or
+    # generally available to hosted customers. it also does not respect the normal
+    # pagination options; however, jobs_controller already accepts `limit` and `offset`
+    # paramaters and defines a sane default limit
+    ApiRouteSet::V1.draw(self) do
+      scope(controller: :jobs) do
+        get 'jobs', action: :index
+        get 'jobs/:id', action: :show
+        post 'jobs/batch_update', action: :batch_update
+      end
+    end
+
   # this is not a "normal" api endpoint in the sense that it is not documented
   # or called directly, it's used as the redirect in the file upload process
   # for local files. it also doesn't use the normal oauth authentication


### PR DESCRIPTION
This patch exposes delayed jobs data as an API route, which makes it accessible using a bearer token. Currently, a token is not accepted as valid authentication, and an Unauthorized error is returned to the client.

Test plan:

- create a user in the Site Admin account and grant it admin rights to Site Admin
- create a user in the Site Admin account (or any other account) but do not grant it admin rights to Site Admin
- create some delayed jobs, failed and otherwise
- test the following routes:
  - `GET /api/v1/jobs?only=jobs&flavor=[failed|future|current|waiting]`: should return list of jobs for specified flavor in JSON
  - `GET /api/v1/jobs/:id`: should return a specific non-failed job
  - `GET /api/v1/jobs/:id`: should return a specific failed job
  - `POST /api/v1/jobs/batch_update` with body `update_action=destroy&job_ids[]=$id1&job_ids[]=$id2`: (replacing
$id1 and $id2 with the IDs of real non-failed jobs) should return a success message with count of destroyed jobs.
  - `POST /api/v1/jobs/batch_update` with body
     `update_action=destroy&job_ids[]=$id1&job_ids[]=$id2&flavor=failed`:
(replacing $id1 and $id2 with the IDs of real failed jobs) will fail
pending instructure/canvas-jobs#2 (with that pull, it will return a
success message with count of destroyed jobs).
  - `POST /api/v1/jobs/batch_update` with body `update_action=destroy&flavor=future`: should return a success message with count of destroyed jobs
  - `POST /api/v1/jobs/batch_update` with body
    `update_action=hold&flavor=future`: should return an error report
(can't hold failed jobs).

When testing the routes, using the second user created (without Site Admin rights) should throw an Unauthorized error. Using a developer key should throw an Invalid Token error.

A signed Instructure Contributor License Agreement is on file under my employer, Simon Fraser University.