### PR TITLE
Use mail_gate to restrict the delivery of mail to only whitelisted email

### DIFF
--- a/Gemfile.d/mail_gate.rb
+++ b/Gemfile.d/mail_gate.rb
@@ -1,0 +1,1 @@
+gem 'mail_gate'

--- a/config/initializers/outgoing_mail.rb
+++ b/config/initializers/outgoing_mail.rb
@@ -7,7 +7,7 @@ require 'net/smtp'
 config = {
   :domain => "unknowndomain.example.com",
   :delivery_method => :smtp,
-}.merge((ConfigFile.load("outgoing_mail") || {}).symbolize_keys)
+}.merge((ConfigFile.load("outgoing_mail") || {}).deep_symbolize_keys)
 
 [:authentication, :delivery_method].each do |key|
   config[key] = config[key].to_sym if config.has_key?(key)
@@ -23,7 +23,7 @@ Rails.configuration.to_prepare do
   IncomingMailProcessor::MailboxAccount.default_outgoing_email = HostUrl.outgoing_email_address
 end
 
-# delivery_method can be :smtp, :sendmail, :letter_opener, or :test
+# delivery_method can be :smtp, :sendmail, :letter_opener, :mail_gate, or :test
 ActionMailer::Base.delivery_method = config[:delivery_method]
 
 ActionMailer::Base.perform_deliveries = config[:perform_deliveries] if config.has_key?(:perform_deliveries)
@@ -33,4 +33,8 @@ when :smtp
   ActionMailer::Base.smtp_settings.merge!(config)
 when :sendmail
   ActionMailer::Base.sendmail_settings.merge!(config)
+when :mail_gate
+  config[:delivery_method] = :smtp
+  config[:whitelist] = eval(config[:whitelist])
+  ActionMailer::Base.mail_gate_settings.merge!(config)
 end

--- a/config/outgoing_mail.yml.example
+++ b/config/outgoing_mail.yml.example
@@ -26,6 +26,22 @@ production:
   outgoing_address: "canvas@example.com"
   default_name: "Instructure Canvas"
 
+# Use mail_gate to block emails to any non @instructure.com email address.
+# for whitelisted emails, smtp is used with the delivery_settings.  These
+staging:
+  delivery_method: mail_gate
+  whitelist: /\@instructure.com/
+  subject_prefix: '[Staging] '
+  delivery_settings:
+    address: "smtp.example.com"
+    port: 25
+    user_name: "user"
+    password: "password"
+    authentication: "plain" # plain, login, or cram_md5
+    domain: "example.com"
+    outgoing_address: "canvas@example.com"
+    default_name: "Instructure Canvas"
+
 # If receiving mail from multiple inboxes (see incoming_mail.yml.example),
 # you'll want to include those addresses in a reply_to_addresses array so
 # Canvas will select the Reply-To field of outgoing messages from all of the


### PR DESCRIPTION
> MailGate is an additional delivery method for the Mail gem that lets you restrict the delivery of mail to only whitelisted emails. Ideal for staging environments where you may be using production data and do not want them to receive emails from your mailers when you submit comments, contact forms, or anything else that may trigger mail delivery.

This PR adds mail_gate as a supported delivery method specifically so staging environments only send email to whitelisted email addresses.

Details:
- Adds a new delivery_method to outgoing_mail.yml: mail_gate
- When mail_gate is the delivery method, and the email is whitelisted, use SMTP as the delivery mechanism
- outgoing_mail.yml.example has settings for configuring mail_gate.  Additional options can be found with the mail_gate gem

Test Plan:
- Configure outgoing email with mail gate and a whitelisted email domain
- Send messages to a whitelisted domain and another domain.  Expect to only receive email on the whitelisted domain
