### PR TITLE
Reduce unnecessary activity stream XHR fetches

### DIFF
--- a/app/jsx/dashboard_card/CourseActivitySummaryStore.jsx
+++ b/app/jsx/dashboard_card/CourseActivitySummaryStore.jsx
@@ -15,6 +15,7 @@ define([
     if (_.has(CourseActivitySummaryStore.getState()['streams'], courseId)) {
       return CourseActivitySummaryStore.getState()['streams'][courseId]
     } else {
+      CourseActivitySummaryStore.getState()['streams'][courseId] = {}
       CourseActivitySummaryStore._fetchForCourse(courseId)
       return {}
     }


### PR DESCRIPTION
On a the dashboard page for a user with multiple courses, duplicate XHR fetches are sent. For example with 12 cards shown, there will be 78 fetches (12+11+10...+1) rather than 12.

Since all of the DashboardCard React views share a single CourseActivitySummaryStore, any update to the store triggers every card to request an update from the store and if it does not exist, it fires another XHR fetch.

This PR prevents the additional fetches by storing an empty result `{}` in the store which will be replaced when the XHR call completes.

Test Plan
- Load the dashboard page for a user multiple course cards
- Observe the XHR requests for `/api/v1/courses/*/activity_stream/summary`
- There should only be 1 request per card and unread activity should show up
