### PR TITLE
Sort courses by id desc so the most recent course is first

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -481,7 +481,7 @@ class Account < ActiveRecord::Base
 
   def fast_course_base(opts)
     columns = "courses.id, courses.name, courses.workflow_state, courses.course_code, courses.sis_source_id, courses.enrollment_term_id"
-    associated_courses = self.associated_courses.active
+    associated_courses = self.associated_courses.active.order(:id => :desc)
     associated_courses = associated_courses.with_enrollments if opts[:hide_enrollmentless_courses]
     associated_courses = associated_courses.for_term(opts[:term]) if opts[:term].present?
     associated_courses = yield associated_courses if block_given?


### PR DESCRIPTION
The courses on the account page are listed without any specified ordering. 

A case could be made to sort alphabetically or by last updated date or by published state. I would like to suggest that sorting by ID descending (or created_at) would be the most helpful and would make it easy to find newly created courses.

Test Plan:
  - From the accounts page, create a new course or two
  - Reload the page
  - The newly created course(s) should be listed first