### PR TITLE
add missing section update API doc parameters

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -228,7 +228,22 @@ class SectionsController < ApplicationController
   end
 
   # @API Edit a section
-  # Modify an existing section.  See the documentation for {api:SectionsController#create create API action}.
+  # Modify an existing section.
+  #
+  # @argument course_section[name] [String]
+  #   The name of the section
+  #
+  # @argument course_section[sis_section_id] [String]
+  #   The sis ID of the section
+  #
+  # @argument course_section[start_at] [DateTime]
+  #   Section start date in ISO8601 format, e.g. 2011-01-01T01:00Z
+  #
+  # @argument course_section[end_at] [DateTime]
+  #   Section end date in ISO8601 format. e.g. 2011-01-01T01:00Z
+  #
+  # @argument course_section[restrict_enrollments_to_section_dates] [Boolean]
+  #   Set to true to restrict user enrollments to the start and end dates of the section.
   #
   # @returns Section
   def update


### PR DESCRIPTION
The API doc comments on the section update method are missing parameters, resulting in incomplete swagger spec and API documentation.

This PR adds documentation for the following parameters (copied from the section create method doc):
```
course_section[name]
course_section[sis_section_id]
course_section[start_at]
course_section[end_at]
course_section[restrict_enrollments_to_section_dates]
```