### PR TITLE
Change generic webcam text to Respondus Monitor

### DIFF
--- a/app/views/quizzes/quizzes/_quiz_show_teacher.html.erb
+++ b/app/views/quizzes/quizzes/_quiz_show_teacher.html.erb
@@ -180,7 +180,7 @@
       <% if @quiz.lockdown_browser_use_lti_tool? %>
         <div class="control-group">
           <div class="control-label">
-            <%= t(:require_lockdown_browser_monitor, "Webcam Required") %>
+            <%= t(:require_lockdown_browser_monitor, "Require Respondus Monitor") %>
           </div>
           <div class="controls">
             <span class="value">


### PR DESCRIPTION
Changing require generic webcam text to Required Respondus Monitor.

We have other products that can use a user's webcam.  Having Respondus Monitor show up as Webcam Required: Yes (No) can be confusing UI/UX.

Test Plan:
  - As an instructor, create a new quiz and click save.
  - In the preview area, you should see Require Respondus Monitor: Yes (or No) rather than Webcam Required: