### PR TITLE
VeriCite: allow institutions to enable VeriCite at the subaccount level

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -450,10 +450,10 @@ class Assignment < ActiveRecord::Base
   end
 
   def create_in_vericite
-    return false unless Canvas::Plugin.find(:vericite).try(:enabled?)
+    return false unless VeriCite.enabled_for_account?(self.context.account_id)
     return true if self.turnitin_settings[:current] && self.turnitin_settings[:vericite]
     vericite = VeriCite::Client.new()
-    res = vericite.createOrUpdateAssignment(self, self.turnitin_settings)
+    res = vericite.createOrUpdateAssignment(self, self.turnitin_settings, self.context.account_id)
 
     # make sure the defaults get serialized
     self.turnitin_settings = turnitin_settings

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2007,7 +2007,7 @@ class Course < ActiveRecord::Base
   end
 
   def vericite_enabled?
-    Canvas::Plugin.find(:vericite).try(:enabled?)
+    VeriCite.enabled_for_account?(self.account_id)
   end
 
   def vericite_pledge

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -629,7 +629,7 @@ class Submission < ActiveRecord::Base
     # check to see if the score is stale, if so, fetch it again
     update_scores = false
     # since there could be multiple versions, let's not waste calls for old versions and use the old score
-    if Canvas::Plugin.find(:vericite).try(:enabled?) && !self.readonly? && lookup_data && self.versions.current && self.versions.current.number == self.version_number
+    if VeriCite.enabled_for_account?(self.context.account_id) && !self.readonly? && lookup_data && self.versions.current && self.versions.current.number == self.version_number
       self.vericite_data_hash.keys.each do |asset_string|
         data = self.vericite_data_hash[asset_string]
         next unless data && data.is_a?(Hash) && data[:object_id]
@@ -706,7 +706,7 @@ class Submission < ActiveRecord::Base
           # keep track of when we asked for this score, so if it fails, we don't keep trying immediately again (i.e. wain 20 sec before trying again)
           data[:similarity_score_check_time] = Time.now.to_i
           vericite ||= VeriCite::Client.new()
-          res = vericite.generateReport(self, asset_string)
+          res = vericite.generateReport(self, asset_string, self.context.account_id)
           if res[:similarity_score]
             # keep track of when we updated the score so that we can ask VC again once it is stale (i.e. cache for 20 mins)
             data[:similarity_score_time] = Time.now.to_i
@@ -753,9 +753,9 @@ class Submission < ActiveRecord::Base
     if self.vericite_data_hash && self.vericite_data_hash[asset_string] && self.vericite_data_hash[asset_string][:similarity_score]
       vericite = VeriCite::Client.new()
       if self.grants_right?(user, :grade)
-        vericite.submissionReportUrl(self, user, asset_string)
+        vericite.submissionReportUrl(self, user, asset_string, self.context.account_id)
       elsif can_view_plagiarism_report('vericite', user, session)
-        vericite.submissionStudentReportUrl(self, user, asset_string)
+        vericite.submissionStudentReportUrl(self, user, asset_string, self.context.account_id)
       end
     else
       nil
@@ -768,9 +768,9 @@ class Submission < ActiveRecord::Base
   def submit_to_vericite(attempt=0)
     Rails.logger.info("VERICITE #submit_to_vericite submission ID: #{self.id}, vericiteable? #{vericiteable?}")
     if vericiteable?
-      Rails.logger.info("VERICITE #submit_to_vericite submission ID: #{self.id}, plugin: #{Canvas::Plugin.find(:vericite)}, vericite plugin enabled? #{Canvas::Plugin.find(:vericite).try(:enabled?)}")
+      Rails.logger.info("VERICITE #submit_to_vericite submission ID: #{self.id}, plugin: #{Canvas::Plugin.find(:vericite)}, vericite plugin enabled? #{VeriCite.enabled_for_account?(self.context.account_id)}")
     end
-    return unless vericiteable? && Canvas::Plugin.find(:vericite).try(:enabled?)
+    return unless vericiteable? && VeriCite.enabled_for_account?(self.context.account_id)
     vericite = VeriCite::Client.new()
     reset_vericite_assets
 
@@ -792,7 +792,7 @@ class Submission < ActiveRecord::Base
     end
     # even if the assignment didn't save, VeriCite will still allow this file to be submitted
     # Submit the file(s)
-    submission_response = vericite.submitPaper(self)
+    submission_response = vericite.submitPaper(self, nil, self.context.account_id)
     # VeriCite will not resubmit a file if it already has a similarity_score (i.e. success)
     update = false
     submission_response.each do |res_asset_string, response|
@@ -898,7 +898,7 @@ class Submission < ActiveRecord::Base
     # Because vericite is new and people are moving to vericite, not
     # moving from vericite to turnitin, we'll give vericite precedence
     # for now.
-    @plagiarism_service_to_use = if Canvas::Plugin.find(:vericite).try(:enabled?)
+    @plagiarism_service_to_use = if VeriCite.enabled_for_account?(self.context.account_id)
       :vericite
     elsif !self.context.turnitin_settings.nil?
       :turnitin

--- a/app/views/plugins/_vericite_settings.html.erb
+++ b/app/views/plugins/_vericite_settings.html.erb
@@ -17,26 +17,48 @@
     </div>
   </div>
 </div>
+
+  <h3><%= mt :credentials, :en => "Crentials" %></h3>
+  Get your credentials from <a href="http://www.vericite.com" target="_blank">VeriCite</a>.<br/>
+  <%= mt :account_credentials_info, "You can set your credentials for all accounts or enable individual Sub-Accounts. To enable all accounts, just set 'Global VeriCite Account ID' and 'Global VeriCite Shared Secret'. If you want to restrict VeriCite to specific Sub-Accounts, enter each Sub-Account's credentials in 'Account VeriCite Credentials' on a new line in the format: canvas_account_id:vericite_account_id:vericite_shared_secret" %>
+  <br/>
+  <br/>
   <table  class="formtable">
     <tr>
-      <td colspan="2">
-        Get your credentials from <a href="http://www.vericite.com" target="_blank">VeriCite</a>
-      </td>
-    </tr>
-    <tr>
-      <td><%= f.blabel :account_id, :en => "VeriCite Account ID" %></td>
+      <td><%= f.blabel :account_id, :en => "Global VeriCite Account ID" %></td>
       <td>
         <%= f.text_field :account_id %>
       </td>
     </tr>
 
     <tr>
-      <td><%= f.blabel :shared_secret, :en => "VeriCite Shared Secret" %></td>
+      <td><%= f.blabel :shared_secret, :en => "Global VeriCite Shared Secret" %></td>
       <td>
         <%= f.text_field :shared_secret %>
       </td>
     </tr>
 
+    <tr>
+      <td><%= mt :or, "**or**" %>:</td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td><%= f.blabel :subaccount_credentials, :en => "Account VeriCite Credentials" %></td>
+      <td>
+        <%= f.text_area :subaccount_credentials, :rows => '4' %>
+        <br/>
+        <%= mt :example, "*example*" %>:
+        <br/>
+        <%= mt :subaccount_format, "*canvas_account_id:vericite_account_id:vericite_shared_secret*" %>
+        <br/>
+        <%= mt :subaccount_format, "*canvas_account_id:vericite_account_id:vericite_shared_secret*" %>
+      </td>
+    </tr>
+   </table>
+
+   <h3><%= mt :settings, :en => "Settings" %></h3>
+   <table>
     <tr>
       <td><%= f.blabel :host, :en => "VeriCite Host" %></td>
       <td>

--- a/lib/canvas/plugins/default_plugins.rb
+++ b/lib/canvas/plugins/default_plugins.rb
@@ -362,6 +362,7 @@ Canvas::Plugin.register('vericite', nil, {
   :settings => {
     :account_id => nil,
     :shared_secret => nil,
+    :subaccount_credentials => nil,
     :host => 'api.vericite.com',
     :comments => nil,
     :pledge => nil,


### PR DESCRIPTION
Currently, institutions can only enable VeriCite at the top level in a "all or nothing" fashion. This feature will allow institutions to enable VeriCite at a subaccount level. There are many use cases for this including: each sub account is a different school and either 1) not all schools have subscribed to VeriCite 2) each school wants a unique key to VeriCite. Also, there are K-12 schools who do not need VeriCite enabled for the lower grades.

Test Plan:

1) Repeat the following steps with multiple plugin settings:
a) plugin setting 1: Set "Global VeriCite Account ID" and "Global VeriCite Shared Secret". Leave "Account VeriCite Credentials" empty
b) plugin setting 2: Set "Global VeriCite Account ID" and "Global VeriCite Shared Secret". Set "Account VeriCite Credentials".
c) plugin setting 3: Leave "Global VeriCite Account ID" and "Global VeriCite Shared Secret" empty. Set "Account VeriCite Credentials".
d) plugin setting 4: Leave "Global VeriCite Account ID" and "Global VeriCite Shared Secret" and "Account VeriCite Credentials" empty

2) Create a new assignment. Make sure that the "Enable VeriCite Submissions" shows or is hidden based on account settings. (caution, if using the same user, it could be automatically "checked" since this setting is saved as a user preference)
3) If you can, create the VeriCite assignment
4) Submit both an attachment and inline submission
5) Make sure the reports show up (could be 10+ minutes depending on server load, to speed this up, you can also set "Show Preliminary Score" to true in the plugin settings)