### PR TITLE
BBB feature recording multiple formats

### DIFF
--- a/app/coffeescripts/views/conferences/ConferenceView.coffee
+++ b/app/coffeescripts/views/conferences/ConferenceView.coffee
@@ -131,20 +131,18 @@ define [
 
     deleteRecording: (e) ->
       e.preventDefault()
-      $deleteButton = $(e.currentTarget).parent('div.ig-button')
-      if !confirm I18n.t("Are you sure you want to delete this recording?")
-        $deleteButton.focus()
-        return
-      $.ajaxJSON($deleteButton.data('url') + "/recording", "DELETE", {
-          recording_id: $deleteButton.data("id"),
-        }
-      ).done( (data, status) =>
-        if data.deleted
-          return @removeRecordingRow($deleteButton)
-        $.flashError(I18n.t("Sorry, the action performed on this recording failed. Try again later"))
-      ).fail( (xhr, status) =>
-        $.flashError(I18n.t("Sorry, the action performed on this recording failed. Try again later"))
-      )
+      if confirm I18n.t("Are you sure you want to delete this recording?")
+        $button = $(e.currentTarget).parents('div.ig-button')
+        $.ajaxJSON($button.data('url') + "/recording", "DELETE", {
+            recording_id: $button.data("id"),
+          }
+        ).done( (data, status) =>
+          if data.deleted
+            return @removeRecordingRow($button)
+          $.flashError(I18n.t("Sorry, the action performed on this recording failed. Try again later"))
+        ).fail( (xhr, status) =>
+          $.flashError(I18n.t("Sorry, the action performed on this recording failed. Try again later"))
+        )
 
     removeRecordingRow: ($button) =>
       $row = $('.ig-row[data-id="' + $button.data("id") + '"]')

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -349,8 +349,7 @@ class ConferencesController < ApplicationController
 
   def recording
     if authorized_action(@conference, @current_user, :read)
-      recording = @conference.recordings.find{ |r| r[:recording_id] == params[:recording_id] }
-      @response = recording || {}
+      @response = @conference.recording(params[:recording_id]) || {}
       respond_to do |format|
         format.html { redirect_to named_context_url(@context, :context_conferences_url) }
         format.json { render :json => @response }

--- a/app/models/big_blue_button_conference.rb
+++ b/app/models/big_blue_button_conference.rb
@@ -87,15 +87,27 @@ class BigBlueButtonConference < WebConference
 
   def recordings
     fetch_recordings.map do |recording|
-      recording_format = recording.fetch(:playback, {}).fetch(:format, {})
-      {
-        recording_id:     recording[:recordID],
-        title:            recording[:name],
-        duration_minutes: recording_format[:length].to_i,
-        playback_url:     recording_format[:url],
-        ended_at:         recording[:endTime].to_i,
-      }
+      recording_formats(recording)
     end
+  end
+
+  def recording(recording_id = nil)
+    unless recording_id.nil?
+      recording = fetch_recordings.find{ |r| r[:recordID]==recording_id }
+      recording_formats(recording) if recording
+    end
+  end
+
+  def recording_formats(recording)
+    recording_formats = recording.fetch(:playback, [])
+    {
+      recording_id:     recording[:recordID],
+      title:            recording[:name],
+      duration_minutes: filter_duration(recording_formats),
+      playback_url:     nil,
+      playback_formats: recording_formats,
+      created_at:       recording[:startTime].to_i,
+    }
   end
 
   def delete_recording(recording_id)
@@ -206,7 +218,8 @@ class BigBlueButtonConference < WebConference
     # The BBB API follows the pattern where a plural element (ie <bars>)
     # contains many singular elements (ie <bar>) and nothing else. Detect this
     # and return an array to be assigned to the plural element.
-    elsif node.name.singularize == child_elements.first.name
+    # It excludes the playback node as all of them may be showing different content.
+    elsif node.name.singularize == child_elements.first.name || node.name == "playback"
       child_elements.map { |child| xml_to_value(child) }
     # otherwise, make a hash of the child elements
     else
@@ -214,6 +227,13 @@ class BigBlueButtonConference < WebConference
         hash[child.name.to_sym] = xml_to_value(child)
 
       end
+    end
+  end
+
+  def filter_duration(recording_formats)
+    # As not all the formats are the actual recording, identify the one that has :length
+    recording_formats.each do |recording_format|
+      return recording_format[:length].to_i if recording_format.key?(:length)
     end
   end
 end

--- a/app/models/web_conference.rb
+++ b/app/models/web_conference.rb
@@ -413,7 +413,7 @@ class WebConference < ActiveRecord::Base
     can :initiate and can :close
 
     given { |user, session| self.context.grants_all_rights?(user, session, :manage_content, :create_conferences) }
-    can :read and can :join and can :initiate and can :delete and can :close
+    can :read and can :join and can :initiate and can :delete and can :close and can :manage_recordings
 
     given { |user, session| context.grants_all_rights?(user, session, :manage_content, :create_conferences) && !finished? }
     can :update

--- a/app/views/jst/conferences/concludedConference.handlebars
+++ b/app/views/jst/conferences/concludedConference.handlebars
@@ -65,16 +65,29 @@
             <div class="ig-row__layout">
               <div class="ig-info">
                 <div class="ig-details">
-                  <a href="{{playback_url}}" target="_blank" class="ig-title"
-                    style="line-height: inherit;" data-id="{{recording_id}}" data-format="presentation">
-                    {{title}}
-                  </a>
+                  <span>{{title}}</span>
+                  &nbsp;&nbsp;&nbsp;
+                  {{#each playback_formats}}
+                    {{#if length}}
+                      <a href="{{url}}" target="_blank" class="ig-title"
+                        style="line-height: inherit;" data-id="{{../recording_id}}" data-format="presentation">
+                        {{#t "type"}}{{type}}{{/t}}
+                      </a>
+                    {{else}}
+                      {{#if ../../../permissions.manage_recordings}}
+                        <a href="{{url}}" target="_blank" class="ig-title"
+                          style="line-height: inherit;" data-id="{{../recording_id}}" data-format="presentation">
+                          {{#t "type"}}{{type}}{{/t}}
+                        </a>
+                      {{/if}}
+                    {{/if}}
+                  {{/each}}
                   {{dateString created_at}}
                   &nbsp;&#124;&nbsp;
                   {{durationToString duration_minutes}}
                 </div>
               </div>
-              {{#if ../permissions.delete}}
+              {{#if ../permissions.manage_recordings}}
                 <div class="ig-button" data-id="{{recording_id}}" data-action="delete" data-url="{{../../url}}">
                   <a href="#"
                       class="btn btn-small icon-trash delete_recording_link"

--- a/app/views/jst/conferences/newConference.handlebars
+++ b/app/views/jst/conferences/newConference.handlebars
@@ -99,16 +99,29 @@
             <div class="ig-row__layout">
               <div class="ig-info">
                 <div class="ig-details">
-                  <a href="{{playback_url}}" target="_blank" class="ig-title"
-                    style="line-height: inherit;" data-id="{{recording_id}}" data-format="presentation">
-                    {{title}}
-                  </a>
+                  <span>{{title}}</span>
+                  &nbsp;&nbsp;&nbsp;
+                  {{#each playback_formats}}
+                    {{#if length}}
+                      <a href="{{url}}" target="_blank" class="ig-title"
+                        style="line-height: inherit;" data-id="{{../recording_id}}" data-format="presentation">
+                        {{#t "type"}}{{type}}{{/t}}
+                      </a>
+                    {{else}}
+                      {{#if ../../../permissions.manage_recordings}}
+                        <a href="{{url}}" target="_blank" class="ig-title"
+                          style="line-height: inherit;" data-id="{{../recording_id}}" data-format="presentation">
+                          {{#t "type"}}{{type}}{{/t}}
+                        </a>
+                      {{/if}}
+                    {{/if}}
+                  {{/each}}
                   {{dateString created_at}}
                   &nbsp;&#124;&nbsp;
                   {{durationToString duration_minutes}}
                 </div>
               </div>
-              {{#if ../permissions.delete}}
+              {{#if ../permissions.manage_recordings}}
                 <div class="ig-button" data-id="{{recording_id}}" data-action="delete" data-url="{{../../url}}">
                   <a href="#"
                       class="btn btn-small icon-trash delete_recording_link"

--- a/spec/coffeescripts/views/conferences/ConferenceViewSpec.js
+++ b/spec/coffeescripts/views/conferences/ConferenceViewSpec.js
@@ -43,7 +43,8 @@ const conferenceView = function(conferenceOpts = {}) {
       read: true,
       resume: false,
       update: true,
-      edit: true
+      edit: true,
+      manage_recordings: true
     }
   })
   const app = new ConferenceView({model: conference})
@@ -101,28 +102,41 @@ test('deleteRecordings calls screenreader', function() {
     200,
     {'Content-Type': 'application/json'},
     JSON.stringify({
-      deleted: 'true',
+      deleted: true,
     })
   ])
-  this.spy($, 'screenReaderFlashMessage')
   const big_blue_button_conference = {
     id: 1,
     recordings: [
       {
-        duration_minutes: 0,
-        ended_at: 1518554650000,
-        playback_url: "www.blah.com",
         recording_id: "954cc3",
-        title: "Conference"
+        title: "Conference",
+        duration_minutes: 0,
+        playback_url: null,
+        playback_formats: [
+          {
+            type: "statistics",
+            url: "www.blah.com",
+            length: null
+          },
+          {
+            type: "presentation",
+            url: "www.blah.com",
+            length: 0
+          }
+        ],
+        created_at: 1518554650000,
       }
     ],
     user_settings: {
       record: true
     }
   }
-  conferenceView(big_blue_button_conference)
+  this.spy($, 'screenReaderFlashMessage')
+  const view = conferenceView(big_blue_button_conference)
   $('div.ig-button[data-id="954cc3"]').children('a').trigger($.Event( "click" ))
   server.respond()
   equal($.screenReaderFlashMessage.callCount, 1)
   server.restore()
+  ok(view)
 })

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_one.xml
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_one.xml
@@ -21,17 +21,27 @@
       </metadata>
       <playback>
         <format>
+          <type>statistics</type>
+          <url>https://bbb.blah.com/instructure/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/statistics/</url>
+          <length/>
+        </format>
+        <format>
           <type>presentation</type>
-          <url>http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014</url>
+          <url>https://bbb.blah.com/instructure/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/presentation/</url>
           <processingTime>9922</processingTime>
           <length>0</length>
           <preview>
             <images>
-              <image alt="Welcome to" height="136" width="176">http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511812307214/thumbnails/thumb-1.png</image>
-              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511812307214/thumbnails/thumb-2.png</image>
-              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511812307214/thumbnails/thumb-3.png</image>
+              <image alt="Welcome to" height="136" width="176">https://bbb.blah.com/instructure/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/presentation/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://bbb.blah.com/instructure/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/presentation/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://bbb.blah.com/instructure/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/presentation/thumbnails/thumb-3.png</image>
             </images>
           </preview>
+        </format>
+        <format>
+          <type>video</type>
+          <url>https://bbb.blah.com/instructure/0225ccf234655ae60658ccac1e272d48781b491c-1511812307014/capture/</url>
+          <length>0</length>
         </format>
       </playback>
     </recording>

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.json
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.json
@@ -13,13 +13,32 @@
       "metadata": {
         "isBreakout": "false"
       },
-      "playback": {
-        "format": {
-                    "type": "video",
-                    "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/capture/",
-                    "length": "0"
+      "playback":
+      [
+        {
+          "type": "statistics",
+          "url": "https://bbb.blah.com/instructure/ae094b1eb62b634c377fc255149de61a04ee8787-1521832370987/statistics/",
+          "length": null
+        },
+        {
+          "type": "presentation",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/",
+          "length": "0",
+          "preview": {
+            "images":
+            [
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/thumbnails/thumb-1.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/thumbnails/thumb-2.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/thumbnails/thumb-3.png"
+            ]
+          }
+        },
+        {
+          "type": "video",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/capture/",
+          "length": "0"
         }
-      }
+      ]
     },
     {
       "recordID": "18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256",
@@ -32,13 +51,32 @@
       "metadata": {
         "isBreakout": "false"
       },
-      "playback": {
-        "format": {
+      "playback":
+      [
+        {
+          "type": "statistics",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/statistics/",
+          "length": null
+        },
+        {
+          "type": "presentation",
+          "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/",
+          "length": "0",
+          "preview": {
+            "images":
+            [
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-1.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-2.png",
+              "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/thumbnails/thumb-3.png"
+            ]
+          }
+        },
+        {
           "type": "video",
           "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/capture/",
           "length": "0"
         }
-      }
+      ]
     }
   ]
 }

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.xml
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.xml
@@ -22,17 +22,27 @@
       </metadata>
       <playback>
         <format>
+          <type>statistics</type>
+          <url>https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/statistics/</url>
+          <length/>
+        </format>
+        <format>
           <type>presentation</type>
-          <url>http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982</url>
-          <processingTime>9590</processingTime>
+          <url>https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/presentation/</url>
+          <processingTime>9922</processingTime>
           <length>0</length>
           <preview>
             <images>
-              <image alt="Welcome to" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511807049008/thumbnails/thumb-1.png</image>
-              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511807049008/thumbnails/thumb-2.png</image>
-              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511807049008/thumbnails/thumb-3.png</image>
+              <image alt="Welcome to" height="136" width="176">https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/presentation/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/presentation/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/presentation/thumbnails/thumb-3.png</image>
             </images>
           </preview>
+        </format>
+        <format>
+          <type>video</type>
+          <url>https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511807048982/capture/</url>
+          <length>0</length>
         </format>
       </playback>
     </recording>
@@ -56,17 +66,27 @@
       </metadata>
       <playback>
         <format>
+          <type>statistics</type>
+          <url>https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/statistics/</url>
+          <length/>
+        </format>
+        <format>
           <type>presentation</type>
-          <url>http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509</url>
-          <processingTime>35788</processingTime>
-          <length>26</length>
+          <url>https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/presentation/</url>
+          <processingTime>9922</processingTime>
+          <length>0</length>
           <preview>
             <images>
-              <image alt="Welcome to" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511809970514/thumbnails/thumb-1.png</image>
-              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511809970514/thumbnails/thumb-2.png</image>
-              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">http://bbb.blah.com/mock/playback/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1511809970514/thumbnails/thumb-3.png</image>
+              <image alt="Welcome to" height="136" width="176">https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/presentation/thumbnails/thumb-1.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/presentation/thumbnails/thumb-2.png</image>
+              <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/presentation/thumbnails/thumb-3.png</image>
             </images>
           </preview>
+        </format>
+        <format>
+          <type>video</type>
+          <url>https://bbb.blah.com/instructure/0858103f804f6e06b6de665dab79584b22c7cf91-1511809970509/capture/</url>
+          <length>0</length>
         </format>
       </playback>
     </recording>

--- a/spec/selenium/helpers/conferences_common.rb
+++ b/spec/selenium/helpers/conferences_common.rb
@@ -90,6 +90,14 @@ module ConferencesCommon
     expect(first_conference_in_list(new_conference_list)).not_to include_text 'Recording'
   end
 
+  def verify_conference_includes_recordings_with_statistics
+    expect(first_conference_in_list(new_conference_list)).to include_text 'statistics'
+  end
+
+  def verify_conference_does_not_include_recordings_with_statistics
+    expect(first_conference_in_list(new_conference_list)).not_to include_text 'statistics'
+  end
+
   def initialize_wimba_conference_plugin
     PluginSetting.create!(
       name: 'wimba',


### PR DESCRIPTION
This PR replaces #1176

BBB feature recording multiple formats

Summary:
Multiple recording formats can be shown as links in the recording list 

Description:
BBB has the ability to deliver multiple recording formats as part of its
recording meta descriptor. Examples of these are [video], [presentation]
and the recently implemented (by some BBB instances) [statistics].

![image](https://user-images.githubusercontent.com/578359/38337015-d0806f50-3831-11e8-8df5-ad4afe73e79e.png)

This commit includes:
* Implemented multiple formats for conference recordings
* Completed multiple formats for conference recordings
* Fixed issue with recording date/time not shown correctly
* Added multiple formats to the mockup files
* Test presence of statistics with selenium
* Fixed coffescript spec
* Fixed filter for recording formats with length=nil
* Added selenium test for students
* Fixed bbb url and secret in order to make evident that they are
  mocked up values
* Fixed issue with links not being properly shown in Firefox

Test Plan:
https://youtu.be/1rsZfDNDgco

- As Instructor create a big_blue_button conference. Set it up as recorded
- Start the conference and record the session
- Logout from the session with option for ending on exit
- Go back to Conferences, wait for a few minutes and refresh the page.
- When the recording shows, expand the row. Link for statistics and video-
  formats should be shown
- As Student go to Conferences. Expand the recording. Only video format
  should be shown 

Development ID: [blindsidenetworks#24
](https://github.com/blindsidenetworks/canvas-lms/issues/24)

refs: COMMS-1035, GH-1270

Change-Id: I2950d8f22d46dadfd16c0517f4abb5b68ba44eaa
