### PR TITLE
Improve score details and grade statistics

### DIFF
--- a/app/coffeescripts/AssignmentDetailsDialog.js
+++ b/app/coffeescripts/AssignmentDetailsDialog.js
@@ -19,19 +19,24 @@ export default class AssignmentDetailsDialog {
 
   show () {
     const {scores, locals} = this.compute()
-    let tally = 0
-    let width = 0
     const totalWidth = 100
+
+    const widthForValue = val => (totalWidth * val / this.assignment.points_possible);
+    
     $.extend(locals, {
       showDistribution: locals.average && this.assignment.points_possible,
-      noneLeftWidth: (width = totalWidth * (locals.min / this.assignment.points_possible)),
-      noneLeftLeft: (tally += width) - width,
-      someLeftWidth: (width = totalWidth * ((locals.average - locals.min) / this.assignment.points_possible)),
-      someLeftLeft: (tally += width) - width,
-      someRightWidth: (width = totalWidth * ((locals.max - locals.average) / this.assignment.points_possible)),
-      someRightLeft: (tally += width) - width,
-      noneRightWidth: (width = totalWidth * ((this.assignment.points_possible - locals.max) / this.assignment.points_possible)),
-      noneRightLeft: (tally += width) - width,
+      
+      lowLeft: widthForValue(locals.min),
+      lqLeft: widthForValue(locals.lowerQuartile),
+      medianLeft: widthForValue(locals.median),
+      uqLeft: widthForValue(locals.upperQuartile),
+      highLeft: widthForValue(locals.max),
+      maxLeft: totalWidth,
+  
+      highWidth: widthForValue(locals.max - locals.upperQuartile),
+      lowLqWidth: widthForValue(locals.lowerQuartile - locals.min),
+      medianLowWidth: widthForValue(locals.median - locals.lowerQuartile) + 1,
+      medianHighWidth: widthForValue(locals.upperQuartile - locals.median),
     })
 
     return $(assignmentDetailsDialogTemplate(locals)).dialog({
@@ -39,13 +44,14 @@ export default class AssignmentDetailsDialog {
       close () { $(this).remove() }
     })
   }
-
+  
   compute (opts = {students: this.students, assignment: this.assignment}) {
     const {students, assignment} = opts
 
     const scores = Object.values(students)
       .filter(student => student[`assignment_${assignment.id}`] && student[`assignment_${assignment.id}`].score != null)
       .map(student => student[`assignment_${assignment.id}`].score)
+      .sort()
 
     const locals = {
       assignment,
@@ -53,10 +59,20 @@ export default class AssignmentDetailsDialog {
       max: this.nonNumericGuard(Math.max(...scores)),
       min: this.nonNumericGuard(Math.min(...scores)),
       pointsPossible: this.nonNumericGuard(assignment.points_possible, I18n.t('N/A')),
-      average: this.nonNumericGuard(round(scores.reduce((a, b) => a + b, 0) / scores.length, 2))
+      average: this.nonNumericGuard(round(scores.reduce((a, b) => a + b, 0) / scores.length, 2)),
+      median: this.nonNumericGuard(this.percentile(scores, 0.5)),
+      lowerQuartile: this.nonNumericGuard(this.percentile(scores, 0.25)),
+      upperQuartile: this.nonNumericGuard(this.percentile(scores, 0.75)),
     }
 
     return {scores, locals}
+  }
+  
+  percentile (values, percentile) {
+    const k = Math.floor(percentile*(values.length - 1)+1)- 1
+    const f = (percentile*(values.length - 1)+1) % 1
+
+    return values[k] + (f * (values[k+1] - values[k]))
   }
 
   nonNumericGuard (number, message = I18n.t('No graded submissions')) {

--- a/app/presenters/grade_summary_presenter.rb
+++ b/app/presenters/grade_summary_presenter.rb
@@ -214,6 +214,16 @@ class GradeSummaryPresenter
     Rails.cache.delete(cache_key(context, 'assignment_stats'))
   end
 
+  # This requires that the array passed in must be sorted.
+  # Adapted from https://stackoverflow.com/a/11785414
+  def percentile(values, count, percentile)
+    return nil if count < 2
+    k = (percentile*(count - 1)+1).floor - 1
+    f = (percentile*(count - 1)+1).modulo(1)
+
+    values[k] + (f * (values[k+1] - values[k]))
+  end
+
   def assignment_stats
     # performance note: There is an overlap between
     # Submission.not_placeholder and the submission where clause.
@@ -223,16 +233,36 @@ class GradeSummaryPresenter
     # require score then add a filter when the DA feature is on
     @stats ||= begin
       Rails.cache.fetch(GradeSummaryPresenter.cache_key(@context, 'assignment_stats')) do
-        @context.assignments.active.except(:order).
+        ret = @context.assignments.active.except(:order).
           joins(:submissions).
           joins("INNER JOIN #{Enrollment.quoted_table_name} enrollments ON submissions.user_id = enrollments.user_id").
           merge(Enrollment.of_student_type.active_or_pending).
           merge(Submission.not_placeholder).
           where(enrollments: {course_id: @context}).
           where("submissions.excused IS NOT TRUE").
-          group("assignments.id").
-          select("assignments.id, max(score) max, min(score) min, avg(score) avg, count(submissions.id) count").
-          index_by(&:id)
+          where("submissions.score IS NOT NULL").
+          order("score").
+          select("assignments.id as id, submissions.score as score").
+          group_by(&:id)
+
+        ret.map do |k,assignment| 
+          scores = assignment.map do |submission|
+            submission.score
+          end
+          Rails.logger.warn(scores)
+
+          count = scores.length
+
+          [k, OpenStruct.new({
+            'max' => scores[-1],
+            'min' => scores[0],
+            'avg' => scores.sum / count,
+            'count' => count,
+            'median' => percentile(scores, count, 0.5),
+            'lower_q' => percentile(scores, count, 0.25),
+            'upper_q' => percentile(scores, count, 0.75)
+          })]
+        end.to_h
       end
     end
   end

--- a/app/stylesheets/bundles/grade_summary.scss
+++ b/app/stylesheets/bundles/grade_summary.scss
@@ -283,6 +283,7 @@ a.screenreader-toggle {
   overflow: hidden;
   border-style: solid;
   border-color: $ic-border-dark;
+  box-sizing: border-box;
 }
 
 div.rubric-toggle {

--- a/app/stylesheets/jst/AssignmentDetailsDialog.scss
+++ b/app/stylesheets/jst/AssignmentDetailsDialog.scss
@@ -19,51 +19,75 @@
 #assignment-details-dialog {
   .distribution {
     margin: 15px 0;
-    height: 30px;
+    height: 40px;
     position: relative;
+
     div {
       position: absolute;
       top: 0;
+      left: 0;
+      width: 0;
+      overflow: hidden;
       border-style: solid;
       border-color: #aaa;
-      overflow: hidden;
+      box-sizing: border-box;
     }
-    .bar-left, .bar-right {
-      height: 10px;
-      width: 0px;
-      margin: 5px 0px;
+
+    .zero, .points-possible{
+      top: 26px;
+      border-width: 0px;
+      width: auto;
     }
-    .bar-left {
-      left: 0;
-      border-width: 2px 0 2px 2px;
+
+    .points-possible {
+      left: auto;
+      right: 0;
     }
-    .none-left, .none-right {
-      height: 11px;
-      border-bottom-width: 2px;
+
+    .zero-point {
+      height: 24px;
+      margin: 0px 0px;
+      border-width: 1px;
+      border-right-width: 0;
     }
-    .some-left {
-      height: 20px;
-      border-width: 2px 0pt 2px 2px;
+
+    .max-point, .min-point {
+      height: 14px;
+      height: 18px;
+      margin: 3px 0px;
+      border-width: 2px;
+      border-left-width: 0;
+    }
+
+    .whisker {
+      height: 0px;
+      margin-top: 10px;
+      border-width: 2px;
+      border-right-width: 0;
+    }
+
+    .left-box {
+      height: 24px;
+      border-width: 2px;
       border-top-left-radius: 3px;
       border-bottom-left-radius: 3px;
+      border-right-width: 0;
       background: #fff;
-      z-index: 2;
     }
-    .some-right {
-      height: 20px;
+    
+    .right-box {
+      height: 24px;
       border-width: 2px;
-      overflow: hidden;
       border-top-right-radius: 3px;
       border-bottom-right-radius: 3px;
       background: #fff;
-      z-index: 2;
     }
-    .bar-right {
-      width: 0;
-      height: 10px;
-      margin: 5px 0;
-      right: 0;
-      border-width: 2px 2px 2px 0;
+
+    .total-point {
+      height: 24px;
+      margin: 0px 1px;
+      border-width: 1px; 
+      border-left-width: 0;
     }
   }
 }

--- a/app/views/gradebooks/grade_summary.html.erb
+++ b/app/views/gradebooks/grade_summary.html.erb
@@ -468,18 +468,27 @@
                       <%= t(:disabled_for_student_view, "Test Student scores are not included in grade statistics.") %>
                     </td>
                   <% else %>
-                    <% high, low, mean = assignment_presenter.grade_distribution %>
+                    <% high, low, mean, median, low_q, high_q = assignment_presenter.grade_distribution %>
                     <td>
                       <%= before_label(:mean, "Mean") %>
                       <%= n(round_if_whole(mean)) %>
+                      <br/>
+                      <%= before_label(:median, "Median") %>
+                      <%= n(round_if_whole(median)) %>
                     </td>
                     <td>
                       <%= before_label(:high, "High") %>
                       <%= n(round_if_whole(high)) %>
+                      <br/>
+                      <%= before_label(:high_q, "Upper Quartile") %>
+                      <%= n(round_if_whole(high_q)) %>
                     </td>
                     <td>
                       <%= before_label(:low, "Low") %>
                       <%= n(round_if_whole(low)) %>
+                      <br/>
+                      <%= before_label(:low_q, "Lower Quartile") %>
+                      <%= n(round_if_whole(low_q)) %>
                     </td>
                     <% if assignment_presenter.deduction_present? %>
                       <td>
@@ -496,14 +505,17 @@
                     <td colspan="<%= assignment_presenter.deduction_present? ? 1 : 3 %>">
                       <% graph = assignment_presenter.graph %>
                       <div style="cursor: pointer; float: right; height: 30px; margin-left: 20px; width: 160px; position: relative; margin-right: 30px;" aria-hidden="true" title="<%= graph.title %>">
-                        <div class="grade-summary-graph-component" style="height: 10px; margin: 5px 0px; border-width: 2px; border-right-width: 0;">&nbsp;</div>
-                        <div class="grade-summary-graph-component" style="width: <%= graph.low_width %>px; height: 0px; margin-top: 10px; border-bottom-width: 2px;">&nbsp;</div>
-                        <div class="grade-summary-graph-component" style="left: <%= graph.high_left %>px; width: <%= graph.high_width %>px; height: 0px; margin-top: 10px; border-bottom-width: 2px;">&nbsp;</div>
-                        <div class="grade-summary-graph-component" style="left: <%= graph.low_width %>px; width: <%= graph.mean_low_width %>px; height: 20px; border-width: 2px; border-top-left-radius: 3px; border-bottom-left-radius: 3px; border-right-width: 0; background: #fff;">&nbsp;</div>
-                        <div class="grade-summary-graph-component" style="left: <%= graph.mean_left%>px; width: <%= graph.mean_high_width%>px; height: 20px; border-width: 2px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; background: #fff;">&nbsp;</div>
-                        <div class="grade-summary-graph-component" style="left: <%= graph.max_left %>px; height: 10px; margin: 5px 0px; border-width: 2px; border-left-width: 0;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="height: 24px; margin: 0px 0px; border-width: 1px; border-right-width: 0;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="left: <%= graph.low_left %>px; height: 18px; margin: 3px 0px; border-width: 2px; border-left-width: 0;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="left: <%= graph.low_left %>px; width: <%= graph.low_lq_width %>px; height: 0px; margin-top: 10px; border-width: 2px; border-right-width: 0;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="left: <%= graph.lq_left %>px; width: <%= graph.median_low_width %>px; height: 24px; border-width: 2px; border-top-left-radius: 3px; border-bottom-left-radius: 3px; border-right-width: 0; background: #fff;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="left: <%= graph.median_left%>px; width: <%= graph.median_high_width%>px; height: 24px; border-width: 2px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; background: #fff;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="left: <%= graph.uq_left %>px; width: <%= graph.high_width %>px; height: 0px; margin-top: 10px; border-bottom-width: 2px;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="left: <%= graph.high_left %>px; height: 14px; height: 18px; margin: 3px 0px; border-width: 2px; border-left-width: 0;">&nbsp;</div>
+                        <div class="grade-summary-graph-component" style="left: <%= graph.max_left %>px; height: 14px; height: 24px; margin: 0px 1px; border-width: 1px; border-left-width: 0;">&nbsp;</div>
+                        
                         <% if submission && submission.score %>
-                          <div class="grade-summary-graph-component" style="top: 5px; height: 10px; width: 10px; left: <%= graph.score_left %>px; border: 2px solid #248; background: #abd; border-radius: 3px;" title="<%= before_label(:your_score, "Your Score") %>
+                          <div class="grade-summary-graph-component" style="top: 5px; height: 14px; width: 14px; left: <%= graph.score_left %>px; border: 2px solid #248; background: #abd; border-radius: 3px;" title="<%= before_label(:your_score, "Your Score") %>
                             <%= t(:submission_score, "*%{score}* out of %{possible}", :wrapper => '\1', :score => n(submission.score), :possible => n(round_if_whole(assignment.points_possible))) %>">&nbsp;
                           </div>
                         <% end %>

--- a/app/views/jst/AssignmentDetailsDialog.handlebars
+++ b/app/views/jst/AssignmentDetailsDialog.handlebars
@@ -1,12 +1,16 @@
 <div id="assignment-details-dialog" title="{{#t "grading_statistics_for_assignment"}}Grade statistics for: {{assignment.name}}{{/t}}">
   {{#if showDistribution}}
-    <div class="distribution" style="display: block; ">
-      <div class="bar-left"></div>
-      <div class="none-left" title="{{#t "no_one_scored_lower"}}No one scored lower than {{min}}{{/t}}" style="width: {{noneLeftWidth}}%; left: {{noneLeftLeft}}%; "></div>
-      <div class="some-left" title="{{#t "scores_lower_than_the_average"}}Scores lower than the average of {{average}}{{/t}}" style="width: {{someLeftWidth}}%; left: {{someLeftLeft}}%; "></div>
-      <div class="some-right" title="{{#t "scores_higher_than_the_average"}}Scores higher than the average of {{average}}{{/t}}" style="width: {{someRightWidth}}%; left: {{someRightLeft}}%; "></div>
-      <div class="none-right" title="{{#t "no_one_scored_higher"}}No one scored higher than {{max}}{{/t}}" style="width: {{noneRightWidth}}%; left: {{noneRightLeft}}%; "></div>
-      <div class="bar-right"></div>
+    <div class="distribution" style="display: block; " aria-hidden="true">
+      <div class="zero">0</div>
+      <div class="zero-point">&nbsp;</div>
+      <div class="min-point" style="left: {{lowLeft}}%;">&nbsp;</div>
+      <div class="whisker" style="left: {{lowLeft}}%; width: {{lowLqWidth}}%;">&nbsp;</div>
+      <div class="left-box" style="left: {{lqLeft}}%; width: {{medianLowWidth}}%;">&nbsp;</div>
+      <div class="right-box" style="left: {{medianLeft}}%; width: {{medianHighWidth}}%;">&nbsp;</div>
+      <div class="whisker" style="left: {{uqLeft}}%; width: {{highWidth}}%;">&nbsp;</div>
+      <div class="max-point" style="left: {{highLeft}}%;">&nbsp;</div>
+      <div class="total-point" style="left: {{maxLeft}}%;">&nbsp;</div>
+      <div class="points-possible">{{assignment.points_possible}}</div>
     </div>
   {{/if}}
   <table id="assignment-details-dialog-stats-table">
@@ -17,6 +21,18 @@
     <tr>
       <th scope="row">{{#t "high_score"}}High Score:{{/t}}</th>
       <td>{{max}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{#t "upper_quartile"}}Upper Quartile:{{/t}}</th>
+      <td>{{upperQuartile}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{#t "median"}}Median Score:{{/t}}</th>
+      <td>{{median}}</td>
+    </tr>
+    <tr>
+      <th scope="row">{{#t "lower_quartile"}}Lower Quartile:{{/t}}</th>
+      <td>{{lowerQuartile}}</td>
     </tr>
     <tr>
       <th scope="row">{{#t "low_score"}}Low Score:{{/t}}</th>

--- a/spec/presenters/grade_summary_presenter_spec.rb
+++ b/spec/presenters/grade_summary_presenter_spec.rb
@@ -113,6 +113,9 @@ describe GradeSummaryPresenter do
       expect(assignment_stats.max.to_f).to eq 10
       expect(assignment_stats.min.to_f).to eq 0
       expect(assignment_stats.avg.to_f).to eq 5
+      expect(assignment_stats.median.to_f).to eq 5
+      expect(assignment_stats.lower_q.to_f).to eq 2.5
+      expect(assignment_stats.upper_q.to_f).to eq 7.5
     end
 
     it 'filters out test students and inactive enrollments' do

--- a/spec/selenium/grades/gradebook/gradebook_spec.rb
+++ b/spec/selenium/grades/gradebook/gradebook_spec.rb
@@ -159,7 +159,7 @@ describe "gradebook" do
     details_dialog = f('#assignment-details-dialog')
     expect(details_dialog).to be_displayed
     table_rows = ff('#assignment-details-dialog-stats-table tr')
-    expect(table_rows[3].find_element(:css, 'td')).to include_text submissions_count
+    expect(table_rows[6].find_element(:css, 'td')).to include_text submissions_count
   end
 
   it "should include student view student for grading" do

--- a/spec/selenium/grades/srgb/srgb_spec.rb
+++ b/spec/selenium/grades/srgb/srgb_spec.rb
@@ -304,6 +304,9 @@ describe "Screenreader Gradebook" do
     data = [
       'Average Score: 10',
       'High Score: 15',
+      'Upper Quartile: 7.5',
+      'Median Score: 10',
+      'Lower Quartile: 12.5', 
       'Low Score: 5',
       'Total Graded Submissions: 2 submissions'
     ]


### PR DESCRIPTION
Adds median and quartile calculations, and uses them to generate a
proper box and whiskers plot. This updates the plot to match the
existing documentation more closely (suggesting that this matches
what a desired product feature).

Student view:
<img width="851" alt="image" src="https://user-images.githubusercontent.com/3067361/31675041-217d1158-b329-11e7-8e06-3ac365ad4d2f.png">

Teacher view:
<img width="515" alt="image" src="https://user-images.githubusercontent.com/3067361/31676530-8f712830-b32d-11e7-9336-3f4fcd9207c3.png">

test plan:
- Grade an assignment for at least 5 students
- Verify the teacher view assignment details show median and quartile
  numbers
- Verify the box plot matches those numbers and looks reasonable
- Verify the student view score details show median and quartile
  numbers
- Verify the box plot matches those numbers and looks reasonable
- The performance of this code should also be verified for a large
  class size

(This is an update to my previous PR because I added support for the teacher view)