### PR TITLE
Add the word 'paginated' to relevant API documentation.

### DIFF
--- a/app/controllers/account_authorization_configs_controller.rb
+++ b/app/controllers/account_authorization_configs_controller.rb
@@ -200,7 +200,7 @@ class AccountAuthorizationConfigsController < ApplicationController
   include Api::V1::AccountAuthorizationConfig
 
   # @API List authentication providers
-  # Returns the list of authentication providers
+  # Returns a paginated list of authentication providers
   #
   # @example_request
   #

--- a/app/controllers/account_reports_controller.rb
+++ b/app/controllers/account_reports_controller.rb
@@ -178,7 +178,7 @@ class AccountReportsController < ApplicationController
 
 # @API List Available Reports
 #
-# Returns the list of reports for the current context.
+# Returns a paginated list of reports for the current context.
 #
 # @response_field name The name of the report.
 # @response_field parameters The parameters will vary for each report

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -113,9 +113,9 @@ class AccountsController < ApplicationController
   SIS_ASSINGMENT_NAME_LENGTH_DEFAULT = 255
 
   # @API List accounts
-  # List accounts that the current user can view or manage.  Typically,
-  # students and even teachers will get an empty list in response, only
-  # account admins can view the accounts that they are in.
+  # A paginated list of accounts that the current user can view or manage.
+  # Typically, students and even teachers will get an empty list in response,
+  # only account admins can view the accounts that they are in.
   #
   # @argument include[] [String, "lti_guid"|"registration_settings"|"services"]
   #   Array of additional information to include.
@@ -146,8 +146,8 @@ class AccountsController < ApplicationController
   end
 
   # @API List accounts for course admins
-  # List accounts that the current user can view through their admin course enrollments.
-  # (Teacher, TA, or designer enrollments).
+  # A paginated list of accounts that the current user can view through their
+  # admin course enrollments. (Teacher, TA, or designer enrollments).
   # Only returns "id", "name", "workflow_state", "root_account_id" and "parent_account_id"
   #
   # @returns [Account]
@@ -275,7 +275,7 @@ class AccountsController < ApplicationController
   include Api::V1::Course
 
   # @API List active courses in an account
-  # Retrieve the list of courses in this account.
+  # Retrieve a paginated list of courses in this account.
   #
   # @argument with_enrollments [Boolean]
   #   If true, include only courses with at least one enrollment.  If false,

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -122,7 +122,7 @@ class AdminsController < ApplicationController
 
   # @API List account admins
   #
-  # List the admins in the account
+  # A paginated list of the admins in the account
   #
   # @argument user_id[] [[Integer]]
   #   Scope the results to those with user IDs equal to any of the IDs specified here.

--- a/app/controllers/appointment_groups_controller.rb
+++ b/app/controllers/appointment_groups_controller.rb
@@ -216,8 +216,8 @@ class AppointmentGroupsController < ApplicationController
 
   # @API List appointment groups
   #
-  # Retrieve the list of appointment groups that can be reserved or managed by
-  # the current user.
+  # Retrieve the paginated list of appointment groups that can be reserved or
+  # managed by the current user.
   #
   # @argument scope [String, "reservable"|"manageable"]
   #   Defaults to "reservable"
@@ -500,9 +500,9 @@ class AppointmentGroupsController < ApplicationController
 
   # @API List user participants
   #
-  # List users that are (or may be) participating in this appointment group.
-  # Refer to the Users API for the response fields. Returns no results for
-  # appointment groups with the "Group" participant_type.
+  # A paginated list of users that are (or may be) participating in this
+  # appointment group.  Refer to the Users API for the response fields. Returns
+  # no results for appointment groups with the "Group" participant_type.
   #
   # @argument registration_status ["all"|"registered"|"registered"]
   #   Limits results to the a given participation status, defaults to "all"
@@ -512,9 +512,9 @@ class AppointmentGroupsController < ApplicationController
 
   # @API List student group participants
   #
-  # List student groups that are (or may be) participating in this appointment
-  # group. Refer to the Groups API for the response fields. Returns no results
-  # for appointment groups with the "User" participant_type.
+  # A paginated list of student groups that are (or may be) participating in
+  # this appointment group. Refer to the Groups API for the response fields.
+  # Returns no results for appointment groups with the "User" participant_type.
   #
   # @argument registration_status ["all"|"registered"|"registered"]
   #   Limits results to the a given participation status, defaults to "all"

--- a/app/controllers/assignment_groups_controller.rb
+++ b/app/controllers/assignment_groups_controller.rb
@@ -98,8 +98,8 @@ class AssignmentGroupsController < ApplicationController
 
   # @API List assignment groups
   #
-  # Returns the list of assignment groups for the current context. The returned
-  # groups are sorted by their position field.
+  # Returns the paginated list of assignment groups for the current context.
+  # The returned groups are sorted by their position field.
   #
   # @argument include[] [String, "assignments"|"discussion_topic"|"all_dates"|"assignment_visibility"|"overrides"|"submission"]
   #  Associations to include with the group. "discussion_topic", "all_dates"

--- a/app/controllers/assignment_overrides_controller.rb
+++ b/app/controllers/assignment_overrides_controller.rb
@@ -97,7 +97,7 @@ class AssignmentOverridesController < ApplicationController
   # @API List assignment overrides
   # @beta
   #
-  # Returns the list of overrides for this assignment that target
+  # Returns the paginated list of overrides for this assignment that target
   # sections/groups/students visible to the current user.
   #
   # @returns [AssignmentOverride]

--- a/app/controllers/assignments_api_controller.rb
+++ b/app/controllers/assignments_api_controller.rb
@@ -560,7 +560,7 @@ class AssignmentsApiController < ApplicationController
   include Api::V1::AssignmentOverride
 
   # @API List assignments
-  # Returns the list of assignments for the current context.
+  # Returns the paginated list of assignments for the current context.
   # @argument include[] [String, "submission"|"assignment_visibility"|"all_dates"|"overrides"|"observed_users"]
   #   Associations to include with the assignment. The "assignment_visibility" option
   #   requires that the Differentiated Assignments course feature be turned on. If
@@ -581,7 +581,7 @@ class AssignmentsApiController < ApplicationController
   end
 
   # @API List assignments for user
-  # Returns the list of assignments for the specified user if the current user has rights to view.
+  # Returns the paginated list of assignments for the specified user if the current user has rights to view.
   # See {api:AssignmentsApiController#index List assignments} for valid arguments.
   def user_index
     @user.shard.activate do

--- a/app/controllers/bookmarks/bookmarks_controller.rb
+++ b/app/controllers/bookmarks/bookmarks_controller.rb
@@ -49,7 +49,7 @@ class Bookmarks::BookmarksController < ApplicationController
   before_action :find_bookmark, :only => [:show, :update, :destroy]
 
   # @API List bookmarks
-  # Returns the list of bookmarks.
+  # Returns the paginated list of bookmarks.
   #
   # @example_request
   #

--- a/app/controllers/calendar_events_api_controller.rb
+++ b/app/controllers/calendar_events_api_controller.rb
@@ -273,7 +273,7 @@ class CalendarEventsApiController < ApplicationController
 
   # @API List calendar events
   #
-  # Retrieve the list of calendar events or assignments for the current user
+  # Retrieve the paginated list of calendar events or assignments for the current user
   #
   # @argument type [String, "event"|"assignment"] Defaults to "event"
   # @argument start_date [Date]
@@ -306,7 +306,7 @@ class CalendarEventsApiController < ApplicationController
 
   # @API List calendar events for a user
   #
-  # Retrieve the list of calendar events or assignments for the specified user.
+  # Retrieve the paginated list of calendar events or assignments for the specified user.
   # To view calendar events for a user other than yourself,
   # you must either be an observer of that user or an administrator.
   #

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -158,9 +158,9 @@ class CollaborationsController < ApplicationController
   end
 
   # @API List collaborations
-  # List collaborations the current user has access to in the context of the course
-  # provided in the url. NOTE: this only returns ExternalToolCollaboration type
-  # collaborations.
+  # A paginated list of collaborations the current user has access to in the
+  # context of the course provided in the url. NOTE: this only returns
+  # ExternalToolCollaboration type collaborations.
   #
   #   curl https://<canvas>/api/v1/courses/1/collaborations/
   #
@@ -337,7 +337,7 @@ class CollaborationsController < ApplicationController
 
   # @API List members of a collaboration.
   #
-  # List the collaborators of a given collaboration
+  # A paginated list of the collaborators of a given collaboration
   #
   # @argument include[] [String, "collaborator_lti_id"|"avatar_image_url"]
   #   - "collaborator_lti_id": Optional information to include with each member.
@@ -363,7 +363,8 @@ class CollaborationsController < ApplicationController
 
   # @API List potential members
   #
-  # List the users who can potentially be added to a collaboration in the given context.
+  # A paginated list of the users who can potentially be added to a
+  # collaboration in the given context.
   #
   # For courses, this consists of all enrolled users.  For groups, it is comprised of the
   # group members plus the admins of the course containing the group.

--- a/app/controllers/comm_messages_api_controller.rb
+++ b/app/controllers/comm_messages_api_controller.rb
@@ -104,7 +104,7 @@ class CommMessagesApiController < ApplicationController
 
   # @API List of CommMessages for a user
   #
-  # Retrieve messages sent to a user.
+  # Retrieve a paginated list of messages sent to a user.
   #
   # @argument user_id [Required, String]
   #   The user id for whom you want to retrieve CommMessages

--- a/app/controllers/communication_channels_controller.rb
+++ b/app/controllers/communication_channels_controller.rb
@@ -85,8 +85,8 @@ class CommunicationChannelsController < ApplicationController
 
   # @API List user communication channels
   #
-  # Returns a list of communication channels for the specified user, sorted by
-  # position.
+  # Returns a paginated list of communication channels for the specified user,
+  # sorted by position.
   #
   # @example_request
   #     curl https://<canvas>/api/v1/users/12345/communication_channels \

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -146,7 +146,7 @@ class ConferencesController < ApplicationController
   before_action :get_conference, :except => [:index, :create]
 
   # @API List conferences
-  # Retrieve the list of conferences for this context
+  # Retrieve the paginated list of conferences for this context
   #
   # This API returns a JSON object containing the list of conferences,
   # the key for the list of conferences is "conferences"

--- a/app/controllers/content_exports_api_controller.rb
+++ b/app/controllers/content_exports_api_controller.rb
@@ -84,8 +84,8 @@ class ContentExportsApiController < ApplicationController
 
   # @API List content exports
   #
-  # List the past and pending content export jobs for a course, group, or user.
-  # Exports are returned newest first.
+  # A paginated list of the past and pending content export jobs for a course,
+  # group, or user. Exports are returned newest first.
   #
   # @returns [ContentExport]
   def index

--- a/app/controllers/context_module_items_api_controller.rb
+++ b/app/controllers/context_module_items_api_controller.rb
@@ -205,7 +205,7 @@ class ContextModuleItemsApiController < ApplicationController
 
   # @API List module items
   #
-  # List the items in a module
+  # A paginated list of the items in a module
   #
   # @argument include[] [String, "content_details"]
   #   If included, will return additional details specific to the content

--- a/app/controllers/context_modules_api_controller.rb
+++ b/app/controllers/context_modules_api_controller.rb
@@ -321,7 +321,7 @@ class ContextModulesApiController < ApplicationController
 
   # @API List modules
   #
-  # List the modules in a course
+  # A paginated list of the modules in a course
   #
   # @argument include[] [String, "items"|"content_details"]
   #    - "items": Return module items inline if possible.

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -166,7 +166,8 @@ class ConversationsController < ApplicationController
   API_ALLOWED_FIELDS = %w{workflow_state subscribed starred}.freeze
 
   # @API List conversations
-  # Returns the list of conversations for the current user, most recent ones first.
+  # Returns the paginated list of conversations for the current user, most
+  # recent ones first.
   #
   # @argument scope [String, "unread"|"starred"|"archived"]
   #   When set, only return conversations of the specified type. For example,

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -321,7 +321,7 @@ class CoursesController < ApplicationController
   include Api::V1::Progress
 
   # @API List your courses
-  # Returns the list of active courses for the current user.
+  # Returns the paginated list of active courses for the current user.
   #
   # @argument enrollment_type [String, "teacher"|"student"|"ta"|"observer"|"designer"]
   #   When set, only return courses where the user is enrolled as this type. For
@@ -464,7 +464,7 @@ class CoursesController < ApplicationController
   end
 
   # @API List courses for a user
-  # Returns a list of active courses for this user. To view the course list for a user other than yourself, you must be either an observer of that user or an administrator.
+  # Returns a paginated list of active courses for this user. To view the course list for a user other than yourself, you must be either an observer of that user or an administrator.
   #
   # @argument include[] [String, "needs_grading_count"|"syllabus_body"|"public_description"|"total_scores"|"current_grading_period_scores"|"term"|"course_progress"|"sections"|"storage_quota_used_mb"|"total_students"|"passback_status"|"favorites"|"teachers"|"observed_users"|"course_image"]
   #   - "needs_grading_count": Optional information to include with each Course.
@@ -795,7 +795,7 @@ class CoursesController < ApplicationController
 
   # @API List students
   #
-  # Returns the list of students enrolled in this course.
+  # Returns the paginated list of students enrolled in this course.
   #
   # DEPRECATED: Please use the {api:CoursesController#users course users} endpoint
   # and pass "student" as the enrollment_type.
@@ -812,7 +812,7 @@ class CoursesController < ApplicationController
   end
 
   # @API List users in course
-  # Returns the list of users in this course. And optionally the user's enrollments in the course.
+  # Returns the paginated list of users in this course. And optionally the user's enrollments in the course.
   #
   # @argument search_term [String]
   #   The partial name or full ID of the users to match and return in the results list.
@@ -943,7 +943,7 @@ class CoursesController < ApplicationController
 
   # @API List recently logged in students
   #
-  # Returns the list of users in this course, ordered by how recently they have
+  # Returns the paginated list of users in this course, ordered by how recently they have
   # logged in. The records include the 'last_login' field which contains
   # a timestamp of the last time that user logged into canvas.  The querying
   # user must have the 'View usage reports' permission.

--- a/app/controllers/custom_gradebook_columns_api_controller.rb
+++ b/app/controllers/custom_gradebook_columns_api_controller.rb
@@ -51,7 +51,7 @@ class CustomGradebookColumnsApiController < ApplicationController
 
   # @API List custom gradebook columns
   #
-  # List all custom gradebook columns for a course
+  # A paginated list of all custom gradebook columns for a course
   #
   # @argument include_hidden [Boolean]
   #   Include hidden parameters (defaults to false)

--- a/app/controllers/enrollments_api_controller.rb
+++ b/app/controllers/enrollments_api_controller.rb
@@ -267,9 +267,10 @@ class EnrollmentsApiController < ApplicationController
 
   include Api::V1::User
   # @API List enrollments
-  # Depending on the URL given, return either (1) all of the enrollments in
-  # a course, (2) all of the enrollments in a section or (3) all of a user's
-  # enrollments. This includes student, teacher, TA, and observer enrollments.
+  # Depending on the URL given, return a paginated list of either (1) all of
+  # the enrollments in a course, (2) all of the enrollments in a section or (3)
+  # all of a user's enrollments. This includes student, teacher, TA, and
+  # observer enrollments.
   #
   # If a user has multiple enrollments in a context (e.g. as a teacher
   # and a student or in multiple course sections), each enrollment will be

--- a/app/controllers/epub_exports_controller.rb
+++ b/app/controllers/epub_exports_controller.rb
@@ -113,8 +113,8 @@ class EpubExportsController < ApplicationController
 
   # @API List courses with their latest ePub export
   #
-  # Lists all courses a user is actively participating in,
-  # and the latest ePub export associated with the user & course.
+  # A paginated list of all courses a user is actively participating in, and
+  # the latest ePub export associated with the user & course.
   #
   # @returns [CourseEpubExport]
   def index

--- a/app/controllers/external_feeds_controller.rb
+++ b/app/controllers/external_feeds_controller.rb
@@ -74,7 +74,7 @@ class ExternalFeedsController < ApplicationController
 
   # @API List external feeds
   #
-  # Returns the list of External Feeds this course or group.
+  # Returns the paginated list of External Feeds this course or group.
   #
   # @example_request
   #     curl https://<canvas>/api/v1/courses/<course_id>/external_feeds \

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -52,7 +52,7 @@ class FavoritesController < ApplicationController
   include Api::V1::Group
 
   # @API List favorite courses
-  # Retrieve the list of favorite courses for the current user. If the user has not chosen
+  # Retrieve the paginated list of favorite courses for the current user. If the user has not chosen
   # any favorites, then a selection of currently enrolled courses will be returned.
   #
   # @argument exclude_blueprint_courses [Boolean]
@@ -90,7 +90,7 @@ class FavoritesController < ApplicationController
   end
 
   # @API List favorite groups
-  # Retrieve the list of favorite groups for the current user. If the user has not chosen
+  # Retrieve the paginated list of favorite groups for the current user. If the user has not chosen
   # any favorites, then a selection of groups that the user is a member of will be returned.
   #
   #

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -142,7 +142,7 @@ class FeatureFlagsController < ApplicationController
 
   # @API List features
   #
-  # List all features that apply to a given Account, Course, or User.
+  # A paginated list of all features that apply to a given Account, Course, or User.
   #
   # @example_request
   #
@@ -164,7 +164,7 @@ class FeatureFlagsController < ApplicationController
 
   # @API List enabled features
   #
-  # List all features that are enabled on a given Account, Course, or User.
+  # A paginated list of all features that are enabled on a given Account, Course, or User.
   # Only the feature names are returned.
   #
   # @example_request

--- a/app/controllers/grading_periods_controller.rb
+++ b/app/controllers/grading_periods_controller.rb
@@ -68,7 +68,7 @@ class GradingPeriodsController < ApplicationController
   # @API List grading periods
   # @beta
   #
-  # Returns the list of grading periods for the current course.
+  # Returns the paginated list of grading periods for the current course.
   #
   # @example_response
   #   {

--- a/app/controllers/grading_standards_api_controller.rb
+++ b/app/controllers/grading_standards_api_controller.rb
@@ -147,7 +147,7 @@ class GradingStandardsApiController < ApplicationController
 
   # @API List the grading standards available in a context.
   #
-  # Returns the list of grading standards for the given context that are visible to the user.
+  # Returns the paginated list of grading standards for the given context that are visible to the user.
   #
   # @example_request
   #   curl https://<canvas>/api/v1/courses/1/grading_standards \

--- a/app/controllers/group_categories_controller.rb
+++ b/app/controllers/group_categories_controller.rb
@@ -98,7 +98,7 @@ class GroupCategoriesController < ApplicationController
 
   # @API List group categories for a context
   #
-  # Returns a list of group categories in a context
+  # Returns a paginated list of group categories in a context
   #
   # @example_request
   #     curl https://<canvas>/api/v1/accounts/<account_id>/group_categories \
@@ -291,7 +291,7 @@ class GroupCategoriesController < ApplicationController
 
   # @API List groups in group category
   #
-  # Returns a list of groups in a group category
+  # Returns a paginated list of groups in a group category
   #
   # @example_request
   #     curl https://<canvas>/api/v1/group_categories/<group_cateogry_id>/groups \
@@ -309,7 +309,7 @@ class GroupCategoriesController < ApplicationController
   include Api::V1::User
   # @API List users in group category
   #
-  # Returns a list of users in the group category.
+  # Returns a paginated list of users in the group category.
   #
   # @argument search_term [String]
   #   The partial name or full ID of the users to match and return in the results

--- a/app/controllers/group_memberships_controller.rb
+++ b/app/controllers/group_memberships_controller.rb
@@ -81,7 +81,7 @@ class GroupMembershipsController < ApplicationController
   #
   # @subtopic Group Memberships
   #
-  # List the members of a group.
+  # A paginated list of the members of a group.
   #
   # @argument filter_states[] [String, "accepted"|"invited"|"requested"]
   #   Only list memberships with the given workflow_states. By default it will

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -185,7 +185,7 @@ class GroupsController < ApplicationController
 
   # @API List your groups
   #
-  # Returns a list of active groups for the current user.
+  # Returns a paginated list of active groups for the current user.
   #
   # @argument context_type [String, "Account"|"Course"]
   #  Only include groups that are in this type of context.
@@ -231,7 +231,7 @@ class GroupsController < ApplicationController
 
   # @API List the groups available in a context.
   #
-  # Returns the list of active groups in the given context that are visible to user.
+  # Returns the paginated list of active groups in the given context that are visible to user.
   #
   # @argument only_own_groups [Boolean]
   #  Will only include groups that the user belongs to if this is set
@@ -667,7 +667,7 @@ class GroupsController < ApplicationController
   include Api::V1::User
   # @API List group's users
   #
-  # Returns a list of users in the group.
+  # Returns a paginated list of users in the group.
   #
   # @argument search_term [String]
   #   The partial name or full ID of the users to match and return in the

--- a/app/controllers/live_assessments/assessments_controller.rb
+++ b/app/controllers/live_assessments/assessments_controller.rb
@@ -107,7 +107,7 @@ module LiveAssessments
     # @API List live assessments
     # @beta
     #
-    # Returns a list of live assessments.
+    # Returns a paginated list of live assessments.
     #
     # @example_response
     #  {

--- a/app/controllers/live_assessments/results_controller.rb
+++ b/app/controllers/live_assessments/results_controller.rb
@@ -137,7 +137,7 @@ module LiveAssessments
     # @API List live assessment results
     # @beta
     #
-    # Returns a list of live assessment results
+    # Returns a paginated list of live assessment results
     #
     # @argument user_id [Integer]
     #   If set, restrict results to those for this user

--- a/app/controllers/master_courses/master_templates_controller.rb
+++ b/app/controllers/master_courses/master_templates_controller.rb
@@ -462,7 +462,7 @@ class MasterCourses::MasterTemplatesController < ApplicationController
   # @API List blueprint migrations
   # @subtopic Blueprint Course History
   #
-  # Shows migrations for the template, starting with the most recent. This endpoint can be called on a
+  # Shows a paginated list of migrations for the template, starting with the most recent. This endpoint can be called on a
   # blueprint course. See also {api:MasterCourses::MasterTemplatesController#imports_index the associated course side}.
   #
   # @example_request
@@ -516,7 +516,7 @@ class MasterCourses::MasterTemplatesController < ApplicationController
   # @API List blueprint imports
   # @subtopic Associated Course History
   #
-  # Shows migrations imported into a course associated with a blueprint, starting with the most recent. See also
+  # Shows a paginated list of migrations imported into a course associated with a blueprint, starting with the most recent. See also
   # {api:MasterCourses::MasterTemplatesController#migrations_index the blueprint course side}.
   #
   # Use 'default' as the subscription_id to use the currently active blueprint subscription.

--- a/app/controllers/moderation_set_controller.rb
+++ b/app/controllers/moderation_set_controller.rb
@@ -30,6 +30,8 @@ class ModerationSetController < ApplicationController
 
   # @API List students selected for moderation
   #
+  # Returns a paginated list of students selected for moderation
+  #
   # @returns [User]
   def index
     if authorized_action(@context, @current_user, :moderate_grades)

--- a/app/controllers/outcome_groups_api_controller.rb
+++ b/app/controllers/outcome_groups_api_controller.rb
@@ -319,7 +319,7 @@ class OutcomeGroupsApiController < ApplicationController
 
   # @API List linked outcomes
   #
-  # List the immediate OutcomeLink children of the outcome group. Paginated.
+  # A paginated list of the immediate OutcomeLink children of the outcome group. Paginated.
   #
   # @argument outcome_style [Optional, String]
   #   The detail level of the outcomes. Defaults to "abbrev".
@@ -538,7 +538,7 @@ class OutcomeGroupsApiController < ApplicationController
 
   # @API List subgroups
   #
-  # List the immediate OutcomeGroup children of the outcome group. Paginated.
+  # A paginated list of the immediate OutcomeGroup children of the outcome group. Paginated.
   #
   # @returns [OutcomeGroup]
   #

--- a/app/controllers/outcome_groups_api_controller.rb
+++ b/app/controllers/outcome_groups_api_controller.rb
@@ -319,7 +319,7 @@ class OutcomeGroupsApiController < ApplicationController
 
   # @API List linked outcomes
   #
-  # A paginated list of the immediate OutcomeLink children of the outcome group. Paginated.
+  # A paginated list of the immediate OutcomeLink children of the outcome group.
   #
   # @argument outcome_style [Optional, String]
   #   The detail level of the outcomes. Defaults to "abbrev".
@@ -538,7 +538,7 @@ class OutcomeGroupsApiController < ApplicationController
 
   # @API List subgroups
   #
-  # A paginated list of the immediate OutcomeGroup children of the outcome group. Paginated.
+  # A paginated list of the immediate OutcomeGroup children of the outcome group.
   #
   # @returns [OutcomeGroup]
   #

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -164,9 +164,10 @@ class PageViewsController < ApplicationController
   end
 
   # @API List user page views
-  # Return the user's page view history in json format, similar to the
-  # available CSV download. Pagination is used as described in API basics
-  # section. Page views are returned in descending order, newest to oldest.
+  # Return a paginated list of the user's page view history in json format,
+  # similar to the available CSV download. Pagination is used as described in
+  # API basics section. Page views are returned in descending order, newest to
+  # oldest.
   #
   # @argument start_time [DateTime]
   #   The beginning of the time range from which you want page views.

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -165,9 +165,8 @@ class PageViewsController < ApplicationController
 
   # @API List user page views
   # Return a paginated list of the user's page view history in json format,
-  # similar to the available CSV download. Pagination is used as described in
-  # API basics section. Page views are returned in descending order, newest to
-  # oldest.
+  # similar to the available CSV download. Page views are returned in
+  # descending order, newest to oldest.
   #
   # @argument start_time [DateTime]
   #   The beginning of the time range from which you want page views.

--- a/app/controllers/planner_notes_controller.rb
+++ b/app/controllers/planner_notes_controller.rb
@@ -72,7 +72,7 @@ class PlannerNotesController < ApplicationController
 
   # @API List planner notes
   #
-  # Retrieve the list of planner notes
+  # Retrieve the paginated list of planner notes
   #
   # @example_response
   #   [

--- a/app/controllers/planner_overrides_controller.rb
+++ b/app/controllers/planner_overrides_controller.rb
@@ -92,8 +92,9 @@ class PlannerOverridesController < ApplicationController
               :include_concluded, :only_favorites
   # @API List planner items
   #
-  # Retrieve the list of objects to be shown on the planner for the current user
-  # with the associated planner override to override an item's visibility if set.
+  # Retrieve the paginated list of objects to be shown on the planner for the
+  # current user with the associated planner override to override an item's
+  # visibility if set.
   #
   # @argument start_date [Date]
   #   Only return items starting from the given date.

--- a/app/controllers/polling/poll_choices_controller.rb
+++ b/app/controllers/polling/poll_choices_controller.rb
@@ -62,7 +62,7 @@ module Polling
     # @API List poll choices in a poll
     # @beta
     #
-    # Returns the list of PollChoices in this poll.
+    # Returns the paginated list of PollChoices in this poll.
     #
     # @example_response
     #   {

--- a/app/controllers/polling/poll_sessions_controller.rb
+++ b/app/controllers/polling/poll_sessions_controller.rb
@@ -82,7 +82,7 @@ module Polling
     # @API List poll sessions for a poll
     # @beta
     #
-    # Returns the list of PollSessions in this poll.
+    # Returns the paginated list of PollSessions in this poll.
     #
     # @example_response
     #   {
@@ -242,7 +242,7 @@ module Polling
     # @API List opened poll sessions
     # @beta
     #
-    # Lists all opened poll sessions available to the current user.
+    # A paginated list of all opened poll sessions available to the current user.
     #
     # @example_response
     #   {
@@ -258,7 +258,7 @@ module Polling
     # @API List closed poll sessions
     # @beta
     #
-    # Lists all closed poll sessions available to the current user.
+    # A paginated list of all closed poll sessions available to the current user.
     #
     # @example_response
     #   {

--- a/app/controllers/polling/polls_controller.rb
+++ b/app/controllers/polling/polls_controller.rb
@@ -67,7 +67,7 @@ module Polling
     # @API List polls
     # @beta
     #
-    # Returns the list of polls for the current user.
+    # Returns the paginated list of polls for the current user.
     #
     # @example_response
     #   {

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -257,7 +257,7 @@ class ProfileController < ApplicationController
   end
 
   # @API List avatar options
-  # Retrieve the possible user avatar options that can be set with the user update endpoint. The response will be an array of avatar records. If the 'type' field is 'attachment', the record will include all the normal attachment json fields; otherwise it will include only the 'url' and 'display_name' fields. Additionally, all records will include a 'type' field and a 'token' field. The following explains each field in more detail
+  # A paginated list of the possible user avatar options that can be set with the user update endpoint. The response will be an array of avatar records. If the 'type' field is 'attachment', the record will include all the normal attachment json fields; otherwise it will include only the 'url' and 'display_name' fields. Additionally, all records will include a 'type' field and a 'token' field. The following explains each field in more detail
   # type:: ["gravatar"|"attachment"|"no_pic"] The type of avatar record, for categorization purposes.
   # url:: The url of the avatar
   # token:: A unique representation of the avatar record which can be used to set the avatar with the user update endpoint. Note: this is an internal representation and is subject to change without notice. It should be consumed with this api endpoint and used in the user update endpoint, and should not be constructed by the client.

--- a/app/controllers/pseudonyms_controller.rb
+++ b/app/controllers/pseudonyms_controller.rb
@@ -27,7 +27,7 @@ class PseudonymsController < ApplicationController
   include Api::V1::Pseudonym
 
   # @API List user logins
-  # Given a user ID, return that user's logins for the given account.
+  # Given a user ID, return a paginated list of that user's logins for the given account.
   #
   # @response_field account_id The ID of the login's account.
   # @response_field id The unique, numeric ID for the login.

--- a/app/controllers/quizzes/quiz_questions_controller.rb
+++ b/app/controllers/quizzes/quiz_questions_controller.rb
@@ -193,7 +193,7 @@ class Quizzes::QuizQuestionsController < ApplicationController
   # @API List questions in a quiz or a submission
   # @beta
   #
-  # Returns the list of QuizQuestions in this quiz.
+  # Returns the paginated list of QuizQuestions in this quiz.
   #
   # @argument quiz_submission_id [Integer]
   #  If specified, the endpoint will return the questions that were presented

--- a/app/controllers/quizzes/quizzes_api_controller.rb
+++ b/app/controllers/quizzes/quizzes_api_controller.rb
@@ -290,7 +290,7 @@ class Quizzes::QuizzesApiController < ApplicationController
 
   # @API List quizzes in a course
   #
-  # Returns the list of Quizzes in this course.
+  # Returns the paginated list of Quizzes in this course.
   #
   # @argument search_term [String]
   #   The partial title of the quizzes to match and return.

--- a/app/controllers/role_overrides_controller.rb
+++ b/app/controllers/role_overrides_controller.rb
@@ -114,7 +114,7 @@ class RoleOverridesController < ApplicationController
   before_action :set_js_env_for_current_account
 
   # @API List roles
-  # List the roles available to an account.
+  # A paginated list of the roles available to an account.
   #
   # @argument account_id [Required, String]
   #   The id of the account to retrieve roles for.

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -175,7 +175,7 @@ class SearchController < ApplicationController
   end
 
   # @API List all courses
-  # List all courses visible in the public index
+  # A paginated list of all courses visible in the public index
   #
   # @argument search [String]
   #   Search terms used for matching users/courses/groups (e.g. "bob smith"). If

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -92,7 +92,7 @@ class SectionsController < ApplicationController
   include Api::V1::Section
 
   # @API List course sections
-  # Returns the list of sections for this course.
+  # A paginated list of the list of sections for this course.
   #
   # @argument include[] [String, "students"|"avatar_url"|"enrollments"|"total_students"|"passback_status"]
   #   - "students": Associations to include with the group. Note: this is only

--- a/app/controllers/submissions_api_controller.rb
+++ b/app/controllers/submissions_api_controller.rb
@@ -183,7 +183,7 @@ class SubmissionsApiController < ApplicationController
 
   # @API List assignment submissions
   #
-  # Get all existing submissions for an assignment.
+  # A paginated list of all existing submissions for an assignment.
   #
   # @argument include[] [String, "submission_history"|"submission_comments"|"rubric_assessment"|"assignment"|"visibility"|"course"|"user"|"group"]
   #   Associations to include with the group.  "group" will add group_id and group_name.
@@ -247,7 +247,7 @@ class SubmissionsApiController < ApplicationController
 
   # @API List submissions for multiple assignments
   #
-  # Get all existing submissions for a given set of students and assignments.
+  # A paginated list of all existing submissions for a given set of students and assignments.
   #
   # @argument student_ids[] [String]
   #   List of student ids to return submissions for. If this argument is
@@ -776,7 +776,7 @@ class SubmissionsApiController < ApplicationController
 
   # @API List gradeable students
   #
-  # List students eligible to submit the assignment. The caller must have permission to view grades.
+  # A paginated list of students eligible to submit the assignment. The caller must have permission to view grades.
   #
   # Section-limited instructors will only see students in their own sections.
   #
@@ -818,7 +818,7 @@ class SubmissionsApiController < ApplicationController
   # @argument assignment_ids[] [String]
   #   Assignments being requested
   #
-  # List students eligible to submit a list of assignments. The caller must have
+  # A paginated list of students eligible to submit a list of assignments. The caller must have
   # permission to view grades for the requested course.
   #
   # Section-limited instructors will only see students in their own sections.

--- a/app/controllers/tabs_controller.rb
+++ b/app/controllers/tabs_controller.rb
@@ -63,7 +63,7 @@ class TabsController < ApplicationController
 
   # @API List available tabs for a course or group
   #
-  # Returns a list of navigation tabs available in the current context.
+  # Returns a paginated list of navigation tabs available in the current context.
   #
   # @argument include[] [String, "external"]
   #   "external":: Optionally include external tool tabs in the returned list of tabs (Only has effect for courses, not groups)

--- a/app/controllers/terms_api_controller.rb
+++ b/app/controllers/terms_api_controller.rb
@@ -73,7 +73,7 @@ class TermsApiController < ApplicationController
 
   # @API List enrollment terms
   #
-  # Return all of the terms in the account.
+  # A paginated list of all of the terms in the account.
   #
   # @argument workflow_state[] [String, "active"|"deleted"|"all"]
   #   If set, only returns terms that are in the given state.

--- a/app/controllers/usage_rights_controller.rb
+++ b/app/controllers/usage_rights_controller.rb
@@ -139,7 +139,7 @@ class UsageRightsController < ApplicationController
   end
 
   # @API List licenses
-  # Lists licenses that can be applied
+  # A paginated list of licenses that can be applied
   #
   # @returns [License]
   def licenses

--- a/app/controllers/user_observees_controller.rb
+++ b/app/controllers/user_observees_controller.rb
@@ -27,7 +27,7 @@ class UserObserveesController < ApplicationController
 
   # @API List observees
   #
-  # List the users that the given user is observing.
+  # A paginated list of the users that the given user is observing.
   #
   # *Note:* all users are allowed to list their own observees. Administrators can list
   # other users' observees.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -367,7 +367,7 @@ class UsersController < ApplicationController
   end
 
   # @API List users in account
-  # Retrieve the list of users associated with this account.
+  # A paginated list of of users associated with this account.
   #
   # @argument search_term [String]
   #   The partial name or full ID of the users to match and return in the
@@ -788,7 +788,7 @@ class UsersController < ApplicationController
 
   include Api::V1::TodoItem
   # @API List the TODO items
-  # Returns the current user's list of todo items, as seen on the user dashboard.
+  # A paginated list of the current user's list of todo items, as seen on the user dashboard.
   #
   # @argument include[] [String, "ungraded_quizzes"]
   #   "ungraded_quizzes":: Optionally include ungraded quizzes (such as practice quizzes and surveys) in the list.
@@ -853,7 +853,7 @@ class UsersController < ApplicationController
   include Api::V1::CalendarEvent
 
   # @API List upcoming assignments, calendar events
-  # Returns the current user's upcoming events, i.e. the same things shown
+  # A paginated list of the current user's upcoming events, i.e. the same things shown
   # in the dashboard 'Coming Up' sidebar.
   #
   # @example_response
@@ -932,7 +932,7 @@ class UsersController < ApplicationController
   end
 
   # @API List Missing Submissions
-  # returns past-due assignments for which the student does not have a submission.
+  # A paginated list of past-due assignments for which the student does not have a submission.
   # The user sending the request must either be an admin or a parent observer using the parent app
   #
   # @argument user_id

--- a/app/controllers/web_zip_exports_controller.rb
+++ b/app/controllers/web_zip_exports_controller.rb
@@ -107,7 +107,7 @@ class WebZipExportsController < ApplicationController
 
   # @API List all web zip exports in a course
   #
-  # Lists all web zip exports in a course for the current user
+  # A paginated list of all web zip exports in a course for the current user
   #
   # @example_request
   #

--- a/app/controllers/wiki_pages_api_controller.rb
+++ b/app/controllers/wiki_pages_api_controller.rb
@@ -218,7 +218,7 @@ class WikiPagesApiController < ApplicationController
 
   # @API List pages
   #
-  # List the wiki pages associated with a course or group
+  # A paginated list of the wiki pages associated with a course or group
   #
   # @argument sort [String, "title"|"created_at"|"updated_at"]
   #   Sort results by this field.
@@ -430,7 +430,7 @@ class WikiPagesApiController < ApplicationController
 
   # @API List revisions
   #
-  # List the revisions of a page. Callers must have update rights on the page in order to see page history.
+  # A paginated list of the revisions of a page. Callers must have update rights on the page in order to see page history.
   #
   # @example_request
   #     curl -H 'Authorization: Bearer <token>' \


### PR DESCRIPTION
Add the word `paginated` before the word `list` to relevant API endpoints to hint that the results are paginated.