### PR TITLE
BigBlueButton feature: Allows the display of multiple recording formats

### DIFF
--- a/app/models/big_blue_button_conference.rb
+++ b/app/models/big_blue_button_conference.rb
@@ -87,15 +87,37 @@ class BigBlueButtonConference < WebConference
 
   def recordings
     fetch_recordings.map do |recording|
-      recording_format = recording.fetch(:playback, {}).fetch(:format, {})
-      {
-        recording_id:     recording[:recordID],
-        title:            recording[:name],
-        duration_minutes: recording_format[:length].to_i,
-        playback_url:     recording_format[:url],
-        ended_at:         recording[:endTime].to_i,
-      }
+      recording_formats(recording)
     end
+  end
+
+  def recording(recording_id = nil)
+    unless recording_id.nil?
+      recording = fetch_recordings.find{ |r| r[:recordID]==recording_id }
+      recording_formats(recording) if recording
+    end
+  end
+
+  def recording_formats(recording)
+    recording_formats = recording.fetch(:playback, [])
+    {
+      recording_id:     recording[:recordID],
+      title:            recording[:name],
+      duration_minutes: filter_duration(recording_formats),
+      playback_formats: filter_formats(recording_formats),
+      ended_at:         recording[:endTime].to_i,
+    }
+  end
+
+  def filter_duration(recording_formats)
+    # As not all the formats are the actual recording, identify the one that has :length
+    recording_formats.each do |recording_format|
+      return recording_format[:length].to_i if recording_format.key?(:length)
+    end
+  end
+
+  def filter_formats(recording_formats)
+    recording_formats.delete_if { |recording_format| recording_format[:type] == "statistics" && user.id != self.user_id }
   end
 
   def delete_recording(recording_id)
@@ -206,7 +228,8 @@ class BigBlueButtonConference < WebConference
     # The BBB API follows the pattern where a plural element (ie <bars>)
     # contains many singular elements (ie <bar>) and nothing else. Detect this
     # and return an array to be assigned to the plural element.
-    elsif node.name.singularize == child_elements.first.name
+    # It excludes the playback node as all of them may be showing different content.
+    elsif node.name.singularize == child_elements.first.name || node.name == "playback"
       child_elements.map { |child| xml_to_value(child) }
     # otherwise, make a hash of the child elements
     else

--- a/app/views/jst/conferences/concludedConference.handlebars
+++ b/app/views/jst/conferences/concludedConference.handlebars
@@ -65,10 +65,14 @@
             <div class="ig-row__layout">
               <div class="ig-info">
                 <div class="ig-details">
-                  <a href="{{playback_url}}" target="_blank" class="ig-title"
-                    style="line-height: inherit;" data-id="{{recording_id}}" data-format="presentation">
-                    {{title}}
+                  <span>{{title}}</span>
+                  &nbsp;&nbsp;&nbsp;
+                  {{#each playback_formats}}
+                  <a href="{{url}}" target="_blank" class="ig-title"
+                    style="line-height: inherit;" data-id="{{../recording_id}}" data-format="presentation">
+                    {{#t "type"}}{{type}}{{/t}}
                   </a>
+                  {{/each}}
                   {{dateString created_at}}
                   &nbsp;&#124;&nbsp;
                   {{durationToString duration_minutes}}

--- a/app/views/jst/conferences/newConference.handlebars
+++ b/app/views/jst/conferences/newConference.handlebars
@@ -99,10 +99,14 @@
             <div class="ig-row__layout">
               <div class="ig-info">
                 <div class="ig-details">
-                  <a href="{{playback_url}}" target="_blank" class="ig-title"
-                    style="line-height: inherit;" data-id="{{recording_id}}" data-format="presentation">
-                    {{title}}
+                  <span>{{title}}</span>
+                  &nbsp;&nbsp;&nbsp;
+                  {{#each playback_formats}}
+                  <a href="{{url}}" target="_blank" class="ig-title"
+                    style="line-height: inherit;" data-id="{{../recording_id}}" data-format="presentation">
+                    {{#t "type"}}{{type}}{{/t}}
                   </a>
+                  {{/each}}
                   {{dateString created_at}}
                   &nbsp;&#124;&nbsp;
                   {{durationToString duration_minutes}}


### PR DESCRIPTION
![screenshot from 2017-12-12 13-07-34](https://user-images.githubusercontent.com/578359/33901083-a56237aa-df3e-11e7-9219-3a2fe82e3525.png)
This PR is complementary to #1079. This extension is to allow multiple recording formats to be shown as processed recording could provide not only multiple formats but also extra content wrapped in the playback.format node.

Development ID:
https://github.com/blindsidenetworks/canvas-lms/issues/24