### PR TITLE
Ignore query parameters for developer key redirects

### DIFF
--- a/app/models/developer_key.rb
+++ b/app/models/developer_key.rb
@@ -145,7 +145,7 @@ class DeveloperKey < ActiveRecord::Base
   # verify that the given uri has the same domain as this key's
   # redirect_uri domain.
   def redirect_domain_matches?(redirect_uri)
-    return true if redirect_uris.include?(redirect_uri)
+    return true if redirect_uris.include?(redirect_uri.to_s.split('?').first)
 
     # legacy deprecated
     self_domain = URI.parse(self.redirect_uri).host

--- a/spec/models/developer_key_spec.rb
+++ b/spec/models/developer_key_spec.rb
@@ -75,13 +75,13 @@ describe DeveloperKey do
 
     it "does not allow subdomains when it matches in redirect_uris" do
       key = DeveloperKey.create!(redirect_uris: "http://example.com/a/b")
-      expect(key.redirect_domain_matches?("http://example.com/a/b")).to eq true
+      expect(key.redirect_domain_matches?("http://example.com/a/b")).to be_truthy
       # other paths on the same domain are NOT ok
-      expect(key.redirect_domain_matches?("http://example.com/other")).to eq false
+      expect(key.redirect_domain_matches?("http://example.com/other")).to be_falsey
       # sub-domains are not ok either
-      expect(key.redirect_domain_matches?("http://www.example.com/a/b")).to eq false
-      expect(key.redirect_domain_matches?("http://a.b.example.com/a/b")).to eq false
-      expect(key.redirect_domain_matches?("http://a.b.example.com/other")).to eq false
+      expect(key.redirect_domain_matches?("http://www.example.com/a/b")).to be_falsey
+      expect(key.redirect_domain_matches?("http://a.b.example.com/a/b")).to be_falsey
+      expect(key.redirect_domain_matches?("http://a.b.example.com/other")).to be_falsey
     end
   end
 
@@ -90,11 +90,11 @@ describe DeveloperKey do
     shared_examples "authorized_for_account?" do
 
       it "should allow allow access to its own account" do
-        expect(@key.authorized_for_account?(Account.find(@account.id))).to be true
+        expect(@key.authorized_for_account?(Account.find(@account.id))).to be_truthy
       end
 
       it "shouldn't allow allow access to a foreign account" do
-        expect(@key.authorized_for_account?(@not_sub_account)).to be false
+        expect(@key.authorized_for_account?(@not_sub_account)).to be_falsey
       end
     end
 

--- a/spec/models/developer_key_spec.rb
+++ b/spec/models/developer_key_spec.rb
@@ -83,6 +83,17 @@ describe DeveloperKey do
       expect(key.redirect_domain_matches?("http://a.b.example.com/a/b")).to be_falsey
       expect(key.redirect_domain_matches?("http://a.b.example.com/other")).to be_falsey
     end
+
+    it "should ignore query parameters" do
+      key = DeveloperKey.create!(redirect_uris: ["http://example.com/a/b", "http://example.com/a/c"])
+      expect(key.redirect_domain_matches?("http://example.com/a/b?code=foobar")).to be_truthy
+      expect(key.redirect_domain_matches?("http://example.com/a/c?code=yay")).to be_truthy
+      # other paths on the same domain are NOT ok
+      expect(key.redirect_domain_matches?("http://example.com/other?code=foobar")).to be_falsey
+      # It should not raise error on nil or empty
+      expect(key.redirect_domain_matches?(nil)).to be_falsey
+      expect(key.redirect_domain_matches?('')).to be_falsey
+    end
   end
 
   context "Account scoped keys" do


### PR DESCRIPTION
When using the new developer key `redirect_uris`, the final redirect uri should exactly match one of the provided uris. However, some LTI apps require request specific parameters to allow cookieless sessions. This results in request specific oauth redirect uris (or at least the query parameters). This is a known issue and therefore this is even discussed in [the api documentation](https://canvas.instructure.com/doc/api/file.oauth.html#oauth2-flow-2) which states:

> If your application passed a state parameter in step 1, it will be returned here in step 2 so that your app can tie the request and response together.

This is true for the old legacy `redirect_uri` but it does not hold for the new `redirect_uris` method. This is because the full redirect uri is checked to the `redirect_uris` as can be seen [here](https://github.com/instructure/canvas-lms/blob/400389b0ca7a1ab8a0c2f1ca6857cd85250cf579/app/models/developer_key.rb#L141). This should not look at any query parameters (in my opinion) but certainly not look at the state query parameters since this is described in the api documentation.

This simple fix just removes the query parameters before checking if it is a valid uri. The input is converted to a string before splitting to prevent an error on nil as an input. I've tested this with an LTI app with cookieless sessions and thus request specific query parameters in the oauth redirect url.


Then a side note:
- The rubocop linter fails with `Perceived complexity for redirect_domain_matches? is too high. [8/7]`. This however also fails when I reject my own changes. This linter failure can be fixed by moving the legacy url check to a seperate method but I am not sure if this is desired.
