### PR TITLE
canvas.docker is a development only hostname

### DIFF
--- a/doc/api/tools_variable_substitutions.head.md
+++ b/doc/api/tools_variable_substitutions.head.md
@@ -70,7 +70,7 @@ curl 'https://<domain>.instructure.com/api/v1/courses/<course_id>/external_tools
 ```
 
 ## Via XML Configuration
-Custom fields can also be <a href="http://canvas.docker/doc/api/file.tools_xml.html">configured via XML</a>.
+Custom fields can also be <a href="/doc/api/file.tools_xml.html">configured via XML</a>.
 
 This would create a tool in a course with custom fields, some of which are specific for a
 particular placement:


### PR DESCRIPTION
When the documentation is published to http://api.instructure.com/ the link to http://canvas.docker isn't valid, making it host relative means it works in both places.