### PR TITLE
Fix bad formatting in documentation for `show`

### DIFF
--- a/app/controllers/assignments_api_controller.rb
+++ b/app/controllers/assignments_api_controller.rb
@@ -745,7 +745,7 @@ class AssignmentsApiController < ApplicationController
   # @argument include[] [String, "submission"|"assignment_visibility"|"overrides"|"observed_users"]
   #   Associations to include with the assignment. The "assignment_visibility" option
   #   requires that the Differentiated Assignments course feature be turned on. If
-  #  "observed_users" is passed, submissions for observed users will also be included.
+  #   "observed_users" is passed, submissions for observed users will also be included.
   # @argument override_assignment_dates [Boolean]
   #   Apply assignment overrides to the assignment, defaults to true.
   # @argument needs_grading_count_by_section [Boolean]


### PR DESCRIPTION
The include[] query parameter's markup was improperly formatted, causing part of the description to appear in the wrong part of the documentation.