### PR TITLE
Docker package renamed

### DIFF
--- a/script/docker_dev_setup.sh
+++ b/script/docker_dev_setup.sh
@@ -41,7 +41,7 @@ if [[ $OS == 'Darwin' ]]; then
   dependencies='docker docker-machine docker-compose dinghy'
 elif [[ $OS == 'Linux' ]]; then
   install='sudo apt-get update && sudo apt-get install -y'
-  dependencies='docker docker-compose'
+  dependencies='docker-ce docker-compose'
 else
   echo 'This script only supports MacOS and Linux :('
   exit 1

--- a/script/docker_dev_setup.sh
+++ b/script/docker_dev_setup.sh
@@ -41,7 +41,7 @@ if [[ $OS == 'Darwin' ]]; then
   dependencies='docker docker-machine docker-compose dinghy'
 elif [[ $OS == 'Linux' ]]; then
   install='sudo apt-get update && sudo apt-get install -y'
-  dependencies='docker-ce docker-compose'
+  dependencies='docker-ce'
 else
   echo 'This script only supports MacOS and Linux :('
   exit 1

--- a/script/docker_dev_setup.sh
+++ b/script/docker_dev_setup.sh
@@ -41,7 +41,7 @@ if [[ $OS == 'Darwin' ]]; then
   dependencies='docker docker-machine docker-compose dinghy'
 elif [[ $OS == 'Linux' ]]; then
   install='sudo apt-get update && sudo apt-get install -y'
-  dependencies='docker-ce'
+  dependencies='docker.io'
 else
   echo 'This script only supports MacOS and Linux :('
   exit 1


### PR DESCRIPTION
Docker's package has been renamed to docker-ce. This commit reflects that rename and unbreaks it on Ubuntu 16.04 LTS