### PR TITLE
Route for Speed Grader Google Doc Preview

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -826,9 +826,14 @@ CanvasRails::Application.routes.draw do
   get 'equation_images/:id' => 'equation_images#show', as: :equation_images, id: /.+/
 
   # assignments at the top level (without a context) -- we have some specs that
-  # assert these routes exist, but just 404. I'm not sure we ever actually want
-  # top-level assignments available, maybe we should change the specs instead.
-  resources :assignments, only: [:index, :show]
+  # assert these routes exist, but just 404 unless it is a download from local
+  # storage. I'm not sure we ever actually want top-level assignments available, 
+  # maybe we should change the specs instead.
+  # Note, if local storage is used, a file is fetched from this top level 
+  # (i.e. SpeedGrader document preview with Google Docs viewer)
+  resources :assignments, only: [:index, :show] do
+    get "files/:id/download" => 'files#show', download: '1'
+  end
 
   resources :files, :except => [:new] do
     get 'download' => 'files#show', download: '1'


### PR DESCRIPTION
Route for Speed Grader Google Doc Preview

Fixes an issue in which the local_storage_path in attachment.rb returns a path without a route when local file storage is used instead of s3.  

closes gh-636

Test Plan:
1. Create a Production Canvas instance using local storage
2. Enable the Google Drive plugin
3. Create a teacher, student, class, and assignment with file uploads enabled
4. As a student, upload an assignment, such as a pdf
5. Access SpeedGrader as a teacher
6. Document from student should appear in preview window using Google Docs Viewer
