### PR TITLE
Fix coffeescript syntax for future versions

### DIFF
--- a/app/coffeescripts/jquery/mediaComment.coffee
+++ b/app/coffeescripts/jquery/mediaComment.coffee
@@ -198,9 +198,9 @@ define [
           close: ->
             $mediaPlayer = $this.data('mediaelementplayer')
             $mediaPlayer.pause() if $mediaPlayer
-          open: (ev) -> $(ev.currentTarget).parent()
-                          .find('.ui-dialog-titlebar-close')
-                          .focus()
+          open: (ev) -> $(ev.currentTarget).parent().
+                          find('.ui-dialog-titlebar-close').
+                          focus()
 
         # Populate dialog box with a video
         $dialog.disableWhileLoading getSourcesAndTracks(id).done (sourcesAndTracks) ->

--- a/app/coffeescripts/util/processMigrationItemSelections.coffee
+++ b/app/coffeescripts/util/processMigrationItemSelections.coffee
@@ -30,7 +30,7 @@ define ->
           allSelections.push matchData[1] if value is "1"
         newData[key] = value
 
-    for own allSelection in allSelections
+    for allSelection in allSelections
       delete newData.items_to_copy[allSelection]
 
     newData


### PR DESCRIPTION
CoffeeScript source is currently pinned to 1.6.2 but these two files will have syntax errors if/when coffeescript is upgraded to >=1.7.0

The syntax errors are `unexpected .` and `cannot use own with for-in`.

To demonstrate the syntax errors, temporarily modify `Gemfile.d/development_and_test.rb` to use `1.7.0` for `coffee-script-source`, bundle update, and recompile assets.

These are the only 2 errors and will work with coffeescript 1.10 as well.

Test Plan
- There should be no change. I did not see if this code is currently covered by a test case.

This is a low-priority PR. I needed to track down these two problems to use a gem which required a higher version of coffee-script.