### PR TITLE
add missing rubric scopes

### DIFF
--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -16,6 +16,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+# @API Rubrics
 class RubricsController < ApplicationController
   before_action :require_context
   before_action { |c| c.active_tab = "rubrics" }


### PR DESCRIPTION
The missing @API tag caused the RubricsController to be missing from the yard `options[:objects]` which are [transformed](https://github.com/instructure/canvas-lms/blob/master/doc/api/fulldoc/html/setup.rb#L159) into the resources which are handed to the ApiScopeMappingWriter.

Since the ApiScopeMappingWriter didn't look at the actions provided in the RubricsController, the scopes weren't written to lib/api_scope_mapper.rb which means that they can't be enabled in
the developer keys.

closes gh-1341

Test Plan:
    - Run either `rails doc:api` or `rails canvas:compile_assets`
    - Make sure the feature option  Developer key management and scoping is enabled in your top level account
    - Go the the admin of your top level account
    - Create a new developer key
    - Enable enforce scopes
    - See if the url:POST|/api/v1/courses/:course_id/rubrics and url:PUT|/api/v1/courses/:course_id/rubrics/:id scopes are present under the rubrics expander