### PR TITLE
Repairing lib/canvas/icu.rb - at least for Ubuntu 14.04 LTS

### DIFF
--- a/Gemfile.d/icu.rb
+++ b/Gemfile.d/icu.rb
@@ -1,3 +1,3 @@
 group :icu do
-  gem 'ffi-icu', '0.1.2'
+  gem 'ffi-icu', '0.1.10'
 end

--- a/lib/canvas/icu.rb
+++ b/lib/canvas/icu.rb
@@ -19,15 +19,15 @@ module Canvas::ICU
 
   begin
     Bundler.require 'icu'
-    if !ICU::Lib.respond_to?(:ucol_getRules)
-      require 'ffi'
-      suffix = ICU::Lib.figure_suffix(ICU::Lib.version.to_s)
+    require 'ffi'
 
-      ICU::Lib.attach_function(:ucol_getRules, "ucol_getRules#{suffix}", [:pointer, :pointer], :pointer)
-      ICU::Lib.attach_function(:ucol_getSortKey, "ucol_getSortKey#{suffix}", [:pointer, :pointer, :int, :pointer, :int], :int)
-      ICU::Lib.attach_function(:ucol_getAttribute, "ucol_getAttribute#{suffix}", [:pointer, :int, :pointer], :int)
-      ICU::Lib.attach_function(:ucol_setAttribute, "ucol_setAttribute#{suffix}", [:pointer, :int, :int, :pointer], :void)
+    suffix = ICU::Lib.figure_suffix(ICU::Lib.version.to_s)
+    ICU::Lib.attach_function(:ucol_getRules, "ucol_getRules#{suffix}", [:pointer, :pointer], :pointer) if !ICU::Lib.respond_to?(:ucol_getRules)
+    ICU::Lib.attach_function(:ucol_getSortKey, "ucol_getSortKey#{suffix}", [:pointer, :pointer, :int, :pointer, :int], :int) if !ICU::Lib.respond_to?(:ucol_getSortKey)
+    ICU::Lib.attach_function(:ucol_getAttribute, "ucol_getAttribute#{suffix}", [:pointer, :int, :pointer], :int) if !ICU::Lib.respond_to?(:ucol_getAttribute)
+    ICU::Lib.attach_function(:ucol_setAttribute, "ucol_setAttribute#{suffix}", [:pointer, :int, :int, :pointer], :void) if !ICU::Lib.respond_to?(:ucol_setAttribute)
 
+    if !ICU::Collation::Collator.new(I18n.locale.to_s).respond_to?(:normalization_mode)
       ICU::Collation::Collator.class_eval do
         def rules
           @rules ||= begin

--- a/lib/canvas/icu.rb
+++ b/lib/canvas/icu.rb
@@ -22,12 +22,12 @@ module Canvas::ICU
     require 'ffi'
 
     suffix = ICU::Lib.figure_suffix(ICU::Lib.version.to_s)
-    ICU::Lib.attach_function(:ucol_getRules, "ucol_getRules#{suffix}", [:pointer, :pointer], :pointer) if !ICU::Lib.respond_to?(:ucol_getRules)
-    ICU::Lib.attach_function(:ucol_getSortKey, "ucol_getSortKey#{suffix}", [:pointer, :pointer, :int, :pointer, :int], :int) if !ICU::Lib.respond_to?(:ucol_getSortKey)
-    ICU::Lib.attach_function(:ucol_getAttribute, "ucol_getAttribute#{suffix}", [:pointer, :int, :pointer], :int) if !ICU::Lib.respond_to?(:ucol_getAttribute)
-    ICU::Lib.attach_function(:ucol_setAttribute, "ucol_setAttribute#{suffix}", [:pointer, :int, :int, :pointer], :void) if !ICU::Lib.respond_to?(:ucol_setAttribute)
+    ICU::Lib.attach_function(:ucol_getRules, "ucol_getRules#{suffix}", [:pointer, :pointer], :pointer) unless ICU::Lib.respond_to?(:ucol_getRules)
+    ICU::Lib.attach_function(:ucol_getSortKey, "ucol_getSortKey#{suffix}", [:pointer, :pointer, :int, :pointer, :int], :int) unless ICU::Lib.respond_to?(:ucol_getSortKey)
+    ICU::Lib.attach_function(:ucol_getAttribute, "ucol_getAttribute#{suffix}", [:pointer, :int, :pointer], :int) unless ICU::Lib.respond_to?(:ucol_getAttribute)
+    ICU::Lib.attach_function(:ucol_setAttribute, "ucol_setAttribute#{suffix}", [:pointer, :int, :int, :pointer], :void) unless ICU::Lib.respond_to?(:ucol_setAttribute)
 
-    if !ICU::Collation::Collator.new(I18n.locale.to_s).respond_to?(:normalization_mode)
+    unless ICU::Collation::Collator.new(I18n.locale.to_s).respond_to?(:normalization_mode)
       ICU::Collation::Collator.class_eval do
         def rules
           @rules ||= begin


### PR DESCRIPTION
Some time ago I was posting issue #711.

The lib-icu gem has recently been published in a new version including the fix I spoke about, see PR: https://github.com/jarib/ffi-icu/pull/30

Before updating icu version, I ran: 

```bash
rspec spec/lib/canvas/icu_spec.rb 
```

Here are the results (Ubuntu 14.04 LTS):

```ruby
DEPRECATION WARNING: Syck is deprecated and support for serialization has been removed. ActiveRecord::Core#yaml_initialize will be removed in 4.1 which will break deserialization support with Syck. (called from <top (required)> at /home/regmillet/Workspace/RailsProjects/canvas-lms/config/application.rb:19)
Bullet Instructure not enabled

Randomized with seed 49399

.........FFFFFFFFF

Failures:

  1) Canvas::ICU ICU .collate_by should work
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x000000054c5c98>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  2) Canvas::ICU ICU .collate_by should handle CanvasSort::First
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x0000000550d890>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  3) Canvas::ICU ICU .collation_key should return something that's comparable
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x0000000553de00>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  4) Canvas::ICU ICU .collation_key should pass-thru CanvasSort::First
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x000000055b52e8>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  5) Canvas::ICU ICU .compare should work
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x000000055fa4d8>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  6) Canvas::ICU ICU .compare should handle CanvasSort::First
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x0000000564af78>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  7) Canvas::ICU ICU .collate should work
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x0000000567cb18>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  8) Canvas::ICU ICU .collate should at the least be case insensitive
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x000000057d4e48>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

  9) Canvas::ICU ICU .collate should not ignore punctuation
     Failure/Error: skip if Canvas::ICU.collator == Canvas::ICU::NaiveCollator
     NoMethodError:
       undefined method `normalization_mode=' for #<ICU::Collation::Collator:0x000000057fc2b8>
     # ./lib/canvas/icu.rb:110:in `collator'
     # ./spec/lib/canvas/icu_spec.rb:92:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:34:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:32:in `block (2 levels) in <top (required)>'

Finished in 0.26774 seconds
18 examples, 9 failures

Failed examples:

rspec ./spec/lib/canvas/icu_spec.rb:24 # Canvas::ICU ICU .collate_by should work
rspec ./spec/lib/canvas/icu_spec.rb:31 # Canvas::ICU ICU .collate_by should handle CanvasSort::First
rspec ./spec/lib/canvas/icu_spec.rb:40 # Canvas::ICU ICU .collation_key should return something that's comparable
rspec ./spec/lib/canvas/icu_spec.rb:48 # Canvas::ICU ICU .collation_key should pass-thru CanvasSort::First
rspec ./spec/lib/canvas/icu_spec.rb:54 # Canvas::ICU ICU .compare should work
rspec ./spec/lib/canvas/icu_spec.rb:58 # Canvas::ICU ICU .compare should handle CanvasSort::First
rspec ./spec/lib/canvas/icu_spec.rb:64 # Canvas::ICU ICU .collate should work
rspec ./spec/lib/canvas/icu_spec.rb:68 # Canvas::ICU ICU .collate should at the least be case insensitive
rspec ./spec/lib/canvas/icu_spec.rb:74 # Canvas::ICU ICU .collate should not ignore punctuation
```

I then updated the version of the ffi-icu gem in Gemfile.d/icu.rb. I also modified the file lib/canvas/icu.rb so that all tests can pass. I did not modify a lot of things but that turned green rspec tests.

I have an explaination on why tests failed for me without modifying icu.rb. You can see line 22: 

```ruby
if !ICU::Lib.respond_to?(:ucol_getRules)
```

But my system lib-icu was already including this function. So all the attach_function were just skipped, which was creating an issue in my app that just kept crashing because of that (undefined method collate_by, see: https://groups.google.com/forum/#!topic/canvas-lms-users/SR_mmZIzge0). 

Test Plan : 

* Just run `rspec spec/lib/canvas/icu_spec.rb` on Ubuntu 14.04 with libicu-dev installed before including my PR. It should show some errors (if it does not, let me know, that would be sooo weird)
* Rerun after including my PR, all tests should pass. 

I will try to answer as quick as possible if you have any questions regarding this issue. 
Thanks a lot!
Regis. 
