### PR TITLE
Fix for the OAuth2 provider's remember authorization checkbox label

### DIFF
--- a/app/views/oauth2_provider/_confirm_form.html.erb
+++ b/app/views/oauth2_provider/_confirm_form.html.erb
@@ -40,7 +40,7 @@
   <% unless @provider.scopes.blank? %>
     <div class="control-group">
       <%= check_box_tag(:remember_access, "1", false, :class => "checkbox") %>
-      <%= label_tag(:remember_access, :en => "Remember my authorization for this service", :class => "checkbox") %>
+      <%= label_tag :remember_access, t('labels.remember_access', "Remember my authorization for this service"), class: "checkbox" %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
This commit fixes the display of the OAuth 2 provider

The checkbox label for remembering an authorization displayed a hash
containing the en value and CSS class, and should instead be displaying
just the text contained in the en value.

 Test Plan:
   - Login to an external service, using Canvas as an OAuth2 provider,
and using a non-empty scope
   - The text next to the checkbox should now display “Remember my
authorization for this service”, and not the hash “{:en=>"Remember my
authorization for this service", :class=>"checkbox”}”