### PR TITLE
Local Storage only: Forces the name of the downloaded file to that of its display name.

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -653,7 +653,7 @@ class FilesController < ApplicationController
       redirect_to safe_domain_file_url(attachment, @safer_domain_host, params[:verifier], !inline)
     elsif Attachment.local_storage?
       @headers = false if @files_domain
-      send_file(attachment.full_filename, :type => attachment.content_type_with_encoding, :disposition => (inline ? 'inline' : 'attachment'))
+      send_file(attachment.full_filename, :type => attachment.content_type_with_encoding, :disposition => (inline ? 'inline' : 'attachment'), :filename => attachment.display_name)
     elsif redirect_to_s3
       redirect_to(inline ? attachment.inline_url : attachment.download_url)
     else


### PR DESCRIPTION
Fixes a download bug which only occurs when Canvas is using local storage to store files (not s3).

If the md5 hash of an uploaded file (say "B") matches the md5 hash of a previously uploaded file (say "A") then the next time that file "B" is downloaded, it will be to a file named "A".

This fix will force the name of the downloaded file to that of the file's display name.

Steps to reproduce:
1. Upload a file (eg. "A") to a group, course, or personal file space.
2. Rename the file to another name (eg. "B").
3. Upload the renamed file.
4. Download the file uploaded in 3).

Result:
The downloaded file will be named the same as in step 1.) ("A")

The origins of the bug lay in how file uploads are handled in local storage (in the 'uploaded_data=' method in attachment_fu.rb). An Attachment object is created for an uploaded file (say 'B') and an md5 hash is taken of the file. If the md5 hash matches that of an existing Attachment object (say, for file 'A') then the uploaded file is linked to that Attachment (self.root_attachment = existing_attachment) and the filename property is set to nil. Whenever that file 'B' is downloaded the filename method returns the filename of the root_attachment (filename method in attachment.rb) resulting in a filename of 'A'.

*NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file.*