### PR TITLE
Local file storage only: Fix IE file upload bug by nulling Content-Type header in GET request.

### DIFF
--- a/app/middleware/strip_content_type_from_get.rb
+++ b/app/middleware/strip_content_type_from_get.rb
@@ -1,0 +1,14 @@
+class StripContentTypeFromGet 
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env['REQUEST_METHOD'] == "GET" && !env['CONTENT_TYPE'].nil?
+      if /^\/api\/v1\/files\/[0-9]+\/create_success$/ =~ env['REQUEST_PATH']
+        env['CONTENT_TYPE'] = nil
+      end
+    end
+    @app.call(env)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -122,6 +122,7 @@ module CanvasRails
       app.config.middleware.insert_after(config.session_store, 'RequestContextSession')
       app.config.middleware.insert_before('ActionDispatch::ParamsParser', 'Canvas::RequestThrottle')
       app.config.middleware.insert_before('Rack::MethodOverride', 'PreventNonMultipartParse')
+      app.config.middleware.insert_before('PreventNonMultipartParse', 'StripContentTypeFromGet')
     end
 
     config.to_prepare do


### PR DESCRIPTION
File upload from IE (all versions) to local file storage fails because, under some conditions, IE will include a Content-Type header in a GET request, in response to a 302 redirect. When Rack receives the GET request and sees a non-null Content-Type header it tries to read a request body, which is missing. The request fails and the multistep file upload process fails.

This 302 redirect is a part of the file upload protocol described in the Canvas API Documentation (https://canvas.instructure.com/doc/api/file.file_uploads.html). As part of the file upload process the client code in IE initially sends a POST request and Canvas responds with a 302 redirect. The client code doesn't have a chance to intervene when the 302 redirect is received. IE responds to the 302 with a GET request, retaining the Content-Type from the initial POST request.

The fix is the addition of Rack middleware which will "nullify" the Content-Type header on a GET request to the file upload URL. So it's very specific when this action takes place and shouldn't be a performance problem.

Note that submissions to assignments are not affect as that uses another method of uploading files.

Test plan:

On a Canvas installation that uses local file storage (not s3):
- Upload a file to the Files area of a course or personal account. 
- File upload should succeed.

_NOTE: We have a signed CLA for all of Simon Fraser University (SFU) on file._
