### PR TITLE
Switched rate_limit_exceeded header from 403 to 429

### DIFF
--- a/app/middleware/request_throttle.rb
+++ b/app/middleware/request_throttle.rb
@@ -173,7 +173,7 @@ class RequestThrottle
   end
 
   def rate_limit_exceeded
-    [ 403,
+    [ 429,
       { 'Content-Type' => 'text/plain; charset=utf-8' },
       ["429 #{Rack::Utils::HTTP_STATUS_CODES[429]} (Rate Limit Exceeded)\n"]
     ]

--- a/app/middleware/request_throttle.rb
+++ b/app/middleware/request_throttle.rb
@@ -175,7 +175,7 @@ class RequestThrottle
   def rate_limit_exceeded
     [ 403,
       { 'Content-Type' => 'text/plain; charset=utf-8' },
-      ["403 #{Rack::Utils::HTTP_STATUS_CODES[403]} (Rate Limit Exceeded)\n"]
+      ["429 #{Rack::Utils::HTTP_STATUS_CODES[429]} (Rate Limit Exceeded)\n"]
     ]
   end
 

--- a/doc/api/throttling.md
+++ b/doc/api/throttling.md
@@ -6,7 +6,7 @@ user from abusing the system and causing adverse effects for others. It
 works by having a rate limit, and a cost for every request. Each request
 subtracts from your quota, and the quota is automatically replenished over
 time. In the event that your API request is throttled, you will receive
-a `403 Forbidden (Rate Limit Exceeded)` response. Your application should
+a `429 Too Many Requests (Rate Limit Exceeded)` response. Your application should
 be prepared for this error, and retry the request at a later time.
 
 To assist applications with planning, every request will return a


### PR DESCRIPTION
Changed rate_limt_exceeded code from 403 to 429

Current response on rate_limit_exceeded is a 403 (Forbidden). IETF (Internet Engineering Task Force) documentation defines a [429 (Too Many Requests)](https://tools.ietf.org/html/rfc6585#section-4) as the proper response code. Code and documentation has been changed to reflect that.