### PR TITLE
Enable correct answer indicator in question banks

### DIFF
--- a/app/stylesheets/pages/quizzes/_quizzes.scss
+++ b/app/stylesheets/pages/quizzes/_quizzes.scss
@@ -532,7 +532,6 @@ li.quiz {
 .question_bank {
   border-bottom: 1px solid #b6babf;
   border-top: 1px solid #fff;
-  overflow: hidden;
   &:first-child {
     border-top: none;
   }

--- a/app/views/question_banks/show.html.erb
+++ b/app/views/question_banks/show.html.erb
@@ -67,7 +67,7 @@
     <span class="current_question_bank_id"><%= @bank.id %></span>
   </div>
 </div>
-<div id="questions" class="<%= 'uneditable' unless can_do(@bank, @current_user, :manage) %> question_editing brief question_bank">
+<div id="questions" class="<%= 'uneditable' unless can_do(@bank, @current_user, :manage) %> question_editing brief question_bank show_correct_answers">
   <% if @questions.total_pages <= 1 %>
     <% @questions.each do |question| %>
       <%= render :partial => "quizzes/quizzes/display_question", :object => question.data, :locals => {:question_bank_id => @bank.id, :editing => true, :asset_string => question.asset_string} %>


### PR DESCRIPTION
In the Question Banks, the correct questions are not marked when Question Details are shown. All of the data/JS is there, the container just needs another class added.

Test Plan:
  - Create a Question Bank in a Course and add a new Question
  - Click "Show Question Details"
  - Answers should now appear with indicator for correct answers