### PR TITLE
Validate submission types for VeriCite assignments

### DIFF
--- a/app/coffeescripts/views/assignments/EditView.coffee
+++ b/app/coffeescripts/views/assignments/EditView.coffee
@@ -461,6 +461,15 @@ ConditionalRelease, deparam, AssignmentConfigurationsTools) ->
         errors["online_submission_types[online_text_entry]"] = [
           message: I18n.t 'at_least_one_submission_type', 'Please choose at least one submission type'
         ]
+      else if data.submission_type == 'online' and data.vericite_enabled == "1"
+        allow_vericite = true
+        _.select _.keys(data.submission_types), (k) ->
+          allow_vericite = allow_vericite && (data.submission_types[k] == "online_upload" || data.submission_types[k] == "online_text_entry")
+        if !allow_vericite
+          errors["online_submission_types[online_text_entry]"] = [
+            message: I18n.t 'vericite_submission_types_validation', 'VeriCite only supports file submissions and text entry'
+          ]
+
       errors
 
     _validateAllowedExtensions: (data, errors) =>


### PR DESCRIPTION
VeriCite only supports file submissions and text entry submission types. When creating or editing an assignment, validate the submission types are only of these type.

Test Plan:
1) Enable VeriCite in the plugins page. You can use dummy data since we are only validating the saving of the assignment
2) Test saving a combination of "Enable VeriCite Submissions" with the available submission types. If VeriCite is enabled, only "Text Entry" and or "File Uploads" (both are ok) are allowed. Including any other submission type should warn the user and not allow them to save the Assignment.
3) Test saving an assignment without VeriCite enabled (both with and without the VeriCite plugin enabled). Make sure you can save any combination of submission types.