### PR TITLE
fix course update API doc params

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -518,10 +518,10 @@ class CoursesController < ApplicationController
   #   - 'public_domain' (Public Domain).
   #
   # @argument course[is_public] [Boolean]
-  #   Set to true if course if public.
+  #   Set to true if course is public to both authenticated and unauthenticated users.
   #
   # @argument course[is_public_to_auth_users] [Boolean]
-  #   Set to true if course if public to authenticated users.
+  #   Set to true if course is public only to authenticated users.
   #
   # @argument course[public_syllabus] [Boolean]
   #   Set to true to make the course syllabus public.
@@ -1926,7 +1926,10 @@ class CoursesController < ApplicationController
   #   - 'public_domain' (Public Domain).
   #
   # @argument course[is_public] [Boolean]
-  #   Set to true if course if public.
+  #   Set to true if course is public to both authenticated and unauthenticated users.
+  #
+  # @argument course[is_public_to_auth_users] [Boolean]
+  #   Set to true if course is public only to authenticated users.
   #
   # @argument course[public_syllabus] [Boolean]
   #   Set to true to make the course syllabus public.


### PR DESCRIPTION
The course update method's API docs are missing the `course[is_public_to_auth_users]` param, resulting in an incomplete swagger spec.  This PR adds documentation of this parameter and fixes a minor typo in the `course[is_public]` documentation.
