### PR TITLE
Remove iframe size limit on frame resize

### DIFF
--- a/public/javascripts/tool_inline.js
+++ b/public/javascripts/tool_inline.js
@@ -148,7 +148,6 @@ window.addEventListener('message', function(e) {
     switch (message.subject) {
       case 'lti.frameResize':
         var height = message.height;
-        if (height >= 5000) height = 5000;
         if (height <= 0) height = 1;
 
         tool_content_wrapper().data('height_overridden', true);


### PR DESCRIPTION
Remove the lti.frameResize limit. This was initially done on the stable branch, but I moved it to master per request. Initial pull request here:
https://github.com/instructure/canvas-lms/pull/790

