### PR TITLE
Fix new QuestionBank form html

### DIFF
--- a/app/views/jst/content_migrations/subviews/QuestionBank.handlebars
+++ b/app/views/jst/content_migrations/subviews/QuestionBank.handlebars
@@ -10,5 +10,5 @@
 </div>
 <br />
 <div class="controls" aria-live="assertive">
-  <input title="{{#t "question_bank_title"}}New question bank name{{/t}}"aria-label={{#t "question_bank_placeholder_aria"}}"Enter new question bank name"{{/t}} placeholder={{#t "question_bank_placeholder"}}"Question bank name"{{/t}} type="text" style="display:none" id="createQuestionInput"/>
+  <input title="{{#t "question_bank_title"}}New question bank name{{/t}}" aria-label="{{#t "question_bank_placeholder_aria"}}Enter new question bank name{{/t}}" placeholder="{{#t "question_bank_placeholder"}}Question bank name{{/t}}" type="text" style="display:none" id="createQuestionInput"/>
 </div>


### PR DESCRIPTION
The generated HTML for the new QuestionBank form is invalid and incorrectly displays the placeholder text. This is due to a missing space before the aria-label attribute.

Test Plan:
  - Go to Import Content for a course and select QTI .zip file
  - For Default Question Bank, choose '-- Create new Question Bank --'
  - The placeholder text should now be `Question bank name` rather
    than `"Question`