### PR TITLE
Support LTI Request for Page Information

### DIFF
--- a/public/javascripts/lti/messages.js
+++ b/public/javascripts/lti/messages.js
@@ -74,6 +74,18 @@ export function ltiMessageHandler(e) {
       }
       break;
 
+      case 'lti.fetchWindowSize':
+          const iframe = findDomForWindow(e.source);
+          if (iframe) {
+              message.height = window.innerHeight;
+              message.width = window.innerWidth;
+              message.offset = $('.tool_content_wrapper').offset();
+              var strMessage = JSON.stringify(message);
+
+              iframe.contentWindow.postMessage(strMessage, '*');
+          }
+        break;
+
       case 'lti.showModuleNavigation':
         if(message.show === true || message.show === false){
           $('.module-sequence-footer').toggle(message.show);

--- a/public/javascripts/lti/messages.js
+++ b/public/javascripts/lti/messages.js
@@ -80,7 +80,7 @@ export function ltiMessageHandler(e) {
               message.height = window.innerHeight;
               message.width = window.innerWidth;
               message.offset = $('.tool_content_wrapper').offset();
-              let strMessage = JSON.stringify(message);
+              const strMessage = JSON.stringify(message);
 
               iframe.contentWindow.postMessage(strMessage, '*');
           }

--- a/public/javascripts/lti/messages.js
+++ b/public/javascripts/lti/messages.js
@@ -74,17 +74,18 @@ export function ltiMessageHandler(e) {
       }
       break;
 
-      case 'lti.fetchWindowSize':
+      case 'lti.fetchWindowSize': {
           const iframe = findDomForWindow(e.source);
           if (iframe) {
               message.height = window.innerHeight;
               message.width = window.innerWidth;
               message.offset = $('.tool_content_wrapper').offset();
-              var strMessage = JSON.stringify(message);
+              let strMessage = JSON.stringify(message);
 
               iframe.contentWindow.postMessage(strMessage, '*');
           }
-        break;
+          break;
+      }
 
       case 'lti.showModuleNavigation':
         if(message.show === true || message.show === false){

--- a/spec/javascripts/jsx/lti/messagesSpec.js
+++ b/spec/javascripts/jsx/lti/messagesSpec.js
@@ -31,6 +31,10 @@ const resizeMessage = {
   height: finalHeight
 }
 
+const fetchWindowSize = {
+  subject: 'lti.fetchWindowSize'
+}
+
 const scrollMessage = {
   subject: 'lti.scrollToTop'
 }
@@ -107,6 +111,21 @@ QUnit.module('Messages', function (suiteHooks) {
     equal(iframe.height(), 100)
     ltiMessageHandler(postMessageEvent(resizeMessage, iframe[0].contentWindow));
     equal(iframe.height(), finalHeight)
+  })
+
+  test('returns the hight and width of the page along with the iframe offset', () => {
+    ltiToolWrapperFixture.append(`
+      <div>
+        <h1 class="page-title">LTI resize test</h1>
+        <p><iframe style="width: 100%; height: ${intialHeight}px;" src="https://canvas.example.com/courses/4/external_tools/retrieve?display=borderless" width="100%" height="${intialHeight}px" allowfullscreen="allowfullscreen" webkitallowfullscreen="webkitallowfullscreen" mozallowfullscreen="mozallowfullscreen"></iframe></p>
+      </div>
+    `)
+    const iframe = $('iframe')
+
+    sinon.spy(iframe[0].contentWindow, 'postMessage')
+    notOk(iframe[0].contentWindow.postMessage.calledOnce)
+    ltiMessageHandler(postMessageEvent(fetchWindowSize, iframe[0].contentWindow))
+    ok(iframe[0].contentWindow.postMessage.calledOnce)
   })
 
   test('hides the module navigation', () => {


### PR DESCRIPTION
# Description

@notebowl is attempting to make the LTI interface more seamless. One of the things that would help a lot is to know the total width and height of the window along with the iFrame's offset. This will help us best display & scale our own elements inside of the iFrame.

## Usage

From the iFrame:
```
// Setup listener to grab response
window.addEventListener('message', function(e) {
    var message = JSON.parse(e.data);
    if(message.subject === 'lti.fetchWindowSize') {
        console.log(message.height);
        console.log(message.width);
        console.log(message.offset);
    }
});

// Ask parent window for the information to be sent to the page event listener
message = {'subject': 'lti.fetchWindowSize'};
window.parent.postMessage(JSON.stringify(message), '*');
```