### PR TITLE
Do not truncate question bank titles

### DIFF
--- a/app/stylesheets/pages/quizzes/_quizzes.scss
+++ b/app/stylesheets/pages/quizzes/_quizzes.scss
@@ -1648,6 +1648,9 @@ ul#quiz_versions {
     border-bottom: 1px dotted #ccc;
     .title {
       font-weight: bold;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .sub_content {
       font-size: 0.8em;

--- a/app/views/quizzes/quizzes/_find_question_from_bank.html.erb
+++ b/app/views/quizzes/quizzes/_find_question_from_bank.html.erb
@@ -68,7 +68,7 @@
     <%= t(:select_a_question_bank, "Select a question bank from the list below to link it to the this quiz as a question group.") %>
     <ul class="side_tabs bank_list unstyled_list">
       <li class="bank blank" style="display: none;">
-        <span class="title"><%= t('headers.bank_name', "Bank Name") %></span>
+        <div class="title"><%= t('headers.bank_name', "Bank Name") %></div>
         <span class="id" style="display: none;">&nbsp;</span>
         <div class="sub_content">
           <%= t(:bank_description, "%{bank_name}, %{n} questions",

--- a/public/javascripts/quizzes.js
+++ b/public/javascripts/quizzes.js
@@ -2452,7 +2452,6 @@ define([
           $dialog.addClass('loaded');
           for(idx in banks) {
             var bank = banks[idx].assessment_question_bank;
-            bank.title = TextHelper.truncateText(bank.title)
             var $bank = $dialog.find(".bank.blank:first").clone(true).removeClass('blank');
             $bank.fillTemplateData({data: bank, dataValues: ['id', 'context_type', 'context_id']});
             $dialog.find(".bank_list").append($bank);


### PR DESCRIPTION
Question Bank titles are truncated although there is plenty of space available to display longer titles. Using CSS text-overflow will better handle long titles.

Test Plan:
  - Create a course and create question banks with long names (>30 characters)
    - "Final Assessment Question Bank 1"
    - "Final Assessment Question Bank 2"
    - "Assessment Bank with Really, Really, ... long name" (>80 characters)
  - Create a quiz and add a new question group
  - Click "Link to a Question Bank"
  - The list of available question banks will no longer be truncated
  - The extremely long name should not wrap

I know Quizzes is in the process of being overhauled but I assume Question Banks will be around for a little while during the transition. I have a few more PRs coming. CLA on file.
