### PR TITLE
For students show the display name in the roster redo

### DIFF
--- a/app/views/jst/courses/roster/rosterUser.handlebars
+++ b/app/views/jst/courses/roster/rosterUser.handlebars
@@ -2,7 +2,11 @@
   {{>avatar}}
 </td>
 <td>
-  <a href="{{html_url}}" class="roster_user_name">{{name}}</a>
+  {{#if canViewSisId}}
+  <a href="{{html_url}}" class="roster_user_name">{{name}}</a> ({{short_name}})
+  {{else}}
+  <a href="{{html_url}}" class="roster_user_name">{{short_name}}</a>
+  {{/if}}
   {{#if isPending}}<span class="label label-info" title="{{#t "pending_acceptance_explanation"}}This user has not yet accepted the invitation to the course{{/t}}">{{#t "pending_acceptance_of_invitation"}}pending{{/t}}</span>{{/if}}
   {{#if isInactive}}<span class="label" title="{{#t}}This user is currently not able to access the course{{/t}}">{{#t}}inactive{{/t}}</span>{{/if}}
 </td>


### PR DESCRIPTION
I botched the rebase so here is #901 done on master.
https://github.com/instructure/canvas-lms/pull/901

repeated from the other PR
This also applies to other non privileged users. In all other areas of canvas that are accessible to students the users display name is shown and not the legal name. For students who name in use is not their legal name this allows them to be contactable inside canvas by their name. This also should apply to groups. The display name is sent in the JSON as short_name and is easily available. For teachers and other privileged users the legal name will be displayed. That said a good option would be to display the (display name) in parens after the link. (I have changed to do this in the new PR)

I looked through the selenium tests and people_spec was the closest to this that I could find but it was only testing in the context of people as a teacher or ta. So I am not sure where to put tests.
