### PR TITLE
Fix URL validation bug with accented characters

### DIFF
--- a/gems/canvas_http/lib/canvas_http.rb
+++ b/gems/canvas_http/lib/canvas_http.rb
@@ -80,6 +80,7 @@ module CanvasHttp
   def self.validate_url(value, host=nil, scheme=nil)
     value = value.strip
     raise ArgumentError if value.empty?
+    value = URI.encode(value, /[^%#{URI::Parser::PATTERN::RESERVED}#{URI::Parser::PATTERN::UNRESERVED}]/)
     uri = URI.parse(value)
     uri.host ||= host
     unless uri.scheme

--- a/gems/canvas_http/spec/canvas_http_spec.rb
+++ b/gems/canvas_http/spec/canvas_http_spec.rb
@@ -127,4 +127,22 @@ describe "CanvasHttp" do
       http.use_ssl?.should == true
     end
   end
+
+  describe ".validate_url" do
+    it "should validate url with accented characters" do 
+      expect { CanvasHttp.validate_url("http://example.com/déjà-vu") }.not_to raise_error
+    end
+
+    it "should properly encode url with accented characters" do 
+      value, uri = CanvasHttp.validate_url("http://example.com/déjà-vu")
+      value.should == "http://example.com/d%C3%A9j%C3%A0-vu"
+      URI.parse(value).should == uri
+    end
+
+    it "should not encode already encoded characters" do 
+      value, uri = CanvasHttp.validate_url("http://example.com/d%C3%A9j%C3%A0-vu")
+      value.should == "http://example.com/d%C3%A9j%C3%A0-vu"
+      uri.path.should == "/d%C3%A9j%C3%A0-vu"
+    end
+  end
 end


### PR DESCRIPTION
Everything is explained in #836. I discussed a good solution with @ccutrer 
### Summary:

Sometimes our students submit urls with accents as submission for online url assignment type. Canvas just sends them a generic error "Assignment failed to submit". 
### Steps to reproduce:

(Tested with last master version)
1. Create an assignment, select online as submission type and "website url". Publish it
2. Use the student view, submit the assignment with a url containing accent: https://www.example.com/url-déjà-vu
3. The submission shouldn't be saved and you should see the generic error message. 
### Expected behavior:

This should not happen as we can't control what students submit as online url and we can't ask them to encode their urls before submitting. Canvas should encode url before validating it. 
Many of our students already tried to submit URLs with accented characters.
### Additional notes:

I have found that urls are validated through this function: validate_url which can be found here [gems/canvas_http/lib/canvas_http.rb](https://github.com/instructure/canvas-lms/blob/master/gems/canvas_http/lib/canvas_http.rb#L80)

As discussed in the issue the solution was to add: `value = URI.encode(value, /[^%#{URI::Parser::PATTERN::RESERVED}#{URI::Parser::PATTERN::UNRESERVED}]/)` in canvas_http gem before parsing value. 

I added the specs to test URL encoding and validation with accented characters. 
