### PR TITLE
Install npm dependencies for gems/plugins

### DIFF
--- a/script/gem_npm
+++ b/script/gem_npm
@@ -7,7 +7,9 @@
 # developing one of these, go into the dir and yarn there
 export NODE_ENV=production
 
-for path in $(ls -1 gems/*/package.json); do
+cwd=$(pwd)
+
+for path in $(ls -1 gems/*/package.json gems/plugins/*/package.json); do
   cd ${path:0:${#path}-13}
   if hash yarn 2>/dev/null; then
     echo "running yarn $1 for $path"
@@ -16,5 +18,5 @@ for path in $(ls -1 gems/*/package.json); do
     echo "npm is deprecated in canvas-lms. You should start using yarn instead. see https://yarnpkg.com. Running npm $1 for $path"
     npm $1
   fi
-  cd ../..
+  cd $cwd
 done


### PR DESCRIPTION
The current version of `script/gem_npm` only looks for `package.json` files in direct descendants of the `./gems/` directory. It will not find `package.json` files in directories under the `gems/plugins` directory.

This change looks in both `./gems/` and `./gems/plugins/` directories and runs `yarn` in any directory where a package.json file is found.

Test Plan:

* create a directory inside `gems/plugins` with a `package.json` file with entries in the `dependencies` and/or `devDependencies` section(s)
* run `script/gem_npm` 
* observe that that the dependencies from above are installed via yarn