### PR TITLE
Permit data-* attributes in HTML content

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -92,7 +92,7 @@ gem 'ruby-saml-mod', '0.2.7'
 gem 'rubycas-client', '2.3.9', require: false
 gem 'rubyzip', '1.1.1', require: 'zip'
 gem 'safe_yaml', '1.0.4', require: false
-gem 'sanitize', '2.0.6', require: false
+gem 'sanitize', '2.1.0', require: false
 gem 'shackles', '1.1.0'
 
 gem 'useragent', '0.10.0', require: false

--- a/gems/canvas_sanitize/canvas_sanitize.gemspec
+++ b/gems/canvas_sanitize/canvas_sanitize.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sanitize", "2.0.6"
+  spec.add_dependency "sanitize", "2.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/gems/canvas_sanitize/lib/canvas_sanitize/canvas_sanitize.rb
+++ b/gems/canvas_sanitize/lib/canvas_sanitize/canvas_sanitize.rb
@@ -90,6 +90,7 @@ module CanvasSanitize #:nodoc:
                    'role',
                    'lang',
                    'dir',
+                   :data,  # Note: the symbol :data allows for arbitrary HTML5 data-* attributes
                    'aria-labelledby',
                    'aria-atomic',
                    'aria-busy',

--- a/gems/canvas_sanitize/spec/canvas_sanitize/canvas_sanitize_spec.rb
+++ b/gems/canvas_sanitize/spec/canvas_sanitize/canvas_sanitize_spec.rb
@@ -28,4 +28,9 @@ describe CanvasSanitize do
     cleaned = Sanitize.clean("<p dir='rtl'>RightToLeft</p>", CanvasSanitize::SANITIZE)
     expect(cleaned).to eq("<p dir=\"rtl\">RightToLeft</p>")
   end
+
+  it "doesnt strip data-* attributes by default" do
+    cleaned = Sanitize.clean("<p data-item-id='1234'>Item1234</p>", CanvasSanitize::SANITIZE)
+    expect(cleaned).to eq("<p data-item-id=\"1234\">Item1234</p>")
+  end
 end

--- a/gems/html_text_helper/html_text_helper.gemspec
+++ b/gems/html_text_helper/html_text_helper.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'nokogiri'
-  spec.add_dependency 'sanitize', '~> 2.0.3'
+  spec.add_dependency 'sanitize', '~> 2.1.0'
   spec.add_dependency 'canvas_text_helper'
   spec.add_dependency 'iconv', '~> 1.0'
 


### PR DESCRIPTION
This PR allows data-* attributes in HTML to pass the santization process.
For example, this allows integration with Embedly if the content includes HTML such as...
```html
<a class="embedly-card" href="http://www.instructure.com/" data-card-controls="0" data-card-type="article">Instructure</a>
```
...and the appropriate JavaScript is loaded.

Test Plan:
- Edit a wiki page using the HTML editor and enter custom HTML5 code that includes data attributes
- Verify the attributes exist in the HTML when the page is rendered

Note: This is minor version upgrade to sanitize. It does not upgrade to 3.x or 4.x which could introduce more changes.