### PR TITLE
Missing gem path for autoextend

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -110,7 +110,7 @@ gem 'activesupport-suspend_callbacks', path: 'gems/activesupport-suspend_callbac
 gem 'acts_as_list', path: 'gems/acts_as_list'
 gem 'adheres_to_policy', path: 'gems/adheres_to_policy'
 gem 'attachment_fu', path: 'gems/attachment_fu'
-gem 'autoextend', path: 'gems'
+gem 'autoextend', path: 'gems/autoextend'
 gem 'bookmarked_collection', path: 'gems/bookmarked_collection'
 gem 'broadcast_policy', path: "gems/broadcast_policy"
 gem 'canvas_breach_mitigation', path: 'gems/canvas_breach_mitigation'


### PR DESCRIPTION
Missing gem path for autoextend. It should be gems/autoextend. Wrong path was generating error while doing bundle.

Ashishs-MacBook-Air:canvas ashish$ bundle
--- ERROR REPORT TEMPLATE -------------------------------------------------------
- What did you do?

  I ran the command `/Users/ashish/.rvm/gems/ruby-2.1.6/bin/bundle `

- What did you expect to happen?

  I expected Bundler to...

- What happened instead?

  Instead, what actually happened was...


Error details

    Errno::ENOENT: No such file or directory @ rb_file_s_stat - Changelog.txt
      /Users/ashish/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:2716:in `stat'
      /Users/ashish/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:2716:in `block in validate_permissions'
      /Users/ashish/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:2715:in `each'
      /Users/ashish/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:2715:in `validate_permissions'
      /Users/ashish/.rvm/rubies/ruby-2.1.6/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:2582:in `validate'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/rubygems_integration.rb:51:in `block in validate'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/ui/shell.rb:76:in `silence'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/rubygems_integration.rb:51:in `validate'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler.rb:369:in `block in load_gemspec_uncached'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/shared_helpers.rb:53:in `chdir'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/shared_helpers.rb:53:in `block in chdir'
      /Users/ashish/.rvm/rubies/ruby-2.1.6/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/shared_helpers.rb:52:in `chdir'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler.rb:362:in `load_gemspec_uncached'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler.rb:352:in `load_gemspec'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/source/path.rb:134:in `block in load_spec_files'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/source/path.rb:133:in `each'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/source/path.rb:133:in `load_spec_files'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/source/path.rb:91:in `local_specs'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/source/path.rb:99:in `specs'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/definition.rb:548:in `block in converge_locked_specs'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/definition.rb:537:in `each'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/definition.rb:537:in `converge_locked_specs'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/definition.rb:194:in `resolve'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/definition.rb:139:in `specs'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/definition.rb:128:in `resolve_remotely!'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/installer.rb:79:in `run'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/installer.rb:18:in `install'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/cli/install.rb:107:in `run'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/cli.rb:158:in `install'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/cli.rb:10:in `start'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/bin/bundle:20:in `block in <top (required)>'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/lib/bundler/friendly_errors.rb:7:in `with_friendly_errors'
      /Users/ashish/.rvm/gems/ruby-2.1.6/gems/bundler-1.10.1/bin/bundle:18:in `<top (required)>'
      /Users/ashish/.rvm/gems/ruby-2.1.6/bin/bundle:23:in `load'
      /Users/ashish/.rvm/gems/ruby-2.1.6/bin/bundle:23:in `<main>'
      /Users/ashish/.rvm/gems/ruby-2.1.6/bin/ruby_executable_hooks:15:in `eval'
      /Users/ashish/.rvm/gems/ruby-2.1.6/bin/ruby_executable_hooks:15:in `<main>'

Environment

    Bundler   1.10.1
    Rubygems  2.4.8
    Ruby      2.1.6p336 (2015-04-13 revision 50298) [x86_64-darwin16.0]
    GEM_HOME  /Users/ashish/.rvm/gems/ruby-2.1.6
    GEM_PATH  /Users/ashish/.rvm/gems/ruby-2.1.6:/Users/ashish/.rvm/gems/ruby-2.1.6@global
    RVM       1.27.0 (latest)
    Git       2.8.4 (Apple Git-73)
    rubygems-bundler (1.4.4)
--- TEMPLATE END ----------------------------------------------------------------

Unfortunately, an unexpected error occurred, and Bundler cannot continue.

First, try this link to see if there are any existing issue reports for this error:
https://github.com/bundler/bundler/search?q=No+such+file+or+directory+%40+rb_file_s_stat+-+Changelog.txt&type=Issues

If there aren't any reports for this error yet, please create copy and paste the report template above into a new issue. Don't forget to anonymize any private data! The new issue form is located at:
https://github.com/bundler/bundler/issues/new