### PR TITLE
Fix syntax error in RedisWrapper for mget

### DIFF
--- a/lib/canvas/redis_wrapper.rb
+++ b/lib/canvas/redis_wrapper.rb
@@ -22,7 +22,7 @@ module Canvas
     end
 
     def mget(*keys)
-      options keys.extract_options!
+      options = keys.extract_options!
       super(*keys, options.merge(raw: true))
     end
   end


### PR DESCRIPTION
The RedisWrapper `mget` method is missing a `=`. Fortunately, nothing in Canvas currently uses `mget` so this never creates a problem. It will be an issue though when something does use it. For example, upgrading the rack-mini-profiler gem would cause mget to be called.

Fixing the syntax error allows the code to run but mget returns an extra `nil` in the response array due to a defect that exists in v1.1.4:
https://github.com/redis-store/redis-store/pull/244

If the redis-store gem was upgraded to v1.2.0 it would have the fix for mget and the marshalling fix (from ccutrer/redis-store) that is currently pinned in the Gemfile.d/redis.rb file. That would also require an update to redis-rails to v5.0.1.

This PR only addresses the missing `=` and does not upgrade any gems so `mget` still suffers from the extra nil issue but does not throw an exception if called.

Test Plan:
  - From a rails console
  - Canvas.redis.set('key1', 1)       # Returns `"OK"`
  - Canvas.redis.set('key2', 2)       # Returns `"OK"`
  - Canvas.redis.mget('key1', 'key2') # Returns `["1", "2", nil]`