### PR TITLE
I18n support for 'Update your notification' in email

### DIFF
--- a/app/messages/_layout.email.html.erb
+++ b/app/messages/_layout.email.html.erb
@@ -95,7 +95,7 @@ Margin is capitalized to fix Outlook.com
                 <%= content(:footer_link).html_safe %> &nbsp;|&nbsp;
               <% end %>
 
-              <a href="<%= communication_profile_url %>" style="white-space: nowrap;"><%= t 'click_to_preferences', "Update your notification settings" %></a>
+              <a href="<%= communication_profile_url %>" style="white-space: nowrap;"><%=t "Update your notification settings" %></a>
 
             </td>
           </tr>


### PR DESCRIPTION
**Summary:**
In all email notifications, the text of link 'communication_profile_url' always displayed in English. No matter whether a translated message is provided in locale files.

**Steps to reproduce:**
1. Select an user with email address set. Change the language preference of this user to a language which is not English( Simplified Chinese, aka '简体中文' for example)
2. Trigger a action to send an email to this user.
3. In the bottom of the notification email, 'Update your notification settings' shows in English. Although it has already been properly translated in locale files (messages.layout.email.html.click_to_preference).

**Expected behavior**
 'Update your notification settings' should replaced, according to locale files.
