### PR TITLE
Prevent warning when redefining YAML

### DIFF
--- a/lib/canvas_yaml.rb
+++ b/lib/canvas_yaml.rb
@@ -28,6 +28,7 @@ require 'syck' # so we can undo all the things before something else requires it
 if defined?(YAML::ENGINE)
   YAML::ENGINE.yamler = 'psych'
 else
+  Object.send(:remove_const, :YAML)
   YAML = Psych # :/
 end
 


### PR DESCRIPTION
Test Plan:
  - Run `rails c`
  - The console should load without "warning: already initialized constant YAML"
  - All tests should still pass