### PR TITLE
add data-attributes for syllabus assignments summary

### DIFF
--- a/app/coffeescripts/views/courses/SyllabusView.coffee
+++ b/app/coffeescripts/views/courses/SyllabusView.coffee
@@ -156,6 +156,7 @@ define [
           'last': true
           'override': override
           'json': json
+          'workflow_state': json['workflow_state']
 
         lastDate['events'].push lastEvent
 

--- a/app/views/assignments/_syllabus_content.html.erb
+++ b/app/views/assignments/_syllabus_content.html.erb
@@ -63,7 +63,7 @@ DOC
   </div>
 <% end %>
 
-<h2><%= before_label :assignments_summary, "Course Summary" %></h2>
+<h2 data-course-summary="h2"><%= before_label :assignments_summary, "Course Summary" %></h2>
 
 <div id="syllabusContainer">
   <div id="syllabus_links">

--- a/app/views/assignments/_syllabus_content.html.erb
+++ b/app/views/assignments/_syllabus_content.html.erb
@@ -63,7 +63,7 @@ DOC
   </div>
 <% end %>
 
-<h2 data-course-summary="h2"><%= before_label :assignments_summary, "Course Summary" %></h2>
+<h2><%= before_label :assignments_summary, "Course Summary" %></h2>
 
 <div id="syllabusContainer">
   <div id="syllabus_links">

--- a/app/views/jst/courses/Syllabus.handlebars
+++ b/app/views/jst/courses/Syllabus.handlebars
@@ -29,7 +29,7 @@
       <td class="details">
         <table class="detail_list">
           {{#each events}}
-          <tr class="syllabus_{{type}} related-{{related_id}}{{#if override}} special_date{{/if}}">
+          <tr class="syllabus_{{type}} related-{{related_id}}{{#if override}} special_date{{/if}}" data-workflow-state="{{workflow_state}}">
             <td class="icon" aria-hidden="true">
               {{#ifEqual type 'assignment'}}
                 {{addIcon 'assignment'}}


### PR DESCRIPTION
...and syllabus assignment TR workflow state.

I would like to add an attribute to assignment rows with the workflow-state of the assignment. There currently seems to be no distinction between published/unpublished assignments. Instructors are unable to determine the difference. Adding the `data-workflow-state` attribute would allow styling at a minimum. see https://community.canvaslms.com/thread/8283#comment-117711

Tested with CSS after updating and running source locally.
```css
table#syllabus tr[data-workflow-state="unpublished"] td a {
    font-weight: bold;
}
```