### PR TITLE
VeriCite: resubmit option should be available for any incomplete reports

### DIFF
--- a/public/javascripts/speed_grader.js
+++ b/public/javascripts/speed_grader.js
@@ -1499,17 +1499,17 @@ define([
         });
 
         var defaultInfoMessage = I18n.t('vericite.info_message',
-                                        'This file is still being processed by VeriCite. Please check back later to see the score'),
+                                        'This file is still being processed by VeriCite. Please check back later to see the score or resubmit if it has been more than a day.'),
             defaultErrorMessage = I18n.t('vericite.error_message',
                                          'There was an error submitting to VeriCite. Please try resubmitting the file before contacting support');
         var $vericiteInfo = $(vericiteInfoTemplate({
           assetString: assetString,
           message: (vericiteAsset.status == 'error' ? (vericiteAsset.public_error_message || defaultErrorMessage) : defaultInfoMessage),
-          showResubmit: vericiteAsset.status == 'error' && isMostRecent
+          showResubmit: isMostRecent
         }));
         $vericiteInfoContainer.append($vericiteInfo);
 
-        if (vericiteAsset.status == 'error' && isMostRecent) {
+        if (isMostRecent) {
           var resubmitUrl = $.replaceTags($assignment_submission_resubmit_to_vericite_url.attr('href'), { user_id: submission.user_id });
           $vericiteInfo.find('.vericite_resubmit_button').click(function(event) {
             event.preventDefault();


### PR DESCRIPTION
The resubmit option doesn't show up unless the submissions process runs successfully. This isn't helpful for instructors who have submissions that the process never successfully kickekd off and results in orphaned submissions that never get submitted to VeriCite. This patch makes sure that all the correct meta data is saved to the submission before the process even begins, so that the instructor will always see the resubmit option if the process errored out for any reason.

Test Plan:

1) Enable VeriCite in the plugins page. You can use dummy data since we are only validating the submission process
2) Create an assignment
3) Submit to this assignment as a student (one for attachments and one for inline submissions)
4) As the instructor, you should immediately see a gray pending icon in both the gradebook overview and the speedgrader page. In the speedgrader page, you should be able to click the pending icon and see an option to resubmit to VeriCite.