### PR TITLE
BBB: Fix for issue with recording duration always shown as '1 minute'

### DIFF
--- a/app/models/big_blue_button_conference.rb
+++ b/app/models/big_blue_button_conference.rb
@@ -238,9 +238,10 @@ class BigBlueButtonConference < WebConference
   end
 
   def filter_duration(recording_formats)
-    # As not all the formats are the actual recording, identify the one that has :length
+    # This is a filter to take the duration from any of the playback formats that include a value in length.
+    # As not all the formats are the actual recording, identify the first one that has :length <> nil
     recording_formats.each do |recording_format|
-      return recording_format[:length].to_i if recording_format.key?(:length)
+      return recording_format[:length].to_i if recording_format[:length].present?
     end
   end
 end

--- a/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.json
+++ b/spec/fixtures/files/conferences/big_blue_button_get_recordings_two.json
@@ -23,7 +23,7 @@
         {
           "type": "presentation",
           "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/presentation/",
-          "length": "0",
+          "length": "2",
           "preview": {
             "images":
             [
@@ -36,7 +36,7 @@
         {
           "type": "video",
           "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031612456/capture/",
-          "length": "0"
+          "length": "2"
         }
       ]
     },
@@ -61,7 +61,7 @@
         {
           "type": "presentation",
           "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/presentation/",
-          "length": "0",
+          "length": "2",
           "preview": {
             "images":
             [
@@ -74,7 +74,7 @@
         {
           "type": "video",
           "url": "https://bbb.blah.com/instructure/18974fe54920ac60ba913e34f49e4a9dabfeea2c-1513031142256/capture/",
-          "length": "0"
+          "length": "2"
         }
       ]
     }

--- a/spec/models/big_blue_button_conference_spec.rb
+++ b/spec/models/big_blue_button_conference_spec.rb
@@ -116,6 +116,11 @@ describe BigBlueButtonConference do
           :recording_enabled => true,
         })
       ])
+      @bbb = BigBlueButtonConference.new
+      @bbb.user_settings = { :record => true }
+      @bbb.user = user_factory
+      @bbb.context = course_factory
+      @bbb.save!
     end
 
     it "should have visible record user_setting" do
@@ -123,50 +128,39 @@ describe BigBlueButtonConference do
     end
 
     it "should send record flag if record user_setting is set" do
-      bbb = BigBlueButtonConference.new
-      bbb.user_settings = { :record => true }
-      bbb.user = user_factory
-      bbb.context = course_factory
-      bbb.save!
-      expect(bbb).to receive(:send_request).with(:create, hash_including(record: "true"))
-      bbb.initiate_conference
+      expect(@bbb).to receive(:send_request).with(:create, hash_including(record: "true"))
+      @bbb.initiate_conference
     end
 
     it "should not send record flag if record user setting is unset" do
-      bbb = BigBlueButtonConference.new
-      bbb.user_settings = { :record => false }
-      bbb.user = user_factory
-      bbb.context = course_factory
-      bbb.save!
-      expect(bbb).to receive(:send_request).with(:create, hash_including(record: "false"))
-      bbb.initiate_conference
+      @bbb.user_settings = { :record => false }
+      @bbb.save!
+      expect(@bbb).to receive(:send_request).with(:create, hash_including(record: "false"))
+      @bbb.initiate_conference
     end
 
     it "should properly serialize a response with no recordings" do
-      bbb = BigBlueButtonConference.new
-      allow(bbb).to receive(:conference_key).and_return('12345')
-      bbb.user_settings = { record: true }
-      bbb.user = user_factory
-      bbb.context = course_factory
-      bbb.save!
+      allow(@bbb).to receive(:conference_key).and_return('12345')
       response = {returncode: 'SUCCESS', recordings: "\n  ",
                   messageKey: 'noRecordings', message: 'There are no recordings for the meeting(s).'}
-      allow(bbb).to receive(:send_request).and_return(response)
-      recordings = bbb.recordings
-      expect(recordings).to eq []
+      allow(@bbb).to receive(:send_request).and_return(response)
+      expect(@bbb.recordings).to eq []
     end
 
     it "should properly serialize a response with recordings" do
-      bbb = BigBlueButtonConference.new
-      allow(bbb).to receive(:conference_key).and_return('12345')
-      bbb.user_settings = { record: true }
-      bbb.user = user_factory
-      bbb.context = course_factory
-      bbb.save!
+      allow(@bbb).to receive(:conference_key).and_return('12345')
       response = JSON.parse(get_recordings_fixture, {symbolize_names: true})
-      allow(bbb).to receive(:send_request).and_return(response)
-      recordings = bbb.recordings
-      expect(recordings).not_to eq []
+      allow(@bbb).to receive(:send_request).and_return(response)
+      expect(@bbb.recordings).not_to eq []
+    end
+
+    it "should not have duration_minutes set to 0" do
+      allow(@bbb).to receive(:conference_key).and_return('12345')
+      response = JSON.parse(get_recordings_fixture, {symbolize_names: true})
+      allow(@bbb).to receive(:send_request).and_return(response)
+      @bbb.recordings.each do |recording|
+        expect(recording[:duration_minutes]).not_to eq(0)
+      end
     end
 
     describe "looking for recordings based on user setting" do


### PR DESCRIPTION
### Summary:
Recording duration is not correctly displayed when statistics are enabled. This is because the condition that filters the playback format used as a reference is incorrect.

### Test Plan:
1. Configure the BBB server to be used by the Plugin. Make sure the recordings are enabled.
2. Go to the Course/Conferences
3. Create a Conference. Enable recordings. Save
4. Start the conference. This will send you to BBB. Start the recording and keep it open for more than 2 minutes.
5. Logout from BBB ending the meeting.
6. Go back to Canvas conferences
7. Wait for a few minutes until the recording is processed. You can refresh the page to see if the result has come trough.
8. Once the recording is shown, expand the recording and verify the duration. It should say "Duration: 2 minutes" (or 3 minutes if you recorded more than 2 mins 30 secs)

### Expected behavior:
As the seconds are rounded, the normal behaviour would be to show:

"1 minute"  when the session lasted from 0 seconds to 1 minute with 30 seconds.
"n minutes" whhen the meeting lasted from 1 minute 31 secs to 59 minutes 30 seconds
"m hours n minutes" when the meeting lasted more than 59 minutes and 31 seconds

### Development ID:
https://github.com/blindsidenetworks/canvas-lms/issues/30





