### PR TITLE
VeriCite: Renaming plugin settings from "account id" to "consumer key"

### DIFF
--- a/app/views/plugins/_vericite_settings.html.erb
+++ b/app/views/plugins/_vericite_settings.html.erb
@@ -42,7 +42,7 @@
       </td>
     </tr>
     <tr>
-      <td><%= f.blabel :account_id, :en => "VeriCite Account ID" %></td>
+      <td><%= f.blabel :account_id, :en => "VeriCite Consumer Key" %></td>
       <td>
         <%= f.text_field :account_id %>
       </td>


### PR DESCRIPTION
VeriCite: Renaming plugin settings from "account id" to "consumer key" to be consistent

Test Plan:

1) Load the VeriCite plugins page: /plugins/vericite
2) Verify that the first text field is named "VeriCite Consumer Key" instead of "VeriCite Account Id"