### PR TITLE
Import and export VeriCite advanced settings

### DIFF
--- a/app/models/importers/assignment_importer.rb
+++ b/app/models/importers/assignment_importer.rb
@@ -211,10 +211,14 @@ module Importers
         end
       end
 
-      if item.turnitin_enabled
+      if item.turnitin_enabled || item.vericite_enabled
         settings = JSON.parse(hash[:turnitin_settings]).with_indifferent_access
         settings[:created] = false if settings[:created]
-        item.turnitin_settings = settings
+        if item.vericite_enabled
+          item.vericite_settings = settings
+        else
+          item.turnitin_settings = settings
+        end
       end
 
       migration.add_imported_item(item)

--- a/lib/cc/assignment_resources.rb
+++ b/lib/cc/assignment_resources.rb
@@ -229,7 +229,7 @@ module CC
         node.external_tool_url assignment.external_tool_tag.url
         node.external_tool_new_tab assignment.external_tool_tag.new_tab
       end
-      node.tag!(:turnitin_settings, (assignment.send(:turnitin_settings).to_json)) if assignment.turnitin_enabled
+      node.tag!(:turnitin_settings, (assignment.send(:turnitin_settings).to_json)) if assignment.turnitin_enabled || assignment.vericite_enabled
     end
 
   end

--- a/spec/models/content_migration/course_copy_assignments_spec.rb
+++ b/spec/models/content_migration/course_copy_assignments_spec.rb
@@ -153,6 +153,12 @@ describe ContentMigration do
       assignment_model(:course => @copy_from, :points_possible => 40, :submission_types => 'file_upload', :grading_type => 'points')
       @assignment.turnitin_enabled = true
       @assignment.vericite_enabled = true
+      @assignment.vericite_settings = {
+          :originality_report_visibility => "after_grading",
+          :exclude_quoted => '1',
+          :exclude_self_plag => '0',
+          :store_in_index => '1'
+      }
       @assignment.peer_reviews = true
       @assignment.peer_review_count = 2
       @assignment.automatic_peer_reviews = true
@@ -168,7 +174,7 @@ describe ContentMigration do
       @copy_to.any_instantiation.expects(:turnitin_enabled?).at_least(1).returns(true)
       @copy_to.any_instantiation.expects(:vericite_enabled?).at_least(1).returns(true)
 
-      attrs = [:turnitin_enabled, :vericite_enabled, :peer_reviews,
+      attrs = [:turnitin_enabled, :vericite_enabled, :turnitin_settings, :peer_reviews,
           :automatic_peer_reviews, :anonymous_peer_reviews,
           :grade_group_students_individually, :allowed_extensions,
           :position, :peer_review_count, :muted, :omit_from_final_grade]
@@ -177,7 +183,11 @@ describe ContentMigration do
 
       new_assignment = @copy_to.assignments.where(migration_id: mig_id(@assignment)).first
       attrs.each do |attr|
-        expect(@assignment[attr]).to eq new_assignment[attr]
+        if @assignment[attr].class == Hash
+          expect(@assignment[attr].stringify_keys).to eq new_assignment[attr].stringify_keys
+        else
+          expect(@assignment[attr]).to eq new_assignment[attr]
+        end
       end
       expect(new_assignment.only_visible_to_overrides).to be_falsey
     end


### PR DESCRIPTION
When importing an assignment into a course, the VeriCite advanced settings were not imported

Test Plan:
1) Enable VeriCite in the plugins page. You can use dummy data since we are only validating the saving of the assignment
2) Create two courses and add an instructor to both
3) In course A, create an assignment with submission type=online and check "Enable VeriCite Submissions".
4) Click "Advanced VeriCite Settings" and make changes to the default settings and click "Update Settings".
5) Save assignment
6) In course B, import the assignments from Course A (https://guides.instructure.com/m/4152/l/57077-how-do-i-copy-content-from-another-canvas-course)
7) In course B, verify that the assignment was created and that the VeriCite settings are correct, including the advanced settings