### PR TITLE
Remove Thor dependency from moodle_importer

### DIFF
--- a/gems/plugins/moodle_importer/moodle_importer.gemspec
+++ b/gems/plugins/moodle_importer/moodle_importer.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.2", "< 4.3"
   s.add_dependency "moodle2cc", "0.2.28"
-  s.add_dependency "thor", "0.18.1"
 end


### PR DESCRIPTION
The `moodle_importer` does not directly use `thor` and has no need for a specific version dependency. `moodle2cc` already has an unversioned thor dependency and `railties` itself requires `>= 0.18.1`.

Specifically for me, this hard dependency caused issues with the current releases of  `derailed_benchmarks` and `foreman` which required `~> 0.19` and `~> 0.19.1` respectively. 

0.19.1 is the current release as of 3/2014.

Test Plan:
- run bundle update
- run `moodle2cc help` to verify moodle2cc thor tasks still load