### PR TITLE
Ignore yarn-error.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ npm-debug.log
 /public/javascripts/translations/
 /tmp/
 /vendor/bundle
+yarn-error.log
 
 # generated plugin stuff
 /app/coffeescripts/plugins/


### PR DESCRIPTION
yarn-error.log files should be ignored, just like npm-debug.log files already are.