### PR TITLE
Exempt files#show_relative from protect_from_forgery

### DIFF
--- a/spec/fixtures/test.js
+++ b/spec/fixtures/test.js
@@ -1,0 +1,1 @@
+console.log('This is totally not a malicious JavaScript file.')


### PR DESCRIPTION
Rails 4.1 introduces CSRF protection from remote <script> tags. This prevents locally-stored JavaScript files uploaded as part of a brand config from loading.

The security implications of exempting `show_relative` needs to be discussed. It would be nice if this could be scoped to account-context files only.

Test plan:
* Create a new brand config
* Upload a JavaScript file
* Save and apply the brand config
* Result: the JS file should load

A signed CLA is on file under my employer, Simon Fraser University.