### PR TITLE
Fix to Assignment LTI application URL

### DIFF
--- a/app/models/context_external_tool.rb
+++ b/app/models/context_external_tool.rb
@@ -452,7 +452,11 @@ class ContextExternalTool < ActiveRecord::Base
   def matches_url?(url, match_queries_exactly=true)
     if match_queries_exactly
       url = ContextExternalTool.standardize_url(url)
-      return true if url == standard_url
+      if url == standard_url
+        return true
+      else 
+        return false
+      end
     elsif standard_url.present?
       if !defined?(@url_params)
         res = Addressable::URI.parse(standard_url)


### PR DESCRIPTION
The matches_url? method should work as - if  match_queries_exactly=true, this method should return true only if the URLs are exactly equal. 

But suppose you have three apps (on the same domain and host) with URLs - 
 www.example.com/app1, www.example.com/app2 and www.example.com/app3. What I saw happening is after adding the app3, the first two stopped working because they were trying to reach the URL of the third app. This was happening because in the method matches_url? after checking if the URLs match exactly, it returns true if they indeed match, but proceeds to check for the hostnames if they don't. 
This happened because of the sorting logic for context_tools (app/models/context_external_tool.rb) - 

`sorted_external_tools = all_external_tools.sort_by { |t| [contexts.index { |c| c.id == t.context_id && c.class.name == t.context_type }, t.precedence, t.id == preferred_tool_id ? CanvasSort::First : CanvasSort::Last] }`

Test plan : 
- Add LTI app with a domain D to a course [App1]
- Add another LTI app with same domain to a course [App2]
- Add yet another LTI app with same domain [App3]
- Add these three apps to three assignments [A1,A2,A3]
- Launch all apps from their Assignments (submission set to external tool)
- Remove App3
- Add another LTI app with same domain [App4]
- Add this app to a new assignment [A4]
- Verify if A1,A2,A4 launch the correct apps.