### PR TITLE
Handle a developer key having no notes

### DIFF
--- a/app/views/jst/developer_key.handlebars
+++ b/app/views/jst/developer_key.handlebars
@@ -48,13 +48,15 @@
             {{#t}}Created:{{/t}} {{datetimeFormatted created_at}}
         </div>
         <div>
-            {{#t}}Last Used:{{/t}} {{#ifExists last_used_at}}{{last_used_at}}{{else}}Never{{/ifExists}}
+            {{#t}}Last Used:{{/t}} {{#ifExists last_used_at}}{{last_used_at}}{{else}}{{#t}}Never{{/t}}{{/ifExists}}
         </div>
     </td>
     <td class='notes'>
-      <div>
-        {{#t}}{{notes}}{{/t}}
-      </div>
+      {{#if notes}}
+        <div>
+            {{notes}}
+        </div>
+      {{/if}}
     </td>
     <td class='links'>
         <a href="#" class="edit_link" aria-label="{{#t}}Edit key {{name}}{{/t}}" title="{{#t "edit_key"}}Edit this key{{/t}}"><i class="icon-edit standalone-icon"></i></a>

--- a/spec/javascripts/jsx/developer_keySpec.js
+++ b/spec/javascripts/jsx/developer_keySpec.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'compiled/handlebars_helpers';
+import developerKey from 'jst/developer_key';
+import $ from 'jquery';
+import 'jquery.instructure_date_and_time';
+
+test('renders nothing in the notes field when the value is NULL', () => {
+  const data = {
+    icon_image_url: '/images/blank.png',
+    name: 'Test',
+    user_name: 'Test User',
+    created: $.datetimeString('2017-05-18 22:19:41.358852'),
+    last_auth: $.datetimeString('2017-05-18 22:19:41.358852'),
+    last_access: $.datetimeString('2017-05-18 22:19:41.358852'),
+    inactive: false,
+    notes: null
+  };
+  const $key = $(developerKey(data));
+  equal($key.find('.notes').children().length, 0);
+});
+
+test('renders nothing in the notes field when the value is an empty string', () => {
+  const data = {
+    icon_image_url: '/images/blank.png',
+    name: 'Test',
+    user_name: 'Test User',
+    created: $.datetimeString('2017-05-18 22:19:41.358852'),
+    last_auth: $.datetimeString('2017-05-18 22:19:41.358852'),
+    last_access: $.datetimeString('2017-05-18 22:19:41.358852'),
+    inactive: false,
+    notes: ''
+  };
+  const $key = $(developerKey(data));
+  equal($key.find('.notes').children().length, 0);
+});
+
+test('shows the note in the notes field when one exists', () => {
+  const data = {
+    icon_image_url: '/images/blank.png',
+    name: 'Test',
+    user_name: 'Test User',
+    created: $.datetimeString('2017-05-18 22:19:41.358852'),
+    last_auth: $.datetimeString('2017-05-18 22:19:41.358852'),
+    last_access: $.datetimeString('2017-05-18 22:19:41.358852'),
+    inactive: false,
+    notes: 'I am a note'
+  };
+  const $key = $(developerKey(data));
+  ok($key.find('.notes').text().match(/I am a note/));
+});


### PR DESCRIPTION
This fixes a bug introduced in #1008. If a developer key had no notes (e.g. the column was NULL), the template would render `[missing %{notes} value]`. This fixes that behaviour.

![screenshot 2017-05-17 13 30 07](https://cloud.githubusercontent.com/assets/146111/26175677/46dd7d00-3b08-11e7-81a6-b7ba25db55f5.png)

Test plan:
- Have a canvas instance with existing developer keys with NULL values in the notes column
- Observe that the notes column is empty
- Add a note for a key
- Observe that the notes for that key are displayed

