### PR TITLE
Fix yard-related errors/warnings

### DIFF
--- a/app/controllers/quizzes/quiz_submission_users_controller.rb
+++ b/app/controllers/quizzes/quiz_submission_users_controller.rb
@@ -115,7 +115,7 @@ module Quizzes
     # @API Send a message to unsubmitted or submitted users for the quiz
     # @beta
     #
-    # @param conversations [QuizUserConversation] - Body and recipients to send the message to.
+    # @argument conversations [QuizUserConversation] - Body and recipients to send the message to.
     #
     # @model QuizUserConversation
     #

--- a/app/controllers/sis_api_controller.rb
+++ b/app/controllers/sis_api_controller.rb
@@ -132,12 +132,12 @@ class SisApiController < ApplicationController
   end
 
   def published_assignments
-    Assignment.published
-      .where(post_to_sis: true)
-      .where(context_type: 'Course', context_id: published_course_ids)
-      .preload(:assignment_group) # preload assignment group
-      .preload(:active_assignment_overrides) # preload *active* overrides
-      .preload(context: { active_course_sections: [:nonxlist_course] }) # preload courses and *active* sections
+    Assignment.published.
+      where(post_to_sis: true).
+      where(context_type: 'Course', context_id: published_course_ids).
+      preload(:assignment_group).
+      preload(:active_assignment_overrides).
+      preload(context: { active_course_sections: [:nonxlist_course] })
   end
 
   def paginated_assignments

--- a/app/controllers/user_observees_controller.rb
+++ b/app/controllers/user_observees_controller.rb
@@ -220,12 +220,12 @@ class UserObserveesController < ApplicationController
     shards = users.map(&:associated_shards).reduce(:&)
     Shard.with_each_shard(shards) do
       user_ids = users.map(&:id)
-      Account.where(id: UserAccountAssociation
-        .joins(:account).where(accounts: {parent_account_id: nil})
-        .where(user_id: user_ids)
-        .group(:account_id)
-        .having("count(*) = #{user_ids.length}") # user => account is unique for user_account_associations
-        .select(:account_id)
+      Account.where(id: UserAccountAssociation.
+        joins(:account).where(accounts: {parent_account_id: nil}).
+        where(user_id: user_ids).
+        group(:account_id).
+        having("count(*) = #{user_ids.length}"). # user => account is unique for user_account_associations
+        select(:account_id)
       )
     end
   end


### PR DESCRIPTION
Yard is having trouble with multi-line statements that use dot-first notation and have comments at the end of line.
The commit moves to end-of-line dot notation (which is more standard in the codebase) and removes some obvious comments. Either change would resolve the issue.

This also switches one `@param` tag to `@argument` since it is not a param.

Test Plan:
  - Run `rake doc:api`
  - The Yard docs should be built without errors/warnings