### PR TITLE
Add ability to filter new gradebook by SIS ID

### DIFF
--- a/app/coffeescripts/gradezilla/Gradebook.coffee
+++ b/app/coffeescripts/gradezilla/Gradebook.coffee
@@ -846,7 +846,7 @@ define [
     rowFilter: (student) =>
       return true unless @isFilteringRowsBySearchTerm()
 
-      propertiesToMatch = ['name', 'login_id', 'short_name', 'sortable_name']
+      propertiesToMatch = ['name', 'login_id', 'short_name', 'sortable_name', 'sis_user_id']
       pattern = new RegExp(@userFilterTerm, 'i')
       _.any propertiesToMatch, (prop) ->
         student[prop]?.match pattern

--- a/spec/javascripts/jsx/gradezilla/GradebookSpec.js
+++ b/spec/javascripts/jsx/gradezilla/GradebookSpec.js
@@ -1478,7 +1478,8 @@ QUnit.module('Gradebook#rowFilter', {
       login_id: 'charlie.xi@example.com',
       name: 'Charlie Xi',
       short_name: 'Chuck Xi',
-      sortable_name: 'Xi, Charlie'
+      sortable_name: 'Xi, Charlie',
+      sis_user_id: '123456789'
     };
   }
 });
@@ -1500,6 +1501,12 @@ test('returns true when search term matches the student short name', function ()
 
 test('returns true when search term matches the student sortable name', function () {
   this.gradebook.userFilterTerm = 'Xi, Charlie';
+  strictEqual(this.gradebook.rowFilter(this.student), true);
+});
+
+
+test('returns true when search term matches the student sis id', function () {
+  this.gradebook.userFilterTerm = '123456789';
   strictEqual(this.gradebook.rowFilter(this.student), true);
 });
 


### PR DESCRIPTION
This PR adds the ability for an instructor to filter the new Gradebook by a user's SIS ID.

Test Plan:
1. Enable the new Gradebook
1. Create a course
1. Add students that have a SIS ID (`sis_user_id`)
1. Publish the course
1. Enter a user's SIS ID into the search field

The gradebook should be filtered by the value entered in the search field (e.g. the SIS ID).
