### PR TITLE
Add notes field and usage stats to Developer Keys

### DIFF
--- a/app/controllers/developer_keys_controller.rb
+++ b/app/controllers/developer_keys_controller.rb
@@ -88,6 +88,6 @@ class DeveloperKeysController < ApplicationController
   end
 
   def developer_key_params
-    params.require(:developer_key).permit(:api_key, :name, :icon_url, :redirect_uri, :redirect_uris, :email, :auto_expire_tokens)
+    params.require(:developer_key).permit(:api_key, :name, :icon_url, :redirect_uri, :redirect_uris, :email, :auto_expire_tokens, :notes, :access_token_count)
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,7 +1,7 @@
 class AccessToken < ActiveRecord::Base
   attr_reader :full_token
   attr_reader :plaintext_refresh_token
-  belongs_to :developer_key
+  belongs_to :developer_key, counter_cache: :access_token_count
   belongs_to :user
   has_one :account, through: :developer_key
 

--- a/app/models/developer_key.rb
+++ b/app/models/developer_key.rb
@@ -106,6 +106,10 @@ class DeveloperKey < ActiveRecord::Base
     account.try(:name)
   end
 
+  def last_used_at
+    self.access_tokens.maximum(:last_used_at)
+  end
+
   class << self
     def find_cached(id)
       global_id = Shard.global_id_for(id)

--- a/app/stylesheets/bundles/developer_keys.scss
+++ b/app/stylesheets/bundles/developer_keys.scss
@@ -38,6 +38,13 @@
       font-weight: bold;
       @include fontSize(14px);
     }
+    &.notes {
+      width: 15%;
+      > div {
+        max-height: 100px;
+        overflow-x: auto
+      }
+    }
     &.links i {
       opacity: 0.4;
     }

--- a/app/views/developer_keys/index.html.erb
+++ b/app/views/developer_keys/index.html.erb
@@ -13,6 +13,7 @@
       <th><%= t :user, "User" %></th>
       <th><%= t :details, "Details" %></th>
       <th><%= t :stats, "Stats" %></th>
+      <th><%= t :notes, "Notes" %></th>
       <th>&nbsp;</th>
     </tr>
   </thead>

--- a/app/views/jst/developer_key.handlebars
+++ b/app/views/jst/developer_key.handlebars
@@ -28,23 +28,33 @@
     <td>
         <div class="details">
             <div>
-               {{#t "identifier"}}ID: {{id}}{{/t}}
+               {{#t}}ID: {{id}}{{/t}}
             </div>
             <div>
-               {{#t "api_key"}}Key: <span class='api_key'>{{api_key}}</span>{{/t}}
+               {{#t}}Key: <span class='api_key'>{{api_key}}</span>{{/t}}
             </div>
             <div>
                 {{#if redirect_uri}}
-                    {{#t "redirect_uri"}}URI: {{redirect_uri}}{{/t}}
+                    {{#t}}URI: {{redirect_uri}}{{/t}}
                 {{/if}}
             </div>
         </div>
     </td>
     <td>
         <div>
-            {{#t "created"}}Created:{{/t}} {{datetimeFormatted created_at}}
+          {{#t}}Access Token Count: {{access_token_count}}{{/t}}
         </div>
-        <!-- TODO: Add some better stats here, like token count, last usage, etc. -->
+        <div>
+            {{#t}}Created:{{/t}} {{datetimeFormatted created_at}}
+        </div>
+        <div>
+            {{#t}}Last Used:{{/t}} {{#ifExists last_used_at}}{{last_used_at}}{{else}}Never{{/ifExists}}
+        </div>
+    </td>
+    <td class='notes'>
+      <div>
+        {{#t}}{{notes}}{{/t}}
+      </div>
     </td>
     <td class='links'>
         <a href="#" class="edit_link" aria-label="{{#t}}Edit key {{name}}{{/t}}" title="{{#t "edit_key"}}Edit this key{{/t}}"><i class="icon-edit standalone-icon"></i></a>
@@ -53,6 +63,6 @@
         {{else}}
           <a href="#" role="checkbox" aria-checked="true" aria-label="{{#t}}Activate key {{name}}{{/t}}" class="deactivate_link" title="{{#t}}Deactivate this key{{/t}}"><i class="icon-lock standalone-icon"></i></a>
         {{/if}}
-        <a href="#" class="delete_link" aria-label="{{#t}}Delete key {{name}}{{/t}}" title="{{#t "delete_key"}}Delete this key{{/t}}"><i class="icon-trash standalone-icon"></i></a>
+        <a href="#" class="delete_link" title="{{#t}}Delete this key{{/t}}"><i class="icon-trash standalone-icon"></i></a>
     </td>
 </tr>

--- a/app/views/jst/developer_key_form.handlebars
+++ b/app/views/jst/developer_key_form.handlebars
@@ -21,6 +21,10 @@
         <td><input type='text' id='icon_url' name='developer_key[icon_url]' value='{{ icon_url }}'/>
     </tr>
     <tr>
+        <td><label for='notes'>{{#t "notes"}}Notes:{{/t}}</label></td>
+        <td><textarea id='notes' name='developer_key[notes]' class="input-block-level">{{ notes }}</textarea>
+    </tr>
+    <tr>
         <td colspan='2'>
             <div class='button-container'>
               <button type='button' class='btn dialog_closer cancel'>{{#t "cancel"}}Cancel{{/t}}</button>

--- a/db/migrate/20170320212242_add_notes_to_developer_keys.rb
+++ b/db/migrate/20170320212242_add_notes_to_developer_keys.rb
@@ -1,0 +1,7 @@
+class AddNotesToDeveloperKeys < ActiveRecord::Migration[4.2]
+  tag :predeploy
+
+  def change
+    add_column :developer_keys, :notes, :text
+  end
+end

--- a/db/migrate/20170323205406_add_access_token_count_to_developer_keys.rb
+++ b/db/migrate/20170323205406_add_access_token_count_to_developer_keys.rb
@@ -1,0 +1,6 @@
+class AddAccessTokenCountToDeveloperKeys < ActiveRecord::Migration[4.2]
+  tag :predeploy
+  def change
+    add_column :developer_keys, :access_token_count, :integer, :default => 0, :null => false
+  end
+end

--- a/db/migrate/20170323212756_update_developer_key_access_token_counts.rb
+++ b/db/migrate/20170323212756_update_developer_key_access_token_counts.rb
@@ -1,0 +1,8 @@
+class UpdateDeveloperKeyAccessTokenCounts < ActiveRecord::Migration[4.2]
+  tag :postdeploy
+
+  def up
+    DataFixup::UpdateDeveloperKeyAccessTokenCounts.send_later_if_production_enqueue_args(:run,
+      :priority => Delayed::LOW_PRIORITY)
+  end
+end

--- a/db/migrate/20170324212128_add_last_used_at_index_to_developer_keys.rb
+++ b/db/migrate/20170324212128_add_last_used_at_index_to_developer_keys.rb
@@ -1,0 +1,8 @@
+class AddLastUsedAtIndexToDeveloperKeys < ActiveRecord::Migration[4.2]
+  tag :predeploy
+  disable_ddl_transaction!
+
+  def change
+    add_index :access_tokens, [:developer_key_id, :last_used_at], algorithm: :concurrently
+  end
+end

--- a/lib/api/v1/developer_key.rb
+++ b/lib/api/v1/developer_key.rb
@@ -20,7 +20,7 @@ module Api::V1::DeveloperKey
   include Api::V1::Json
 
   DEVELOPER_KEY_JSON_ATTRS = %w(
-    name created_at email user_id user_name icon_url workflow_state
+    name created_at email user_id user_name icon_url notes workflow_state
   ).freeze
 
   def developer_keys_json(keys, user, session, context=nil)
@@ -34,6 +34,9 @@ module Api::V1::DeveloperKey
         hash['api_key'] = key.api_key
         hash['redirect_uri'] = key.redirect_uri
         hash['redirect_uris'] = key.redirect_uris.join("\n")
+        hash['notes'] = key.notes
+        hash['access_token_count'] = key.access_token_count
+        hash['last_used_at'] = key.last_used_at
       end
       hash['account_name'] = key.account_name
       hash['id'] = key.global_id

--- a/lib/data_fixup/update_developer_key_access_token_counts.rb
+++ b/lib/data_fixup/update_developer_key_access_token_counts.rb
@@ -1,0 +1,5 @@
+module DataFixup::UpdateDeveloperKeyAccessTokenCounts
+  def self.run
+    DeveloperKey.find_each { |key| DeveloperKey.reset_counters(key.id, :access_tokens) }
+  end
+end

--- a/spec/models/developer_key_spec.rb
+++ b/spec/models/developer_key_spec.rb
@@ -55,6 +55,36 @@ describe DeveloperKey do
     expect(key).to be_valid
   end
 
+  it "returns the correct count of access_tokens" do
+    key = DeveloperKey.create!(
+      :name => 'test',
+      :email => 'test@test.com',
+      :redirect_uri => 'http://test.com'
+    )
+
+    expect(key.access_token_count).to eq 0
+
+    AccessToken.create!(:user => user_model, :developer_key => key)
+    AccessToken.create!(:user => user_model, :developer_key => key)
+    AccessToken.create!(:user => user_model, :developer_key => key)
+
+    expect(key.access_token_count).to eq 3
+  end
+
+  it "returns the last_used_at value for a key" do
+    key = DeveloperKey.create!(
+      :name => 'test',
+      :email => 'test@test.com',
+      :redirect_uri => 'http://test.com'
+    )
+
+    expect(key.last_used_at).to be_nil
+    at = AccessToken.create!(:user => user_model, :developer_key => key)
+    at.used!
+    expect(key.last_used_at).not_to be_nil
+  end
+
+
   describe "#redirect_domain_matches?" do
     it "should match domains exactly, and sub-domains" do
       key = DeveloperKey.create!(:redirect_uri => "http://example.com/a/b")


### PR DESCRIPTION
This pull request enhances the Developer Keys page in two ways:

## Notes field

A notes field is added on the `developer_keys` table. When creating a key, there is sometimes a need to record more information (for example, a ticket number for the request, information on how the key is to be used, etc). The notes field is exposed in the developer key listing, in the API response, and in the dialog for creating/editing a key.

## Usage stats

While adding the notes field, I found a `TODO` marker for "add some better stats here, like token count, last usage, etc.". Mark that `TODO` as `DONE`! This PR adds two methods to the `DeveloperKey` model: `access_token_count` and `last_used_at`. These fields are returned in the API response, and are displayed in the Stats column on the Developer Key page.

---
![screenshot 2017-03-21 16 55 19](https://cloud.githubusercontent.com/assets/146111/24176111/5650248c-0e57-11e7-9114-bfd4887d6fe0.png)

![screenshot 2017-03-21 16 55 28](https://cloud.githubusercontent.com/assets/146111/24176125/63ad6ba8-0e57-11e7-8e4d-070a4778ff0e.png)

----

I have left my commits un-squashed in case there are changes required. I can squash them into one commit prior to merging.

A signed CLA is on file under my employer, Simon Fraser University.
