### PR TITLE
Fix external error reporting via HTTP POST

### DIFF
--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -228,7 +228,7 @@ error_id: #{error_report.id}
       params = {}
       params[config[:subject_param]] = error_report.subject
       params[config[:body_param]] = body
-      Net::HHTP.post_form(URI.parse(config[:url]), params)
+      Net::HTTP.post_form(URI.parse(config[:url]), params)
     elsif config[:action] == 'email' && config[:email]
       Message.create!(
         :to => config[:email],


### PR DESCRIPTION
When enabling and testing the external error reporting plugin, I found that
it had a typo: `Net:HHTP` instead of `Net::HTTP`.

Test Plan:
  - Enable external errpor rerpoting to a URL
  - Send an error report with `ErrorReport.last.send_to_external`
  - Expect the configured URL to receive the POST