### PR TITLE
Fix appearence of Profile link inside ProfileTray in accordance to th…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,7 +137,7 @@ class ApplicationController < ActionController::Base
           eportfolios_enabled: (@domain_root_account && @domain_root_account.settings[:enable_eportfolios] != false), # checking all user root accounts is slow
           collapse_global_nav: @current_user.try(:collapse_global_nav?),
           show_feedback_link: show_feedback_link?,
-          enable_profiles: (@domain_root_account && @domain_root_account.settings[:enable_profiles] != false)
+          enable_profiles: (@domain_root_account && @domain_root_account.settings[:enable_profiles] == true)
         },
       }
       @js_env[:page_view_update_url] = page_view_path(@page_view.id, page_view_token: @page_view.token) if @page_view


### PR DESCRIPTION
…e enable_profiles account setting

Closes gh-1077

Test Plan:
  - From rails console, ensure that the setting :enable_profiles for the choosen account was not been set before. Otherwise set it to nil.
  - Login into Canvas. Click on the Account icon on the main menu. The "Profile" link should not appear among the links in the tray.
  - Login now with an account admin. From the account settings enable the checkbox "Enable Profiles" and save.
  - Click on the Account icon on the main menu and the Profile link should now appear.
  - Now, disable the same checkbox and save again.
  - Click on the Account icon on the main menu and the Profile link should not be present.