### PR TITLE
Fix docker pg build

### DIFF
--- a/docker-compose/postgres/Dockerfile
+++ b/docker-compose/postgres/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -qq \
       build-essential \
       ca-certificates \
       libicu-dev \
-      postgresql-server-dev-all \
+      postgresql-server-dev-9.3 \
       pgxnclient \
   && rm -rf /var/lib/apt/lists/*
 # Install postgres extension for I8n sorting


### PR DESCRIPTION
Probably broken by the release of PG 10, but it could be something else.

test plan:
- Check out the commit
- Try `dc build --no-cache postgres`
- It should successfully build