### PR TITLE
#1036 Whitelist virtual attribute locked for quiz locking via UI

### DIFF
--- a/lib/api/v1/quiz.rb
+++ b/lib/api/v1/quiz.rb
@@ -31,6 +31,7 @@ module Api::V1::Quiz
       ip_filter
       lock_at
       lockdown_browser_monitor_data
+      locked
       one_question_at_a_time
       one_time_results
       only_visible_to_overrides

--- a/spec/controllers/quizzes/quizzes_controller_spec.rb
+++ b/spec/controllers/quizzes/quizzes_controller_spec.rb
@@ -1271,6 +1271,13 @@ describe Quizzes::QuizzesController do
       expect(assigns[:quiz].title).to eql("some quiz")
     end
 
+    it "should lock if asked to" do
+      user_session(@teacher)
+      course_quiz
+      post 'update', :course_id => @course.id, :id => @quiz.id, :quiz => {:locked => 'true'}
+      expect(@quiz.reload.locked?).to be(true)
+    end
+
     it "should publish if asked to" do
       user_session(@teacher)
       course_quiz


### PR DESCRIPTION
Since rails 4.2 and strong parameters the lock quiz feature via web UI isn't working anymore

 closes gh-1036

Test Plan:
  - Create a new Quiz
  - Click on menu item "Lock this Quiz Now" on show page
  - After redirect a notification shows "Quiz successfully updated"
  - The Quiz now should be locked and the previous menu item should be labeled "Let Students Take this Quiz Now"