### PR TITLE
Repaired mark as done button in production.

### DIFF
--- a/app/coffeescripts/bundles/assignment_show.coffee
+++ b/app/coffeescripts/bundles/assignment_show.coffee
@@ -12,8 +12,9 @@ require [
 ], (INST, I18n, $, Assignment, PublishButtonView, SpeedgraderLinkView, vddTooltip, MarkAsDone) ->
 
   $ ->
-    $('#mark-as-done-checkbox').click ->
+    $('#content').on('click', '#mark-as-done-checkbox', ->
       MarkAsDone.toggle(this)
+    )
 
   $ ->
     $el = $('#assignment_publish_button')

--- a/app/coffeescripts/bundles/wiki_page_show.coffee
+++ b/app/coffeescripts/bundles/wiki_page_show.coffee
@@ -7,8 +7,9 @@ require [
 ], ($, WikiPage, WikiPageView, MarkAsDone) ->
 
   $ ->
-    $('#mark-as-done-checkbox').click ->
+    $('#content').on('click', '#mark-as-done-checkbox', ->
       MarkAsDone.toggle(this)
+    )
 
   $('body').addClass('show')
 


### PR DESCRIPTION
The button was working fine in development but not in production.
The events was never triggered (confirmed that by adding a 'console.log').
I had to modify the click listener with a 'on' one to make it work.
It is quite logic I think, as the button is actually 'appended' using javascript.
In production it was failing both for firefox and chrome.

Test plan:
* Create a course, with a module and a page (and/or an assignment)
* Add a mark as done requirement for the newly created resource
* Invite a student and connect using his account
* Go to the page (of course you did not forget to publish it?)
* Try the mark as done button

Again, it was working fine in development but not in production. I do wonder why... if you have any ideas, let me know.

The code I modified was originally added here: #625