### PR TITLE
syntax error patch for graphql_helpers_spec.rb

### DIFF
--- a/spec/graphql/graphql_helpers_spec.rb
+++ b/spec/graphql/graphql_helpers_spec.rb
@@ -20,7 +20,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 
 describe GraphQLHelpers do
   context "relay_or_legacy_id_prepare_func" do
-    let :relay_user_id { "VXNlci0xMjM0" }
+    let(:relay_user_id) { "VXNlci0xMjM0" }
 
     it "passes legacy ids straight through" do
       expect(
@@ -48,9 +48,9 @@ describe GraphQLHelpers do
   end
 
   context "relay_or_legacy_ids_prepare_func" do
-    let :user1234 { "VXNlci0xMjM0" }
-    let :user5678 { "VXNlci01Njc4" }
-    let :ctx { nil }
+    let(:user1234) { "VXNlci0xMjM0" }
+    let(:user5678) { "VXNlci01Njc4" }
+    let(:ctx) { nil }
 
     it "works for valid ids" do
       expect(


### PR DESCRIPTION
`An error occurred while loading ./spec/graphql/graphql_helpers_spec.rb.
Failure/Error: load_dependency(file) { result = super }
SyntaxError:
  /usr/src/app/spec/graphql/graphql_helpers_spec.rb:23: syntax error, unexpected '{', expecting keyword_end
      let :relay_user_id { "VXNlci0xMjM0" }
                          ^
  /usr/src/app/spec/graphql/graphql_helpers_spec.rb:23: syntax error, unexpected '}', expecting keyword_end
  lay_user_id { "VXNlci0xMjM0" }
                                ^
  /usr/src/app/spec/graphql/graphql_helpers_spec.rb:48: syntax error, unexpected keyword_end, expecting end-of-input
    end
       ^`