### PR TITLE
Create & chown app/stylesheets/brandable_css_brands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN mkdir -p log \
              public/assets \
              client_apps/canvas_quizzes/node_modules \
              /home/docker/.cache/yarn/.tmp \
+             app/stylesheets/brandable_css_brands \
   && chown -R docker:docker ${APP_HOME} /home/docker
 
 USER docker


### PR DESCRIPTION
If `app/stylesheets/brandable_css_brands` does not exist when the docker container is created, the volume will be mounted as root-owned. If the volume is mounted as root, the initial db:migrate will fail, as will anything else that tries to write to it.

Test plan:
- Ensure that app/stylesheets/brandable_css_brands does not exist in your local path.
- Run through the docker setup (bundle install, db:create, db:initial_setup, compile_assets).
- It should work and not fail with a permissions error on `/usr/src/app/app/stylesheets/brandable_css_brands`