### PR TITLE
VeriCite report links do not work when a user clicks to view the report

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -561,7 +561,6 @@ class Submission < ActiveRecord::Base
       }
     end
     ret_val = turnitin_data.merge(data)
-    ret_val.delete(:provider)
     ret_val
   end
 


### PR DESCRIPTION
This seems to be a regression from https://github.com/instructure/canvas-lms/commit/e087da776f2a8037886510ab1677773244ee5653 where it deletes the provider identifier for the originality_data, which is used to determine whether the link is a VeriCite or TII link

Test Plan:
1) enable VeriCite plugin
2) create an assignment with VeriCite enabled
3) submit to the assignment and wait for report to be ready
4) click the link to view the report
5) make sure report works and doesn't give an error saying report is missing
(also check anything relate to TII and viewing reports)