### PR TITLE
BigBlueButton feature: Delete recordings individually

### DIFF
--- a/app/coffeescripts/handlebars_helpers.coffee
+++ b/app/coffeescripts/handlebars_helpers.coffee
@@ -150,6 +150,30 @@ define [
       real_min_str = (if real_minutes < 10 then "0" + real_minutes else real_minutes)
       "#{hours}:#{real_min_str}"
 
+    ###*
+     * Convert the total amount of minutes into a readable duration.
+     * @param {number}  Duration in minutes elapsed
+     * @return {string} String containing a formatted duration including hours and minutes
+     * Example:
+     *     ...
+     *     duration = 97
+     *     durationToString(duration)
+     *     ...
+     *     Returns
+     *       "Duration: 1 hour and 37 minutes"
+    ###
+    durationToString : (duration) ->
+      # stores the hours in the duration
+      hours = Math.floor(duration / 60)
+      # stores the remaining minutes after substracting the hours
+      minutes = duration % 60
+      if hours > 0
+        return I18n.t("Duration: %{hours} hours and %{minutes} minutes", {hours: hours, minutes: minutes})
+      else if minutes > 1
+        return I18n.t("Duration: %{minutes} minutes", {minutes: minutes})
+      else
+        return I18n.t("Duration: 1 minute")
+
     # helper for easily creating icon font markup
     addIcon : (icontype) ->
       new Handlebars.SafeString "<i class='icon-#{htmlEscape icontype}'></i>"

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -347,6 +347,27 @@ class ConferencesController < ApplicationController
     end
   end
 
+  def recording
+    if authorized_action(@conference, @current_user, :read)
+      recording = @conference.recordings.find{ |r| r[:recording_id] == params[:recording_id] }
+      @response = recording || {}
+      respond_to do |format|
+        format.html { redirect_to named_context_url(@context, :context_conferences_url) }
+        format.json { render :json => @response }
+      end
+    end
+  end
+
+  def delete_recording
+    if authorized_action(@conference, @current_user, :delete)
+      @response = @conference.delete_recording(params[:recording_id])
+      respond_to do |format|
+        format.html { redirect_to named_context_url(@context, :context_conferences_url) }
+        format.json { render :json => @response, :status => :ok }
+      end
+    end
+  end
+
   protected
 
   def require_config

--- a/app/views/jst/conferences/concludedConference.handlebars
+++ b/app/views/jst/conferences/concludedConference.handlebars
@@ -7,15 +7,16 @@
             aria-controls="conference-{{id}}"
             aria-expanded="false"
             role="button">
-          <i class="icon-mini-arrow-right"></i>
+          <i class="icon-mini-arrow-right auto_rotate"></i>
           {{title}}
         </a>
       {{else}}
         <span class="ig-title">{{title}}</span>
       {{/if}}
+
       <div class="ig-details">
         <div class="ig-details__item">
-          {{dateString ended_at}}
+          {{datetimeFormatted ended_at}}
         </div>
         {{#if description}}
           <div class="ig-details__item ig-details__item--wrap-text">
@@ -23,12 +24,12 @@
           </div>
         {{/if}}
         {{#if recording}}
-          <div class="ig-details__item">
-            {{#if multipleRecordings}}
-              {{#t "recordings"}}{{recordingCount}} Recordings{{/t}}
-            {{else}}
-              {{#t "recording"}}1 Recording{{/t}}
-            {{/if}}
+          <div class="ig-details__item-recordings ig-details__item-recordings--wrap-text">
+          {{#if multipleRecordings}}
+            {{#t "recordings"}}{{recordingCount}} Recordings{{/t}}
+          {{else}}
+            {{#t "recording"}}1 Recording{{/t}}
+          {{/if}}
           </div>
         {{/if}}
       </div>
@@ -56,27 +57,31 @@
   </div>
 </div>
 {{#if recording}}
-  <div class="ig-sublist" id="conference-{{id}}" style="display: none;">
+  <div class="ig-sublist" data-id="{{id}}" id="conference-{{id}}" style="display: none;">
     <ul>
       {{#each recordings}}
-        <li>
-          <div class="ig-row">
+        <li class="recording">
+          <div class="ig-row" data-id="{{recording_id}}" style="text-align: center;">
             <div class="ig-row__layout">
               <div class="ig-info">
                 <div class="ig-details">
-                  <a href="{{playback_url}}" target="_blank" class="ig-title">
+                  <a href="{{playback_url}}" target="_blank" class="ig-title"
+                    style="line-height: inherit;" data-id="{{recording_id}}" data-format="presentation">
                     {{title}}
                   </a>
                   {{dateString created_at}}
                   &nbsp;&#124;&nbsp;
-                  {{minutesToHM duration_minutes}}
+                  {{durationToString duration_minutes}}
                 </div>
               </div>
-              <div class="ig-button">
-                <a class="btn btn-small" target="_blank" href="{{playback_url}}">
-                  {{#t "view"}}View{{/t}}
-                </a>
-              </div>
+              {{#if ../permissions.delete}}
+                <div class="ig-button" data-id="{{recording_id}}" data-action="delete" data-url="{{../../url}}">
+                  <a href="#"
+                      class="btn btn-small icon-trash delete_recording_link"
+                      title="{{#t "delete"}}Delete{{/t}}">{{#t "delete"}}Delete{{/t}}
+                  </a>
+                </div>
+              {{/if}}
             </div>
           </div>
         </li>

--- a/app/views/jst/conferences/newConference.handlebars
+++ b/app/views/jst/conferences/newConference.handlebars
@@ -7,7 +7,7 @@
             aria-controls="conference-{{id}}"
             aria-expanded="false"
             role="button">
-          <i class="icon-mini-arrow-right"></i>
+          <i class="icon-mini-arrow-right auto_rotate"></i>
           {{title}}
         </a>
       {{else}}
@@ -22,14 +22,20 @@
         {{#if scheduled}}
           <div>{{datetimeFormatted scheduled_at}}</div>
         {{/if}}
-        {{#if recording}}
-          {{#if multipleRecordings}}
-            <div>{{#t "recordings"}}{{recordingCount}} Recordings{{/t}}</div>
-          {{else}}
-            <div>{{#t "recording"}}1 Recording{{/t}}</div>
-          {{/if}}
+        {{#if description}}
+          <div class="ig-details__item ig-details__item--wrap-text">
+            {{description}}
+          </div>
         {{/if}}
-        <div>{{description}}</div>
+        {{#if recording}}
+          <div class="ig-details__item-recordings ig-details__item-recordings--wrap-text">
+          {{#if multipleRecordings}}
+            {{#t "recordings"}}{{recordingCount}} Recordings{{/t}}
+          {{else}}
+            {{#t "recording"}}1 Recording{{/t}}
+          {{/if}}
+          </div>
+        {{/if}}
       </div>
     </div>
     <div class="ig-admin">
@@ -85,27 +91,31 @@
   </div>
 </div>
 {{#if recording}}
-  <div class="ig-sublist" id="conference-{{id}}" style="display: none;">
+  <div class="ig-sublist" data-id="{{id}}" id="conference-{{id}}" style="display: none;">
     <ul>
       {{#each recordings}}
-        <li>
-          <div class="ig-row">
+        <li class="recording">
+          <div class="ig-row" data-id="{{recording_id}}" style="text-align: center;">
             <div class="ig-row__layout">
               <div class="ig-info">
                 <div class="ig-details">
-                  <a href="{{playback_url}}" target="_blank" class="ig-title">
+                  <a href="{{playback_url}}" target="_blank" class="ig-title"
+                    style="line-height: inherit;" data-id="{{recording_id}}" data-format="presentation">
                     {{title}}
                   </a>
                   {{dateString created_at}}
                   &nbsp;&#124;&nbsp;
-                  {{minutesToHM duration_minutes}}
+                  {{durationToString duration_minutes}}
                 </div>
               </div>
-              <div class="ig-button">
-                <a class="btn btn-small" target="_blank" href="{{playback_url}}">
-                  {{#t "view"}}View{{/t}}
-                </a>
-              </div>
+              {{#if ../permissions.delete}}
+                <div class="ig-button" data-id="{{recording_id}}" data-action="delete" data-url="{{../../url}}">
+                  <a href="#"
+                      class="btn btn-small icon-trash delete_recording_link"
+                      title="{{#t "delete"}}Delete{{/t}}">{{#t "delete"}}Delete{{/t}}
+                  </a>
+                </div>
+              {{/if}}
             </div>
           </div>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,8 +162,12 @@ CanvasRails::Application.routes.draw do
 
   concern :conferences do
     resources :conferences do
+      # rubocop:disable SymbolArray
       match :join, via: [:get, :post]
       match :close, via: [:get, :post]
+      match :recording, via: [:get]
+      match :recording, via: [:delete], to: 'conferences#delete_recording', as: :delete_recording
+      # rubocop:enable SymbolArray
       get :settings
     end
   end

--- a/spec/controllers/big_blue_button_conferences_controller_spec.rb
+++ b/spec/controllers/big_blue_button_conferences_controller_spec.rb
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2011 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe ConferencesController do
+  before :once do
+    # these specs need an enabled web conference plugin
+    @plugin = PluginSetting.create!(name: 'big_blue_button')
+    @plugin.update_attribute(:settings, { :domain => 'bigbluebutton.test', secret: 'secret', recording_enabled: true })
+    course_with_teacher(active_all: true, user: user_with_pseudonym(active_all: true))
+    @inactive_student = course_with_user('StudentEnrollment', course: @course, enrollment_state: 'invited').user
+    student_in_course(active_all: true, user: user_with_pseudonym(active_all: true))
+  end
+
+  before :each do
+    allow(BigBlueButtonConference).to receive(:send_request).and_return('')
+    allow(BigBlueButtonConference).to receive(:get_auth_token).and_return('abc123')
+  end
+
+  describe "GET 'recording'" do
+    it "should require authorization" do
+      @conference = @course.web_conferences.create!(:conference_type => 'BigBlueButton', :duration => 60, :user => @teacher)
+      get 'recording', params: {:course_id => @course.id, :conference_id => @conference.id, :recording_id => 'abc123-xyz'}
+      assert_unauthorized
+    end
+  end
+
+  describe "DELETE 'recording'" do
+    it "should require authorization" do
+      @conference = @course.web_conferences.create!(:conference_type => 'BigBlueButton', :duration => 60, :user => @teacher)
+      delete 'recording', params: {:course_id => @course.id, :conference_id => @conference.id, :recording_id => 'abc123-xyz'}
+      assert_unauthorized
+    end
+  end
+end

--- a/spec/fixtures/files/conferences/big_blue_button_delete_recordings.xml
+++ b/spec/fixtures/files/conferences/big_blue_button_delete_recordings.xml
@@ -1,0 +1,4 @@
+<response>
+  <returncode>SUCCESS</returncode>
+  <deleted>true</deleted>
+</response>

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_none.xml
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_none.xml
@@ -1,0 +1,6 @@
+<response>
+  <returncode>SUCCESS</returncode>
+  <recordings></recordings>
+  <messageKey>noRecordings</messageKey>
+  <message>There are no recordings for the meeting(s).</message>
+</response>

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_one.xml
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_one.xml
@@ -1,0 +1,39 @@
+<response>
+  <returncode>SUCCESS</returncode>
+  <recordings>
+    <recording>
+      <recordID>0225ccf234655ae60658ccac1e272d48781b491c-1511812307014</recordID>
+      <meetingID>instructure_web_conference_3Fn2k10wu0jK7diwJHs2FkDU0oXyX1ErUZCavikc</meetingID>
+      <internalMeetingID>0225ccf234655ae60658ccac1e272d48781b491c-1511812307014</internalMeetingID>
+      <name>John Doe's conference</name>
+      <isBreakout>false</isBreakout>
+      <published>true</published>
+      <state>published</state>
+      <startTime>1511812307014</startTime>
+      <endTime>1511812327102</endTime>
+      <participants>1</participants>
+      <metadata>
+        <meetingName>John Doe's conference</meetingName>
+        <meetingId>instructure_web_conference_3Fn2k10wu0jK7diwJHs2FkDU0oXyX1ErUZCavikc</meetingId>
+        <canvas-recording-ready-user>John Doe &lt;jdoe@mockmail.com&gt;</canvas-recording-ready-user>
+        <canvas-recording-ready-url>http://canvas.blah.com/mock/recording_ready</canvas-recording-ready-url>
+        <isBreakout>false</isBreakout>
+      </metadata>
+      <playback>
+        <format>
+          <type>presentation</type>
+          <url>http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014</url>
+          <processingTime>9922</processingTime>
+          <length>0</length>
+          <preview>
+            <images>
+              <image alt="Welcome to" height="136" width="176">http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511812307214/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511812307214/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511812307214/thumbnails/thumb-3.png</image>
+            </images>
+          </preview>
+        </format>
+      </playback>
+    </recording>
+  </recordings>
+</response>

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.json
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.json
@@ -1,0 +1,44 @@
+{
+  "returncode": "SUCCESS",
+  "recordings":
+  [
+    {
+      "recordID": "18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456",
+      "meetingID": "instructure_web_conference_oKdQ1gfiZjl0bOy8PQSytaF1vBuwOU3CxHDd4kJr",
+      "name": "Conference Development 101",
+      "published": "true",
+      "protected": "false",
+      "startTime": "1513031612000",
+      "endTime": "1513031628000",
+      "metadata": {
+        "isBreakout": "false"
+      },
+      "playback": {
+        "format": {
+                    "type": "video",
+                    "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/capture/",
+                    "length": "0"
+        }
+      }
+    },
+    {
+      "recordID": "18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256",
+      "meetingID": "instructure_web_conference_oKdQ1gfiZjl0bOy8PQSytaF1vBuwOU3CxHDd4kJr",
+      "name": "Conference Development 101",
+      "published": "true",
+      "protected": "false",
+      "startTime": "1513031142000",
+      "endTime": "1513031164000",
+      "metadata": {
+        "isBreakout": "false"
+      },
+      "playback": {
+        "format": {
+          "type": "video",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/capture/",
+          "length": "0"
+        }
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.xml
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.xml
@@ -1,0 +1,74 @@
+
+<response>
+  <returncode>SUCCESS</returncode>
+  <recordings>
+    <recording>
+      <recordID>0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982</recordID>
+      <meetingID>instructure_web_conference_3Fn2k10wu0jK7diwJHs2FkDU0oXyX1ErUZCavikc</meetingID>
+      <internalMeetingID>0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982</internalMeetingID>
+      <name>John Doe's conference</name>
+      <isBreakout>false</isBreakout>
+      <published>true</published>
+      <state>published</state>
+      <startTime>1511807048982</startTime>
+      <endTime>1511807068542</endTime>
+      <participants>1</participants>
+      <metadata>
+        <meetingName>John Doe's conference</meetingName>
+        <meetingId>instructure_web_conference_3Fn2k10wu0jK7diwJHs2FkDU0oXyX1ErUZCavikc</meetingId>
+        <canvas-recording-ready-user>John Doe &lt;jdoe@mockmail.com&gt;</canvas-recording-ready-user>
+        <canvas-recording-ready-url>http://canvas.blah.com/mock/recording_ready</canvas-recording-ready-url>
+        <isBreakout>false</isBreakout>
+      </metadata>
+      <playback>
+        <format>
+          <type>presentation</type>
+          <url>http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982</url>
+          <processingTime>9590</processingTime>
+          <length>0</length>
+          <preview>
+            <images>
+              <image alt="Welcome to" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511807049008/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511807049008/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511807049008/thumbnails/thumb-3.png</image>
+            </images>
+          </preview>
+        </format>
+      </playback>
+    </recording>
+    <recording>
+      <recordID>0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509</recordID>
+      <meetingID>instructure_web_conference_3Fn2k10wu0jK7diwJHs2FkDU0oXyX1ErUZCavikc</meetingID>
+      <internalMeetingID>0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509</internalMeetingID>
+      <name>John Doe's conference</name>
+      <isBreakout>false</isBreakout>
+      <published>true</published>
+      <state>published</state>
+      <startTime>1511809970509</startTime>
+      <endTime>1511811548853</endTime>
+      <participants>2</participants>
+      <metadata>
+        <meetingName>John Doe's conference</meetingName>
+        <meetingId>instructure_web_conference_3Fn2k10wu0jK7diwJHs2FkDU0oXyX1ErUZCavikc</meetingId>
+        <canvas-recording-ready-user>John Doe &lt;jdoe@mockmail.com&gt;</canvas-recording-ready-user>
+        <canvas-recording-ready-url>http://canvas.blah.com/mock/recording_ready</canvas-recording-ready-url>
+        <isBreakout>false</isBreakout>
+      </metadata>
+      <playback>
+        <format>
+          <type>presentation</type>
+          <url>http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509</url>
+          <processingTime>35788</processingTime>
+          <length>26</length>
+          <preview>
+            <images>
+              <image alt="Welcome to" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511809970514/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511809970514/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511809970514/thumbnails/thumb-3.png</image>
+            </images>
+          </preview>
+        </format>
+      </playback>
+    </recording>
+  </recordings>
+</response>

--- a/spec/selenium/conferences/big_blue_button_conference_spec.rb
+++ b/spec/selenium/conferences/big_blue_button_conference_spec.rb
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2018 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+require_relative '../common'
+require_relative '../helpers/conferences_common'
+require_relative '../helpers/public_courses_context'
+
+describe 'BigBlueButton conferences' do
+  include_context 'in-process server selenium tests'
+  include ConferencesCommon
+  include WebMock::API
+
+  bbb_endpoint = 'bbb.instructure.com'
+  bbb_secret = '8cd8ef52e8e101574e400365b55e11a6'
+  bbb_fixtures = {
+    :get_recordings => {
+      'meetingID' => 'instructure_web_conference_3Fn2k10wu0jK7diwJHs2FkDU0oXyX1ErUZCavikc',
+      'checksum' => 'ffa33deaa16e039bcbd84df90ed39196e518c69e'
+    },
+    :delete_recordings => {
+      'recordID' => '0225ccf234655ae60658ccac1e272d48781b491c-1511812307014',
+      'checksum' => 'f9a2b4c9b3e0dd611c1b541eee8bb32309a327ae'
+    }
+  }
+
+  before(:once) do
+    initialize_big_blue_button_conference_plugin bbb_endpoint, bbb_secret
+    course_with_teacher(name: 'Teacher Bob', active_all: true)
+    course_with_ta(name: 'TA Alice', course: @course, active_all: true)
+    4.times do |i|
+      course_with_student(name: "Student_#{i + 1}", course: @course, active_all: true)
+    end
+  end
+
+  before(:each) do
+    user_session(@teacher)
+    get conferences_index_page
+  end
+
+  after { close_extra_windows }
+  context 'when a conference is open' do
+    before(:once) do
+      stub_request(:get, /create/)
+    end
+
+    context 'and the conference has no recordings' do
+      before(:once) do
+        stub_request(:get, /getRecordings/).
+          with(query: bbb_fixtures[:get_recordings]).
+          to_return(:body => big_blue_button_mock_response('get_recordings', 'none'))
+        @conference = create_big_blue_button_conference(bbb_fixtures[:get_recordings]['meetingID'])
+      end
+
+      it 'should not include list with recordings', priority: '2' do
+        verify_conference_does_not_include_recordings
+      end
+    end
+
+    context 'and the conference has recordings' do
+      before(:once) do
+        stub_request(:get, /getRecordings/).
+          with(query: bbb_fixtures[:get_recordings]).
+          to_return(:body => big_blue_button_mock_response('get_recordings', 'two'))
+        @conference = create_big_blue_button_conference(bbb_fixtures[:get_recordings]['meetingID'])
+      end
+
+      it 'should include list with recordings', priority: '2' do
+        verify_conference_includes_recordings
+      end
+    end
+
+    context 'and the conference has one recording and it is deleted' do
+      before(:once) do
+        stub_request(:get, /deleteRecordings/).
+          with(query: bbb_fixtures[:delete_recordings]).
+          to_return(:body => big_blue_button_mock_response('delete_recordings'))
+        stub_request(:get, /getRecordings/).
+          with(query: bbb_fixtures[:get_recordings]).
+          to_return(:body => big_blue_button_mock_response('get_recordings', 'one'))
+        @conference = create_big_blue_button_conference(bbb_fixtures[:get_recordings]['meetingID'])
+      end
+
+      it 'should remove recording from the list', priority: '2' do
+        show_recordings_in_first_conference_in_list
+        delete_first_recording_in_first_conference_in_list
+        verify_conference_does_not_include_recordings
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
  Summary:
Implementation of delete recordings that can be performed on BigBlueButton Conferences when they hold recordings.

  Description:
The modification to the UI is based on the Mockup shared by Matt Goodwin. The icon used for the external link is the same used before so we don't affect themes.

As this feature is particular for BBB, a new attribute (:vendor => 'bigbluebuton') was added to the recording the code so in handlebars the UI can be differentiated.

There is some additional code in coffee script for ensuring that the action (delete) was performed. This is because when BBB is behind a load balancer (depending of the implementation) there may be a delay in its execution. This confirmation will show the user that the action is in process (disabling the recording link) and performing delete when is confirmed. If delete fails, a message is shown and the recording is restored in the UI (both, the button and the link)

 Test Plan:
   - As an instructor or administrator create a conference and join the session. Click on the recording button and after a few seconds logout from BBB.
   - The recording has to be processed, so wait for some minutes and refresh the page. More recordings can be created in the meanwhile following step 1.
   - When the recording is ready, the conference (long lasting running or ended) title can be expanded. The recording (or recordings) should be shown, one per row. At the left the new button "Delete" should be shown.
   - Click on delete and the delete message will be sent to BBB. An spinning wheel may be shown for a sec (or more if the delete is not confirmed in the attempt) and the row is deleted.

When the spinning wheel is shown for more than 1 sec means that the delete was enqueued but needs to be confirmed, in such case there will be 5 attempts of confirmation. If the delete is not confirmed, the row will be restored (link and button) and a flash message will be shown.