### PR TITLE
Generate JavaScript sourcemaps in production

### DIFF
--- a/frontend_build/baseWebpackConfig.js
+++ b/frontend_build/baseWebpackConfig.js
@@ -71,8 +71,11 @@ module.exports = {
   // In prod build, don't attempt to continue if there are any errors.
   bail: process.env.NODE_ENV === 'production',
 
-  // This makes the bundle appear split into separate modules in the devtools in dev/test.
-  devtool: process.env.NODE_ENV === 'production' ? undefined : 'eval',
+  // In production, and when not using JS_BUILD_NO_UGLIFY, generate separate sourcemap files.
+  // In development, generate `eval` sourcemaps.
+  devtool: process.env.NODE_ENV === 'production' ?
+    process.env.JS_BUILD_NO_UGLIFY ? undefined : 'source-map'
+    : 'eval',
 
   entry: Object.assign({
     vendor: require('./modulesToIncludeInVendorBundle'),

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "webpack": "gulp rev & webpack --progress --color --watch",
     "webpack-development": "gulp rev & webpack --progress --color",
     "webpack-stats": "webpack --profile --json",
-    "webpack-production": "NODE_ENV=production gulp rev & webpack --color --config webpack.production.config.js",
+    "webpack-production": "gulp rev & node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js --progress --color --config webpack.production.config.js",
     "jspec": "./spec/jspec.sh",
     "jspec-watch": "./spec/jspec.sh --watch"
   }


### PR DESCRIPTION
Resolves instructure/canvas-lms#1101

In production, generate separate sourcemap files so that bundles appear split into their original, un-obfuscated source files in browser devtools.

Note: `source-map` generation on large projects can cause node/v8 to exhaust its memory allocation (see webpack/webpack#1914, webpack/webpack#2157). This is the reason for the change to package.json. In the future (e.g. when Canvas uses Node 8, or the NODE_OPTIONS feature is back-ported to Node 6, this can go back to a traditional npm script that doesn't directly invoke `node`.

Test Plan:
- Remove the `public/dist/webpack-*` directories.
- Run `JS_BUILD_NO_UGLIFY=true npm run webpack-production`. No sourcemap files should be present in  `public/dist/webpack-production`.
- Run `npm run webpack-production`. Sourcemap files should be present in `public/dist/webpack-production`