### PR TITLE
Change the max height for lti.frameResize.

### DIFF
--- a/public/javascripts/tool_inline.js
+++ b/public/javascripts/tool_inline.js
@@ -148,7 +148,7 @@ window.addEventListener('message', function(e) {
     switch (message.subject) {
       case 'lti.frameResize':
         var height = message.height;
-        if (height >= 5000) height = 5000;
+        if (height >= 25000) height = 25000;
         if (height <= 0) height = 1;
 
         tool_content_wrapper().data('height_overridden', true);


### PR DESCRIPTION
The max height being 5000 is far to short for some of our content. I see the need for setting a max height, but having it set to a max of 5000 does not allow for displaying large content pieces. I guess the question is, where do you stop.