### PR TITLE
Support class reloading with BroadcastPolicy

### DIFF
--- a/config/initializers/broadcast_policy.rb
+++ b/config/initializers/broadcast_policy.rb
@@ -1,4 +1,6 @@
 require 'broadcast_policy'
-BroadcastPolicy.notifier = lambda { Notifier.new }
-BroadcastPolicy.notification_finder = lambda { NotificationFinder.new(Notification.all_cached) }
+Rails.configuration.to_prepare do
+  BroadcastPolicy.notifier = lambda { Notifier.new }
+  BroadcastPolicy.notification_finder = lambda { NotificationFinder.new(Notification.all_cached) }
+end
 ActiveRecord::Base.send(:extend, BroadcastPolicy::ClassMethods)

--- a/gems/broadcast_policy/README.md
+++ b/gems/broadcast_policy/README.md
@@ -23,8 +23,10 @@ In order to use the gem in Rails, you'll need an initializer something like this
 config/initializers/broadcast_policy.rb
 
 require 'broadcast_policy'
-BroadcastPolicy.notifier = lambda { Notifier.new }
-BroadcastPolicy.notification_finder = lambda { NotificationFinder.new(Nofication.all) }
+Rails.configuration.to_prepare do
+  BroadcastPolicy.notifier = lambda { Notifier.new }
+  BroadcastPolicy.notification_finder = lambda { NotificationFinder.new(Notification.all_cached) }
+end
 ActiveRecord::Base.send(:extend, BroadcastPolicy::ClassMethods)
 
 The two BroadcastPolicy services are necessary to supply the canvas domain objects

--- a/gems/broadcast_policy/lib/broadcast_policy.rb
+++ b/gems/broadcast_policy/lib/broadcast_policy.rb
@@ -58,6 +58,7 @@ module BroadcastPolicy #:nodoc:
 
   def self.notifier=(notifier_or_proc)
     if notifier_or_proc.respond_to?(:call)
+      @notifier = nil
       @notifier_proc = notifier_or_proc
     else
       @notifier = notifier_or_proc
@@ -71,6 +72,7 @@ module BroadcastPolicy #:nodoc:
 
   def self.notification_finder=(notification_finder_or_proc)
     if notification_finder_or_proc.respond_to?(:call)
+      @notification_finder = nil
       @notification_finder_proc = notification_finder_or_proc
     else
       @notification_finder = notification_finder_or_proc


### PR DESCRIPTION
Since Notification and NotificationPolicy can be reloaded, BroadcastPolicy needs to re-cache the references on reload. This problem was discussed on the mailing list on 11/23/15.

To test:
You can experience a reloading error before applying this patch by triggering a notification after a reload.
```
rails console
reload!
Course.last.enroll_student(User.last).accept!
```
This will cause `ArgumentError: A copy of Notifier has been removed from the module tree but is still active!`

With this patch applied, there should be no error (assuming that student can be enrolled in that class).