### PR TITLE
VeriCite Advanced Settings in the Assignment tool get overridden

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -429,7 +429,11 @@ class Assignment < ActiveRecord::Base
   end
 
   def turnitin_settings=(settings)
-    settings = Turnitin::Client.normalize_assignment_turnitin_settings(settings)
+    if vericite_enabled?
+      settings = VeriCite::Client.normalize_assignment_vericite_settings(settings)
+    else
+      settings = Turnitin::Client.normalize_assignment_turnitin_settings(settings)
+    end
     unless settings.blank?
       [:created, :error].each do |key|
         settings[key] = self.turnitin_settings[key] if self.turnitin_settings[key]


### PR DESCRIPTION
VeriCite Advanced Settings in the Assignment tool get overridden by Turrnitin settings after the first submission to the assignment

This seems to be a regression introduced from https://github.com/instructure/canvas-lms/commit/ffe268b829934efa684139fc21cfe58cbe864433
When a VeriCite assignment is first saved, it will have the correct data saved in the turnitin_data structure. However, once a user submits, the assignment is resaved with the default Turnitin settings and the VeriCite settings get overridden

Test Plan:
1) Make sure that the test plan in https://github.com/instructure/canvas-lms/commit/ffe268b829934efa684139fc21cfe58cbe864433 works
2) Create a VeriCite assignment with the advanced settings all set to true/checked (make sure only VeriCite is enabled and not other plagiarism service)
3) Edit the assignment and verify that the advanced settings for VeriCite are still all set to true (no need to resave)
4) Submit as a student to the assignment
5) Wait a few mins (cron job takes about 1-2 mins)
6) Edit the assignment and verify that the advanced settings for VeriCite are still all set to true