### PR TITLE
Fix permissions typo closes gh-736

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1616,7 +1616,7 @@ class CoursesController < ApplicationController
         :add_tas => course_users_path(:course_id => @context),
         :publish_course => course_path(@context)
       },
-      :permisssions => {
+      :permissions => {
         # Sending the permissions just so maybe later we can extract this easier.
         :can_manage_content => can_do(@context, @current_user, :manage_content),
         :can_manage_students => can_do(@context, @current_user, :manage_students),

--- a/app/jsx/course_wizard/InfoFrame.jsx
+++ b/app/jsx/course_wizard/InfoFrame.jsx
@@ -97,7 +97,7 @@ define([
           );
         }
         if (this.state.itemShown.key === 'publish_course') {
-          if (window.ENV.COURSE_WIZARD.permisssions.can_change_course_state) {
+          if (window.ENV.COURSE_WIZARD.permissions.can_change_course_state) {
             return (
               <form acceptCharset='UTF-8' action={window.ENV.COURSE_WIZARD.publish_course} method='post'>
                 <input name='utf8' type='hidden' value='✓' />


### PR DESCRIPTION
Decided to put a PR in for a simple typo I saw, permissions was spelled permisssions.

Closes #736.