### PR TITLE
Fix rubric API pagination

### DIFF
--- a/app/controllers/rubrics_api_controller.rb
+++ b/app/controllers/rubrics_api_controller.rb
@@ -147,7 +147,7 @@ class RubricsApiController < ApplicationController
 
   def index
     return unless authorized_action(@context, @current_user, :manage_rubrics)
-    rubrics = Api.paginate(@context.rubrics.active, self, api_v1_course_assignments_url(@context))
+    rubrics = Api.paginate(@context.rubrics.active, self, rubric_pagination_url)
     render json: rubrics_json(rubrics, @current_user, session) unless performed?
   end
 

--- a/lib/api/v1/rubric.rb
+++ b/lib/api/v1/rubric.rb
@@ -46,4 +46,12 @@ module Api::V1::Rubric
     hash['assessments'] = rubric_assessments_json(opts[:assessments], user, session, opts) if opts[:assessments].present?
     hash
   end
+
+  def rubric_pagination_url
+    if @context.is_a? Course
+      api_v1_course_rubrics_url(@context)
+    else
+      api_v1_account_rubrics_url(@context)
+    end
+  end
 end


### PR DESCRIPTION
This is a fix for rubric API endpoints incorrectly returning assignment URLs in pagination headers. Along the way I noticed the rubrics_api_spec was only checking course context so I also added separate tests for account contexts. I tried to follow the lead of external_tools_controller for both the code and the spec.