### PR TITLE
Add `excuse' parameter documentation for update_grades

### DIFF
--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -738,6 +738,10 @@ class SubmissionsApiController < ApplicationController
   #   See documentation for the posted_grade argument in the
   #   {api:SubmissionsApiController#update Submissions Update} documentation
   #
+  # @argument grade_data[<student_id>][excuse] [Boolean]
+  #   See documentation for the excuse argument in the
+  #   {api:SubmissionsApiController#update Submissions Update} documentation
+  #
   # @argument grade_data[<student_id>][rubric_assessment] [RubricAssessment]
   #   See documentation for the rubric_assessment argument in the
   #   {api:SubmissionsApiController#update Submissions Update} documentation


### PR DESCRIPTION
I mainly use the `bulk_update` api, and recently wanted to excuse
students from an assignment in the same request as updating others'
grades. There was no documentation for this, but the source indicated
that passing `grade_data[<student_id>][excuse]` as a Boolean would work.
Testing appeared to confirm this, so perhaps it should be documented.