### PR TITLE
Updating Live Events (Canvas Raw) Documentation

### DIFF
--- a/doc/api/live_events.md
+++ b/doc/api/live_events.md
@@ -16,41 +16,53 @@ The currently supported queue is <a href="https://aws.amazon.com/sqs/">Amazon SQ
 Live Events is currently an invite-only, experimental feature.
 
 
-### Event Format
+Additional Documentation can be viewed at
+[Live Events Services Table of Contents](https://community.canvaslms.com/docs/DOC-15740-live-events-services-table-of-contents)
+
+
+### Live Events - Canvas Raw Format
+
+The events, fields, and data in this document are specific to the Canvas Raw format.
+
+[See Caliper v1.1 formatted events here](https://canvas.instructure.com/doc/api/file.caliper_live_events.html)
 
 #### Event Attributes
 
-Events are delivered with attributes and a body. The attributes are:
+Events are delivered with attributes and a message. The attributes are:
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
-| `event_name` | String | The name of the event. | `create_discussion_topic` |
+| `event_name` | String | The name of the event. | `submission_created`, `asset_accessed` |
 | `event_time` | String.timestamp | The time, in ISO 8601 format. | `2015-03-18T15:15:54Z` |
 
-#### Body (metadata)
 
-The body is a JSON-formatted string with two keys: `metadata` and `data`.
+#### Message (Metadata)
+
+The message is a JSON-formatted string with two keys: `metadata` and `body`.
 `metadata` will be any or all of the following keys and values, if the
 event originated as part of a web request:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `user_id`    | String | The Canvas id of the currently logged in user. |
-| `real_user_id` | String | If the current user is being masqueraded, this is the Canvas id of the masquerading user. |
-| `user_login` | String | The login of the current user. |
-| `user_agent` | String | The User-Agent sent by the browser making the request. |
-| `root_account_uuid` | String | The Canvas uuid of the root account associated with the current user. |
-| `root_account_id` | String | The Canvas id of the root account associated with the current user. |
-| `root_account_lti_guid` | String | The Canvas lti_guid of the root account associated with the current user. |
-| `context_type` | String | The type of context where the event happened. |
 | `context_id` | String | The Canvas id of the current context. Always use the `context_type` when using this id to lookup the object. |
-| `role` | String | The role of the current user in the current context.  |
+| `context_role` | String | The role of the current user in the current context.  |
+| `context_type` | String | The type of context where the event happened. |
+| `event_name` | String | The name of the event. |
+| `event_time` | String.timestamp | The time, in ISO 8601 format. |
 | `hostname` | String | The hostname of the current request |
 | `producer` | String | The name of the producer of an event. Will always be 'canvas' when an event is originating in canvas. |
+| `real_user_id` | String | If the current user is being masqueraded, this is the Canvas id of the masquerading user. |
 | `request_id` | String | The identifier for this request. |
+| `root_account_id` | String | The Canvas id of the root account associated with the current user. |
+| `root_account_lti_guid` | String | The Canvas lti_guid of the root account associated with the current user. |
+| `root_account_uuid` | String | The Canvas uuid of the root account associated with the current user. |
 | `session_id` | String | The session identifier for this request. Can be used to correlate events in the same session for a user. |
 | `user_account_id` | String | The Canvas id of the account that the current user belongs to. |
+| `user_agent` | String | The User-Agent sent by the browser making the request. |
+| `user_id`    | String | The Canvas id of the currently logged in user. |
+| `user_login` | String | The login of the current user. |
 | `user_sis_id` | String | The SIS id of the user. |
+
 
 For events originating as part of an asynchronous job, the following
 fields may be set:
@@ -63,215 +75,33 @@ fields may be set:
 | `root_account_id` | String | The Canvas id of the root account associated with the context of the job. |
 | `root_account_lti_guid` | String | The Canvas lti_guid of the root account associated with the context of the job. |
 
-#### Body (data)
+
+#### Message (Body)
 
 The `body` object will have key/value pairs with information specific to
 each event, as described below.
 
-Note: All Canvas ids are "global" identifiers, returned as strings.
-
-
-### Supported Events
-
 Note that the actual bodies of events may include more fields than
 what's described in this document. Those fields are subject to change.
 
+For more message payload examples see
+https://community.canvaslms.com/docs/DOC-15741-event-type-by-format
 
-#### `course_created`
+Note: All Canvas ids are "global" identifiers, returned as strings.
+However, some context_id's sent in the body of the message will be the local id.
 
-| Field | Description |
-| ----- | ----------- |
-| `course_id` | The Canvas id of the created course. |
-| `uuid` | The unique id of the course. |
-| `account_id` | The Account id of the created course. |
-| `name` | The name the created course. |
-| `created_at` | The time at which this course was created. |
-| `updated_at` | The time at which this course was last modified in any way. |
-| `workflow_state` | The state of the course. |
+### Supported Events
 
-#### `course_updated`
+#### `account_notification_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `course_id` | The Canvas id of the updated course. |
-| `account_id` | The Account id of the updated course. |
-| `name` | The name the updated course. |
-| `created_at` | The time at which this course was created. |
-| `updated_at` | The time at which this course was last modified in any way. |
-| `workflow_state` | The state of the course. |
-
-
-#### `syllabus_updated`
-
-| Field | Description |
-| ----- | ----------- |
-| `course_id` | The Canvas id of the updated course. |
-| `syllabus_body` | The new syllabus content (possibly truncated). |
-| `old_syllabus_body` | The old syllabus content (possibly truncated). |
-
-
-#### `discussion_entry_created`
-
-| Field | Description |
-| ----- | ----------- |
-| `discussion_entry_id` | The Canvas id of the newly added entry. |
-| `parent_discussion_entry_id` | If this was a reply, the Canvas id of the parent entry. |
-| `parent_discussion_entry_author_id` | If this was a reply, the Canvas id of the parent entry author. |
-| `discussion_topic_id` | The Canvas id of the topic the entry was added to. |
-| `text` | The (possibly truncated) text of the post. |
-
-
-#### `discussion_topic_created`
-
-| Field | Description |
-| ----- | ----------- |
-| `discussion_topic_id` | The Canvas id of the new discussion topic. |
-| `is_announcement` | `true` if this topic was posted as an announcement, `false` otherwise. |
-| `title` | Title of the topic (possibly truncated). |
-| `body` | Body of the topic (possibly truncated). |
-
-
-#### `group_category_created`
-
-| Field | Description |
-| ----- | ----------- |
-| `group_category_id` | The Canvas id of the newly created group category. |
-| `group_category_name` | The name of the newly created group category. |
-
-
-#### `group_created`
-
-| Field | Description |
-| ----- | ----------- |
-| `group_id` | The Canvas id of the group. |
-| `uuid` | The unique id of the group. |
-| `group_name` | The name of the group. |
-| `group_category_id` | The Canvas id of the group category. |
-| `group_category_name` | The name of the group category. |
-| `context_type` | The type of the group's context ('Account' or 'Course'). |
-| `context_id` | The Canvas id of the group's context. |
-| `account_id` | The Canvas id of the group's account. |
-| `workflow_state` | The state of the group. |
-
-
-#### `group_updated`
-
-| Field | Description |
-| ----- | ----------- |
-| `group_id` | The Canvas id of the group. |
-| `group_name` | The name of the group. |
-| `group_category_id` | The Canvas id of the group category. |
-| `group_category_name` | The name of the group category. |
-| `context_type` | The type of the group's context ('Account' or 'Course'). |
-| `context_id` | The Canvas id of the group's context. |
-| `account_id` | The Canvas id of the group's account. |
-| `workflow_state` | The state of the group. |
-
-
-#### `group_membership_created`
-
-Note: Only manual group assignments are currently sent. Groups where
-people are automatically assigned to groups will not send `group_assign`
-events.
-
-| Field | Description |
-| ----- | ----------- |
-| `group_membership_id` | The Canvas id of the group membership. |
-| `user_id` | The Canvas id of the user being assigned to a group. |
-| `group_id` | The Canvas id of the group the user is assigned to. |
-| `group_name` | The name of the group the user is being assigned to. |
-| `group_category_id` | The Canvas id of the group category. |
-| `group_category_name` | The name of the group category. |
-| `workflow_state` | The state of the group membership. |
-
-
-#### `group_membership_updated`
-
-| Field | Description |
-| ----- | ----------- |
-| `group_membership_id` | The Canvas id of the group membership. |
-| `user_id` | The Canvas id of the user assigned to a group. |
-| `group_id` | The Canvas id of the group the user is assigned to. |
-| `group_name` | The name of the group the user is assigned to. |
-| `group_category_id` | The Canvas id of the group category. |
-| `group_category_name` | The name of the group category. |
-| `workflow_state` | The state of the group membership. |
-
-
-#### `logged_in`
-
-| Field | Description |
-| ----- | ----------- |
-| `redirect_url` | The URL the user was redirected to after logging in. Is set when the user logs in after clicking a deep link into Canvas. |
-
-
-#### `logged_out`
-
-No extra data.
-
-
-#### `quiz_submitted`
-
-| Field | Description |
-| ----- | ----------- |
-| `submission_id` | The Canvas id of the quiz submission. |
-| `quiz_id` | The Canvas id of the quiz. |
-
-
-#### `grade_change`
-
-`grade_change` events are posted every time a grade changes. These can
-happen as the result of a teacher changing a grade in the gradebook or
-speedgrader, a quiz being automatically scored, or changing an assignment's
-points possible or grade type. In the case of a quiz being scored, the
-`grade_change` event will be fired as the result of a student turning in a
-quiz, and the `user_id` in the message attributes will be of the student. In
-these cases, `grader_id` should be null in the body.
-
-| Field | Description |
-| ----- | ----------- |
-| `submission_id` | The Canvas id of the submission that the grade is changing on. |
-| `assignment_id` | The Canvas id of the assignment associated with the submission. |
-| `grade` | The new grade. |
-| `old_grade` | The previous grade, if there was one. |
-| `score` | The new score. |
-| `old_score` | The previous score. |
-| `points_possible` | The maximum points possible for the submission's assignment. |
-| `old_points_possible` | The maximum points possible for the previous grade. |
-| `grader_id` | The Canvas id of the user making the grade change. Null if this was the result of automatic grading. |
-| `user_id` | The Canvas id of the user associated with the submission with the change. |
-| `muted` | The boolean muted state of the submissions's assignment.  Muted grade changes
-should not be published to students. |
-| `grading_complete` | The boolean state that the submission is completely graded.  False
-if the assignment is only partially graded, for example a quiz with automatically and manually
-graded sections. Incomplete grade changes should not be published to students. |
-
-#### `wiki_page_created`
-
-| Field | Description |
-| ----- | ----------- |
-| `wiki_page_id` | The Canvas id of the new wiki page. |
-| `title` | The title of the new page (possibly truncated). |
-| `body` | The body of the new page (possibly truncated). |
-
-
-#### `wiki_page_updated`
-
-| Field | Description |
-| ----- | ----------- |
-| `wiki_page_id` | The Canvas id of the changed wiki page. |
-| `title` | The new title (possibly truncated). |
-| `old_title` | The old title (possibly truncated). |
-| `body` | The new page body (possibly truncated). |
-| `old_body` | The old page body (possibly truncated). |
-
-
-#### `wiki_page_deleted`
-
-| Field | Description |
-| ----- | ----------- |
-| `wiki_page_id` | The Canvas id of the delete wiki page. |
-| `title` | The title of the deleted wiki page (possibly truncated). |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `account_notification_id` | bigint | The Canvas id of the account notification. |
+| `subject` | varchar | The subject of the notification. |
+| `message` | varchar | The message to be sent in the notification. |
+| `icon` | varchar | The icon to display with the message. Defaults to warning. |
+| `start_at` | datetime | When to send out the notification. |
+| `end_at` | datetime | When to expire the notification. |
 
 
 #### `asset_accessed`
@@ -288,81 +118,478 @@ If `asset_subtype` is not set, then the access is on the asset described
 by `asset_type` and `asset_id`.
 
 
-| Field | Description |
-| ----- | ----------- |
-| `asset_type` | The type of asset being accessed. |
-| `asset_id` | The Canvas id of the asset. |
-| `asset_subtype` | See above. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `asset_id` | bigint | The Canvas id of the asset. |
+| `asset_type` | varchar | The type of asset being accessed. |
+| `asset_subtype` | varchar | See above. |
+| `category` | varchar | Basically nagivation routes like Announcements, Assignments, Calendar, Pages, Quizzes, Roster, Syllabus |
+| `level` | varchar | eventfielddescription |
+| `role` | varchar | The role of the user accessing the asset. |
 
 
 #### `assignment_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `assignment_id` | The Canvas id of the new assignment. |
-| `title` | The title of the assignment (possibly truncated). |
-| `description` | The description of the assignment (possibly truncated). |
-| `due_at` | The due date for the assignment. |
-| `unlock_at` | The unlock date (assignment is unlocked after this date) |
-| `lock_at` | The lock date (assignment is locked after this date) |
-| `updated_at` | The time at which this assignment was last modified in any way |
-| `points_possible` | The maximum points possible for the assignment |
-| `lti_assignment_id` | The LTI assignment guid for the assignment |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `assignment_id` | bigint | The Canvas id of the new assignment. |
+| `title` | varchar | The title of the assignment (possibly truncated). |
+| `description` | varchar | The description of the assignment (possibly truncated). |
+| `due_at` | datetime | The due date for the assignment. |
+| `unlock_at` | datetime | The unlock date (assignment is unlocked after this date). |
+| `lock_at` | datetime | The lock date (assignment is locked after this date). |
+| `updated_at` | datetime | The time at which this assignment was last modified in any way. |
+| `points_possible` | double precision | The maximum points possible for the assignment. |
+| `workflow_state` | varchar | Workflow state of the assignment. |
+| `lti_assignment_id` | varchar | The LTI assignment guid for the assignment. |
+| `lti_resource_link_id` | varchar | eventfielddescription |
+| `lti_resource_link_id_duplicated_from` | varchar | eventfielddescription |
 
 
 #### `assignment_updated`
 
-| Field | Description |
-| ----- | ----------- |
-| `assignment_id` | The Canvas id of the new assignment. |
-| `title` | The title of the assignment (possibly truncated). |
-| `description` | The description of the assignment (possibly truncated). |
-| `due_at` | The due date for the assignment. |
-| `unlock_at` | The unlock date (assignment is unlocked after this date) |
-| `lock_at` | The lock date (assignment is locked after this date) |
-| `updated_at` | The time at which this assignment was last modified in any way |
-| `points_possible` | The maximum points possible for the assignment |
-| `lti_assignment_id` | The LTI assignment guid for the assignment |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `assignment_id` | bigint | The Canvas id of the new assignment. |
+| `title` | varchar | The title of the assignment (possibly truncated). |
+| `description` | varchar | The description of the assignment (possibly truncated). |
+| `due_at` | datetime | The due date for the assignment. |
+| `unlock_at` | datetime | The unlock date (assignment is unlocked after this date). |
+| `lock_at` | datetime | The lock date (assignment is locked after this date). |
+| `updated_at` | datetime | The time at which this assignment was last modified in any way. |
+| `points_possible` | double precision | The maximum points possible for the assignment. |
+| `workflow_state` | varchar | Workflow state of the assignment. |
+| `lti_assignment_id` | varchar | The LTI assignment guid for the assignment. |
+| `lti_resource_link_id` | varchar | eventfielddescription |
+| `lti_resource_link_id_duplicated_from` | varchar | eventfielddescription |
 
 
-#### `submission_created`
+#### `attachment_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `submission_id` | The Canvas id of the new submission. |
-| `assignment_id` | The Canvas id of the assignment being submitted. |
-| `user_id` | The Canvas id of the user associated with the submission. |
-| `lti_user_id` | The Lti id of the user associated with the submission. |
-| `submitted_at` | The timestamp when the assignment was submitted. |
-| `updated_at` | The time at which this assignment was last modified in any way |
-| `score` | The raw score |
-| `grade` | The grade for the submission, translated into the assignment grading scheme (so a letter grade, for example)|
-| `submission_type` | The types of submission ex: ('online_text_entry'\|'online_url'\|'online_upload'\|'media_recording') |
-| `body` | The content of the submission, if it was submitted directly in a text field. (possibly truncated) |
-| `url` | The URL of the submission (for 'online_url' submissions) |
-| `attempt` | This is the submission attempt number. |
-| `lti_assignment_id` | The LTI assignment guid of the submission's assignment |
-| `group_id` | The submissions’s group ID if the assignment is a group assignment. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user_id` | bigint | The Canvas id of the user associated with the attachment. |
+| `attachment_id` | bigint | The Canvas id of the attachment. |
+| `display_name` | varchar | The display name of the attachment (possibly truncated). |
+| `filename` | varchar | The file name of the attachment (possibly truncated). |
+| `folder_id` | bigint | The id of the folder where the attachment was saved. |
+| `unlock_at` | datetime | The unlock date (attachment is unlocked after this date). |
+| `lock_at` | datetime | The lock date (attachment is locked after this date). |
+| `updated_at` | datetime | The time at which this attachment was last modified in any way .|
+| `context_type` | varchar | The type of context the attachment is used in. |
+| `context_id` | varchar | The id of the context the attachment is used in. |
+| `content_type` | varchar | The content type of the attachment. |
 
 
-#### `submission_updated`
+#### `attachment_deleted`
 
-| Field | Description |
-| ----- | ----------- |
-| `submission_id` | The Canvas id of the new submission. |
-| `assignment_id` | The Canvas id of the assignment being submitted. |
-| `user_id` | The Canvas id of the user associated with the submission. |
-| `lti_user_id` | The Lti id of the user associated with the submission. |
-| `submitted_at` | The timestamp when the assignment was submitted. |
-| `updated_at` | The time at which this assignment was last modified in any way |
-| `score` | The raw score |
-| `grade` | The grade for the submission, translated into the assignment grading scheme (so a letter grade, for example)|
-| `submission_type` | The types of submission ex: ('online_text_entry'\|'online_url'\|'online_upload'\|'media_recording') |
-| `body` | The content of the submission, if it was submitted directly in a text field. (possibly truncated) |
-| `url` | The URL of the submission (for 'online_url' submissions) |
-| `attempt` | This is the submission attempt number. |
-| `lti_assignment_id` | The LTI assignment guid of the submission's assignment |
-| `group_id` | The submissions’s group ID if the assignment is a group assignment. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user_id` | bigint | The Canvas id of the user associated with the attachment. |
+| `attachment_id` | bigint | The Canvas id of the attachment. |
+| `display_name` | varchar | The display name of the attachment (possibly truncated). |
+| `filename` | varchar | The file name of the attachment (possibly truncated). |
+| `folder_id` | bigint | The id of the folder where the attachment was saved. |
+| `unlock_at` | datetime | The unlock date (attachment is unlocked after this date). |
+| `lock_at` | datetime | The lock date (attachment is locked after this date). |
+| `updated_at` | datetime | The time at which this attachment was last modified in any way. |
+| `context_type` | varchar | The type of context the attachment is used in. |
+| `context_id` | varchar | The id of the context the attachment is used in. |
+| `content_type` | varchar | The content type of the attachment. |
+
+
+#### `attachment_updated`
+
+`attachment_updated` events are triggered when an attachment's `display_name` is updated.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user_id` | bigint | The Canvas id of the user associated with the attachment. |
+| `attachment_id` | bigint | The Canvas id of the attachment. |
+| `display_name` | varchar | The old display name of the attachment (possibly truncated). |
+| `old_display_name` | varchar | The new display name of the attachment (possibly truncated). |
+| `filename` | varchar | The file name of the attachment (possibly truncated). |
+| `folder_id` | bigint | The id of the folder where the attachment was saved. |
+| `unlock_at` | datetime | The unlock date (attachment is unlocked after this date). |
+| `lock_at` | datetime | The lock date (attachment is locked after this date). |
+| `updated_at` | datetime | The time at which this attachment was last modified in any way. |
+| `context_type` | varchar | The type of context the attachment is used in. |
+| `context_id` | varchar | The id of the context the attachment is used in. |
+| `content_type` | varchar | The content type of the attachment. |
+
+
+#### `content_migration_completed`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `content_migration_id` | bigint | The Canvas id of the content migration |
+| `context_id` | bigint | The Canvas id of the context associated with the content migration. |
+| `context_type` | varchar | The type of context associated with the content migration. |
+| `lti_context_id` | varchar | The lti context id of the context associated with the content migration.  |
+| `context_uuid` | varchar | The uuid of the context associated with the content migration. |
+| `import_quizzes_next` | boolean | Indicates whether the user requested that the quizzes in the content migration be created in Quizzes.Next (true) or in native Canvas (false). |
+
+
+#### `course_completed`
+
+The body fields for this event are nested.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `progress['requirement_count']` | int | Count of all the requirements in the course as a number. |
+| `progress['requirement_completed_count']` | int | The count of those requirements that are done. |
+| `progress['next_requirement_url']` | varchar |  Link to the module item that is next in the order of requirements to complete. |
+| `progress['completed_at']` | datetime | Timestamp when the course was completed. |
+| `user['email']` | varchar | The students email. |
+| `user['id']` | varchar | The Canvas id of the student completing the course. |
+| `user['name']` | varchar | The name of the student. |
+| `course['id']` | int | The local Canvas id of the course. |
+| `course['name']` | varchar | The name of the course. |
+
+```javascript
+"body": {
+  "progress": {
+    "requirement_count": 99,
+    "requirement_completed_count": 99,
+    "next_requirement_url": nil,
+    "completed_at": "2018-10-18T20:50:35Z"
+  },
+  "user": {
+    "id": "1234567",
+    "name": "Sheldon Cooper",
+    "email": "sheldon@caltech.example.com"
+  },
+  "course": {
+    "id": "123456",
+    "name": "Computer Science I"
+  }
+}
+```
+
+#### `course_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `course_id` | bigint | The Canvas id of the created course. |
+| `uuid` | varchar | The unique id of the course. |
+| `account_id` | bigint | The Account id of the created course. |
+| `name` | varchar | The name the created course. |
+| `created_at` | datetime | The time at which this course was created. |
+| `updated_at` | datetime | The time at which this course was last modified in any way. |
+| `workflow_state` | varchar | The state of the course.  |
+
+
+#### `course_section_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `course_section_id` | integer | The local Canvas id of the section. |
+| `sis_source_id` | varchar | Correlated id for the record for this course in the SIS system (assuming SIS integration is configured). |
+| `sis_batch_id` | varchar | The batch id of the sis import. |
+| `course_id` | integer | The local Canvas id of the course. |
+| `enrollment_term_id` | varchar | The Canvas if of the enrollment term. |
+| `name` | varchar | The name of the course. |
+| `default_section` | boolean | eventfielddescription |
+| `accepting_enrollments` | varchar | eventfielddescription |
+| `can_manually_enroll` | varchar | eventfielddescription |
+| `start_at` | datetime | Section start date in ISO8601 format. |
+| `end_at` | datetime | Section end date in ISO8601 format. |
+| `workflow_state` | varchar | The workflow state of the section. |
+| `restrict_enrollments_to_section_dates` | boolean | eventfielddescription |
+| `nonxlist_course_id` | varchar | The unique identifier of the original course of a cross-listed section. |
+| `stuck_sis_fields` | varchar | eventfielddescription |
+| `integration_id` | varchar | eventfielddescription |
+
+
+#### `course_section_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `course_section_id` | integer | The local Canvas id of the section. |
+| `sis_source_id` | varchar | Correlated id for the record for this course in the SIS system (assuming SIS integration is configured). |
+| `sis_batch_id` | varchar | The batch id of the sis import. |
+| `course_id` | integer | The local Canvas id of the course. |
+| `enrollment_term_id` | varchar | The Canvas if of the enrollment term. |
+| `name` | varchar | The name of the course. |
+| `default_section` | boolean | eventfielddescription |
+| `accepting_enrollments` | varchar | eventfielddescription |
+| `can_manually_enroll` | varchar | eventfielddescription |
+| `start_at` | datetime | Section start date in ISO8601 format. |
+| `end_at` | datetime | Section end date in ISO8601 format. |
+| `workflow_state` | varchar | The workflow state of the section. |
+| `restrict_enrollments_to_section_dates` | boolean | eventfielddescription |
+| `nonxlist_course_id` | varchar | The unique identifier of the original course of a cross-listed section. |
+| `stuck_sis_fields` | varchar | eventfielddescription |
+| `integration_id` | varchar | eventfielddescription |
+
+
+#### `course_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `course_id` | bigint | The Canvas id of the updated course. |
+| `account_id` | bigint | The Account id of the updated course. |
+| `uuid` | varchar | The unique id of the course. |
+| `name` | varchar | The name the updated course. |
+| `created_at` | datetime | The time at which this course was created. |
+| `updated_at` | datetime | The time at which this course was last modified in any way. |
+| `workflow_state` | varchar | The state of the course. |
+
+
+#### `discussion_entry_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `discussion_entry_id` | bigint | The Canvas id of the newly added entry. |
+| `parent_discussion_entry_id` | bigint | If this was a reply, the Canvas id of the parent entry. |
+| `parent_discussion_entry_author_id` | bigint | If this was a reply, the Canvas id of the parent entry author. |
+| `discussion_topic_id` | bigint | The Canvas id of the topic the entry was added to. |
+| `text` | text | The (possibly truncated) text of the post. |
+
+
+#### `discussion_topic_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `discussion_topic_id` | bigint | The Canvas id of the new discussion topic. |
+| `is_announcement` | boolean | `true` if this topic was posted as an announcement, `false` otherwise. |
+| `title` | varchar | Title of the topic (possibly truncated). |
+| `body` | text | Body of the topic (possibly truncated). |
+
+
+#### `enrollment_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `enrollment_id` | bigint | The Canvas id of the new enrollment. |
+| `course_id` | bigint | The Canvas id of the course for this enrollment. |
+| `user_id` | bigint | The Canvas id of the user for this enrollment. |
+| `user_name` | varchar | The user's name. |
+| `type` | varchar | The type of enrollment; e.g. 'StudentEnrollment', 'TeacherEnrollment', etc. |
+| `created_at` | datetime | The time at which this enrollment was created. |
+| `updated_at` | datetime | The time at which this enrollment was last modified in any way. |
+| `limit_privileges_to_course_section` | boolean | Whether students can only talk to students within their course section. |
+| `course_section_id` | bigint | The id of the section of the course for the new enrollment. |
+| `associated_user_id` | bigint | The id of the user observed by an observer's enrollment. Omitted from non-observer enrollments. |
+| `workflow_state` | varchar | The state of the enrollment. |
+
+
+#### `enrollment_state_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `enrollment_id` | bigint | The Canvas id of the new enrollment. |
+| `state` | varchar |  The state of the enrollment. |
+| `state_started_at` | datetime | The time when this enrollment state starts. |
+| `state_is_current` | boolean | If this enrollment_state is uptodate. |
+| `state_valid_until` | datetime | The time at which this enrollment is no longer valid. |
+| `restricted_access` | boolean | True if this enrollment_state is restricted. |
+| `access_is_current` | boolean |  If this enrollment_state access is uptodate. |
+| `state_invalidated_at` | datetime | Time enrollment_state was invalidated. |
+| `state_recalculated_at` | datetime | Time enrollment_state was created. |
+| `access_invalidated_at` | datetime | Time enrollment_state access was invalidated. |
+| `access_recalculated_at` | datetime | Time enrollment_state access was created. |
+
+
+#### `enrollment_state_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `enrollment_id` | bigint | The Canvas id of the new enrollment. |
+| `state` | varchar |  The state of the enrollment. |
+| `state_started_at` | datetime | The time when this enrollment state starts. |
+| `state_is_current` | boolean | If this enrollment_state is uptodate. |
+| `state_valid_until` | datetime | The time at which this enrollment is no longer valid. |
+| `restricted_access` | boolean | True if this enrollment_state is restricted. |
+| `access_is_current` | boolean |  If this enrollment_state access is uptodate. |
+| `state_invalidated_at` | datetime | Time enrollment_state was invalidated. |
+| `state_recalculated_at` | datetime | Time enrollment_state was created. |
+| `access_invalidated_at` | datetime | Time enrollment_state access was invalidated. |
+| `access_recalculated_at` | datetime | Time enrollment_state access was created. |
+
+
+#### `enrollment_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `enrollment_id` | bigint | The Canvas id of the new enrollment. |
+| `course_id` | bigint | The Canvas id of the course for this enrollment. |
+| `user_id` | bigint | The Canvas id of the user for this enrollment. |
+| `user_name` | varchar | The user's name. |
+| `type` | varchar | The type of enrollment; e.g. 'StudentEnrollment', 'TeacherEnrollment', etc. |
+| `created_at` | datetime | The time at which this enrollment was created. |
+| `updated_at` | datetime | The time at which this enrollment was last modified in any way. |
+| `limit_privileges_to_course_section` | boolean | Whether students can only talk to students within their course section. |
+| `course_section_id` | bigint | The id of the section of the course for the new enrollment. |
+| `associated_user_id` | bigint | The id of the user observed by an observer's enrollment. Omitted from non-observer enrollments. |
+| `workflow_state` | varchar | The state of the enrollment. |
+
+
+#### `grade_change`
+
+`grade_change` events are posted every time a grade changes. These can
+happen as the result of a teacher changing a grade in the gradebook or
+speedgrader, a quiz being automatically scored, or changing an assignment's
+points possible or grade type. In the case of a quiz being scored, the
+`grade_change` event will be fired as the result of a student turning in a
+quiz, and the `user_id` in the message attributes will be of the student. In
+these cases, `grader_id` should be null in the body.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `submission_id` | bigint | The Canvas id of the submission that the grade is changing on. |
+| `assignment_id` | bigint | The Canvas id of the assignment associated with the submission. |
+| `grade` | varchar | The new grade. |
+| `old_grade` | varchar | The previous grade, if there was one.  |
+| `score` | double precision | The new score. |
+| `old_score` | double precision | The previous score. |
+| `points_possible` | double precision | The maximum points possible for the submission's assignment. |
+| `old_points_possible` | double precision | The maximum points possible for the previous grade. |
+| `grader_id` | bigint | The Canvas id of the user making the grade change. Null if this was the result of automatic grading. |
+| `user_id` | bigint | The Canvas id of the user associated to the submission with the change. |
+| `student_id` | bigint | Same as the user_id. |
+| `student_sis_id` | varchar | The SIS ID of the student. |
+| `muted` | boolean | The boolean muted state of the submissions's assignment. Muted grade changes should not be published to students. |
+| `grading_complete` | boolean | The boolean state that the submission is completely graded. False if the assignment is only partially graded, for example a quiz with automatically and manually graded sections. Incomplete grade changes should not be published to students. |
+
+
+#### `group_category_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `group_category_id` | bigint | The Canvas id of the newly created group category. |
+| `group_category_name` | varchar | The name of the newly created group category. |
+| `group_limit` | integer | The cap of the number of users in each group. |
+| `context_id` | integer | The Canvas id of the group's context. |
+| `context_type` | varchar | The type of the group's context ('Account' or 'Course') |
+
+
+#### `group_category_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `group_category_id` | varchar |  The Canvas id of the newly created group category. |
+| `group_category_name` | varchar | The name of the newly created group category. |
+| `group_limit` | varchar | The cap of the number of users in each group. |
+| `context_id` | integer | The Canvas id of the group's context. |
+| `context_type` | varchar | The type of the group's context ('Account' or 'Course') |
+
+
+#### `group_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `group_id` | bigint | The Canvas id of the group. |
+| `group_name` | varchar | The name of the group. |
+| `group_category_id` | bigint | The Canvas id of the group category. |
+| `group_category_name` | varchar | The name of the group category. |
+| `context_type` | varchar |  The type of the group's context ('Account' or 'Course'). |
+| `context_id` | varchar | The Canvas id of the group's context. |
+| `uuid` | varchar | The unique id of the group. |
+| `account_id` | bigint | The Canvas id of the group's account. |
+| `workflow_state` | varchar | The state of the group. |
+| `max_membership` | integer | The maximum membership cap for the group |
+
+
+#### `group_membership_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `group_membership_id` | bigint | The Canvas id of the group membership. |
+| `user_id` | bigint | The Canvas id of the user being assigned to a group. |
+| `group_id` | bigint | The Canvas id of the group the user is assigned to. |
+| `group_name` | varchar | The name of the group the user is being assigned to. |
+| `group_category_id` | bigint | The Canvas id of the group category. |
+| `group_category_name` | varchar | The name of the group category. |
+| `workflow_state` | varchar | The state of the group membership. |
+
+
+#### `group_membership_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `group_membership_id` | bigint | The Canvas id of the group membership. |
+| `user_id` | bigint | The Canvas id of the user assigned to a group. |
+| `group_id` | bigint | The Canvas id of the group the user is assigned to. |
+| `group_name` | varchar | The name of the group the user is assigned to. |
+| `group_category_id` | bigint | The Canvas id of the group category. |
+| `group_category_name` | varchar | The name of the group category. |
+| `workflow_state` | varchar | The state of the group membership. |
+
+
+#### `group_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `group_id` | bigint | The Canvas id of the group. |
+| `group_name` | varchar | The name of the group. |
+| `group_category_id` | bigint | The Canvas id of the group category. |
+| `group_category_name` | varchar | The name of the group category. |
+| `context_type` | varchar |  The type of the group's context ('Account' or 'Course'). |
+| `context_id` | varchar | The Canvas id of the group's context. |
+| `uuid` | varchar | The unique id of the group. |
+| `account_id` | bigint | The Canvas id of the group's account. |
+| `workflow_state` | varchar | The state of the group. |
+| `max_membership` | integer | The maximum membership cap for the group |
+
+
+#### `logged_in`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `redirect_url` | text | The URL the user was redirected to after logging in. Is set when the user logs in after clicking a deep link into Canvas. |
+
+
+#### `logged_out`
+
+No extra data.
+
+#### `module_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `module_id` | integer | The Canvas id of the module. |
+| `context_id` | varchar | The local Canvas id of the context. |
+| `context_type` | varchar | The type of module's context ('Course'). |
+| `name` | varchar | The name of the module. |
+| `position` | integer | The position of the module in the course. |
+| `workflow_state` | varchar | The workflow state of the module. |
+
+
+#### `module_item_created`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `module_item_id` | integer | The Canvas id of the module item. |
+| `module_id` | integer | The Canvas id of the module. |
+| `context_id` | varchar | The local Canvas id of the context. |
+| `context_type` | varchar | The type of module's context ('Course'). |
+| `position` | integer | The position of the module item in the module. |
+| `workflow_state` | varchar | The workflow state of the module item. |
+
+
+#### `module_item_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `module_item_id` | integer | The Canvas id of the module item. |
+| `module_id` | integer | The Canvas id of the module. |
+| `context_id` | varchar | The local Canvas id of the context. |
+| `context_type` | varchar | The type of module's context ('Course'). |
+| `position` | integer | The position of the module item in the module. |
+| `workflow_state` | varchar | The workflow state of the module item. |
+
+
+#### `module_updated`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `module_id` | integer | The Canvas id of the module. |
+| `context_id` | varchar | The local Canvas id of the context. |
+| `context_type` | varchar | The type of module's context ('Course'). |
+| `name` | varchar | The name of the module. |
+| `position` | integer | The position of the module in the course. |
+| `workflow_state` | varchar | The workflow state of the module. |
 
 
 #### `plagiarism_resubmit`
@@ -384,207 +611,153 @@ by `asset_type` and `asset_id`.
 | `lti_assignment_id` | The LTI assignment guid of the submission's assignment |
 | `group_id` | The submissions’s group ID if the assignment is a group assignment. |
 
-#### `user_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `user_id` | The Canvas id of user. |
-| `uuid` | Unique user id. |
-| `name` | Name of user. |
-| `short_name` | Short name of user. |
-| `workflow_state` | State of the user. |
-| `created_at` | The time at which this user was created. |
-| `updated_at` | The time at which this user was last modified in any way. |
+#### `quiz_export_complete`
+
+The body fields for this event are nested.
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `assignment['resource_link_id']` | varchar | eventfielddescription |
+| `assignment['title']` | varchar | Title of the quiz |
+| `assignment['context_title']` | varchar | Title of the course |
+| `assignment['course_uuid']` | varchar | The unique id of the course for this association.|
+| `qti_export['url']` | varchar | The URL of the exported quiz, zip file |
+
+```javascript
+"body": {
+  "assignment": {
+    "resource_link_id": "9b8a57aa143083d824fae97a79d15525dafedc9d",
+    "title": "Quiz Title",
+    "context_title": "Course Title",
+    "course_uuid": "nXSr0rA8dAbC5vWe1evjOLMhYV9nxyzSXszT1U6T"
+  },
+  "qti_export": {
+    "url": "https://instructure-uploads.s3.amazonaws.com/account_100000000123456/attachments/123456/course-name-quiz-export.zip?[...]"
+  }
+}
+```
+
+#### `quiz_submitted`
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `submission_id` | bigint | The Canvas id of the quiz submission |
+| `quiz_id` | bigint | The Canvas id of the quiz. |
 
 
-#### `user_updated`
+#### `submission_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `user_id` | The Canvas id of user. |
-| `name` | Name of user. |
-| `short_name` | Short name of user. |
-| `workflow_state` | State of the user. |
-| `created_at` | The time at which this user was created. |
-| `updated_at` | The time at which this user was last modified in any way. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `submission_id` | bigint | The Canvas id of the new submission. |
+| `assignment_id` | bigint | The Canvas id of the assignment being submitted. |
+| `user_id` | bigint | The Canvas id of the user associated with the submission. |
+| `lti_user_id` | varchar | The LTI id of the user associated with the submission. |
+| `lti_assignment_id` | varchar | The LTI assignment guid of the submission's assignment |
+| `submitted_at` | datetime | The timestamp when the assignment was submitted. |
+| `graded_at` | datetime | The timestamp when the assignment was graded, if it was graded. |
+| `updated_at` | datetime | The time at which this assignment was last modified in any way |
+| `score` | double precision | The raw score |
+| `grade` | varchar | The grade for the submission, translated into the assignment grading scheme (so a letter grade, for example) |
+| `submission_type` | varchar | The types of submission ex: ('online_text_entry'\|'online_url'\|'online_upload'\|'media_recording') |
+| `body` | text | The content of the submission, if it was submitted directly in a text field. (possibly truncated) |
+| `url` | varchar | The URL of the submission (for 'online_url' submissions) |
+| `attempt` | integer | This is the submission attempt number. |
+| `group_id` | integer | The submissions’s group ID if the assignment is a group assignment. |
 
 
-#### `enrollment_created`
+#### `submission_updated`
 
-| Field | Description |
-| ----- | ----------- |
-| `enrollment_id` | The Canvas id of the new enrollment. |
-| `course_id` | The Canvas id of the course for this enrollment. |
-| `user_id` | The Canvas id of the user for this enrollment. |
-| `user_name` | The user's name. |
-| `type` | The type of enrollment; e.g. 'StudentEnrollment', 'TeacherEnrollment', etc. |
-| `created_at` | The time at which this enrollment was created. |
-| `updated_at` | The time at which this enrollment was last modified in any way. |
-| `limit_privileges_to_course_section` | Whether students can only talk to students within their course section. |
-| `course_section_id` | The id of the section of the course for the new enrollment. |
-| `associated_user_id` | The id of the user observed by an observer's enrollment. Omitted from non-observer enrollments. |
-| `workflow_state` | The state of the enrollment. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `submission_id` | bigint | The Canvas id of the new submission. |
+| `assignment_id` | bigint | The Canvas id of the assignment being submitted. |
+| `user_id` | bigint | The Canvas id of the user associated with the submission. |
+| `lti_user_id` | varchar | The LTI id of the user associated with the submission. |
+| `lti_assignment_id` | varchar | The LTI assignment guid of the submission's assignment |
+| `submitted_at` | datetime | The timestamp when the assignment was submitted. |
+| `graded_at` | datetime | The timestamp when the assignment was graded, if it was graded. |
+| `updated_at` | datetime | The time at which this assignment was last modified in any way |
+| `score` | double precision | The raw score |
+| `grade` | varchar | The grade for the submission, translated into the assignment grading scheme (so a letter grade, for example) |
+| `submission_type` | varchar | The types of submission ex: ('online_text_entry'\|'online_url'\|'online_upload'\|'media_recording') |
+| `body` | text | The content of the submission, if it was submitted directly in a text field. (possibly truncated) |
+| `url` | varchar | The URL of the submission (for 'online_url' submissions) |
+| `attempt` | integer | This is the submission attempt number. |
+| `group_id` | integer | The submissions’s group ID if the assignment is a group assignment. |
 
-#### `enrollment_updated`
 
-| Field | Description |
-| ----- | ----------- |
-| `enrollment_id` | The Canvas id of the new enrollment. |
-| `course_id` | The Canvas id of the course for this enrollment. |
-| `user_id` | The Canvas id of the user for this enrollment. |
-| `user_name` | The user's name. |
-| `type` | The type of enrollment; e.g. 'StudentEnrollment', 'TeacherEnrollment', etc. |
-| `created_at` | The time at which this enrollment was created. |
-| `updated_at` | The time at which this enrollment was last modified in any way. |
-| `limit_privileges_to_course_section` | Whether students can only talk to students within their course section. |
-| `course_section_id` | The id of the section of the course for the new enrollment. |
-| `associated_user_id` | The id of the user observed by an observer's enrollment. Omitted from non-observer enrollments. |
-| `workflow_state` | The state of the enrollment. |
+#### `syllabus_updated`
 
-#### `enrollment_state_created`
-
-| Field | Description |
-| ----- | ----------- |
-| `enrollment_id` | The Canvas id of the new enrollment. |
-| `state` | The state of the enrollment. |
-| `state_started_at` | The time when this enrollment state starts. |
-| `state_is_current` | If this enrollment_state is uptodate |
-| `state_valid_until` | The time at which this enrollment is no longer valid. |
-| `restricted_access` | True if this enrollment_state is restricted. |
-| `access_is_current ` | If this enrollment_state access is upto date. |
-| `state_invalidated_at ` | Time enrollment_state was invalidated. |
-| `state_recalculated_at` | Time enrollment_state was created. |
-| `access_invalidated_at` | Time enrollment_state access was invalidated. |
-| `access_recalculated_at` | Time enrollment_state access was created. |
-
-#### `enrollment_state_updated`
-
-| Field | Description |
-| ----- | ----------- |
-| `enrollment_id` | The Canvas id of the new enrollment. |
-| `state` | The state of the enrollment. |
-| `state_started_at` | The time when this enrollment state starts. |
-| `state_is_current` | If this enrollment_state is uptodate |
-| `state_valid_until` | The time at which this enrollment is no longer valid. |
-| `restricted_access` | True if this enrollment_state is restricted. |
-| `access_is_current ` | If this enrollment_state access is upto date. |
-| `state_invalidated_at ` | Time enrollment_state was invalidated. |
-| `state_recalculated_at` | Time enrollment_state was created. |
-| `access_invalidated_at` | Time enrollment_state access was invalidated. |
-| `access_recalculated_at` | Time enrollment_state access was created. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `course_id` | bigint | The Canvas id of the updated course. |
+| `syllabus_body` | text | The new syllabus content (possibly truncated). |
+| `old_syllabus_body` | text | The old syllabus content (possibly truncated). |
 
 
 #### `user_account_association_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `user_id` | The Canvas id of the user for this association. |
-| `account_id` | The Canvas id of the account for this association. |
-| `account_uuid` | The unique id of the account for this association.|
-| `created_at` | The time at which this association was created. |
-| `updated_at` | The time at which this association was last modified. |
-| `roles` | The roles the user has in the account. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user_id` | bigint |  The Canvas id of the user for this association. |
+| `account_id` | bigint | The Canvas id of the account for this association. |
+| `account_uuid` | varchar | The unique id of the account for this association. |
+| `created_at` | datetime | The time at which this association was created. |
+| `updated_at` | datetime | The time at which this association was last modified. |
+| `is_admin` | boolean | The roles the user has in the account. |
 
-#### `attachment_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `user_id` | The Canvas id of the user associated with the attachment. |
-| `attachment_id` | The Canvas id of the attachment. |
-| `display_name` | The display name of the attachment (possibly truncated). |
-| `filename` | The file name of the attachment (possibly truncated). |
-| `unlock_at` | The unlock date (attachment is unlocked after this date) |
-| `lock_at` | The lock date (attachment is locked after this date) |
-| `updated_at` | The time at which this attachment was last modified in any way |
-| `context_type` | The type of context the attachment is used in. |
-| `context_id` | The id of the context the attachment is used in. |
-| `content_type` | The content type of the attachment. |
+#### `user_created`
 
-#### `attachment_updated`
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user_id` | bigint | The Canvas id of user. |
+| `uuid` | varchar | Unique user id. |
+| `name` | varchar | Name of user. |
+| `short_name` | varchar | Short name of user. |
+| `workflow_state` | varchar | State of the user. |
+| `created_at` | datetime | The time at which this user was created. |
+| `updated_at` | datetime | The time at which this user was last modified in any way. |
 
-`attachment_updated` events are triggered when an attachment's `display_name` is updated.
 
-| Field | Description |
-| ----- | ----------- |
-| `user_id` | The Canvas id of the user associated with the attachment. |
-| `attachment_id` | The Canvas id of the attachment. |
-| `display_name` | The display name of the attachment (possibly truncated). |
-| `old_display_name` | The old display name of the attachment (possibly truncated). |
-| `filename` | The file name of the attachment (possibly truncated). |
-| `unlock_at` | The unlock date (attachment is unlocked after this date) |
-| `lock_at` | The lock date (attachment is locked after this date) |
-| `updated_at` | The time at which this attachment was last modified in any way |
-| `context_type` | The type of context the attachment is used in. |
-| `context_id` | The id of the context the attachment is used in. |
-| `content_type` | The content type of the attachment. |
+#### `user_updated`
 
-#### `attachment_deleted`
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `user_id` | bigint | The Canvas id of user. |
+| `uuid` | varchar | Unique user id. |
+| `name` | varchar | Name of user. |
+| `short_name` | varchar | Short name of user. |
+| `workflow_state` | varchar | State of the user. |
+| `created_at` | datetime | The time at which this user was created. |
+| `updated_at` | datetime | The time at which this user was last modified in any way. |
 
-| Field | Description |
-| ----- | ----------- |
-| `user_id` | The Canvas id of the user associated with the attachment. |
-| `attachment_id` | The Canvas id of the attachment. |
-| `display_name` | The display name of the attachment (possibly truncated). |
-| `filename` | The file name of the attachment (possibly truncated). |
-| `unlock_at` | The unlock date |
-| `lock_at` | The lock date |
-| `updated_at` | The time at which this attachment was last modified in any way |
-| `context_type` | The type of context the attachment is used in. |
-| `context_id` | The id of the context the attachment is used in. |
-| `content_type` | The content type of the attachment. |
 
-#### `account_notification_created`
+#### `wiki_page_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `account_notification_id` | The Canvas id of the account notification. |
-| `subject` | The subject of the notification. |
-| `message` | The message to be sent in the notification. |
-| `icon` | The icon to display with the message.  Defaults to warning. |
-| `start_at` | When to send out the notification. |
-| `end_at` | When to expire the notification. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `wiki_page_id` | bigint | The Canvas id of the new wiki page. |
+| `title` | varchar | The title of the new page (possibly truncated). |
+| `body` | text | The body of the new page (possibly truncated). |
 
-#### `module_created`
 
-| Field | Description |
-| ----- | ----------- |
-| `module_id` | The Canvas id of the module. |
-| `name` | The name of the module. |
-| `position` | The position of the module in the course. |
-| `workflow_state` | The workflow state of the module. |
+#### `wiki_page_deleted`
 
-#### `module_updated`
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `wiki_page_id` | bigint | The Canvas id of the delete wiki page. |
+| `title` | varchar | The title of the deleted wiki page (possibly truncated). |
 
-| Field | Description |
-| ----- | ----------- |
-| `module_id` | The Canvas id of the module. |
-| `name` | The name of the module. |
-| `position` | The position of the module in the course. |
-| `workflow_state` | The workflow state of the module. |
 
-#### `module_item_created`
+#### `wiki_page_updated`
 
-| Field | Description |
-| ----- | ----------- |
-| `module_item_id` | The Canvas id of the module item. |
-| `position` | The position of the module item in the module. |
-| `workflow_state` | The workflow state of the module item. |
-
-#### `module_item_updated`
-
-| Field | Description |
-| ----- | ----------- |
-| `module_item_id` | The Canvas id of the module item. |
-| `position` | The position of the module item in the module. |
-| `workflow_state` | The workflow state of the module item. |
-
-#### `content_migration_completed`
-
-| Field | Description |
-| ----- | ----------- |
-| `content_migration_id` | The Canvas id of the content migration. |
-| `context_id` | The Canvas id of the context associated with the content migration. |
-| `context_type` | The type of context associated with the content migration. |
-| `lti_context_id` | The lti context id of the context associated with the content migration. |
-| `context_uuid` | The uuid of the context associated with the content migration. |
-| `import_quizzes_next` | Indicates whether the user requested that the quizzes in the content migration be created in Quizzes.Next (true) or in native Canvas (false). |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `wiki_page_id` | bigint |  The Canvas id of the changed wiki page. |
+| `title` | varchar | The new title (possibly truncated). |
+| `old_title` | varchar | The old title (possibly truncated). |
+| `body` | text | The new page body (possibly truncated). |
+| `old_body` | text | The old page body (possibly truncated). |


### PR DESCRIPTION
Looking for some collaborative editing.

I've added and updated some items at the top. Alphabetized the events. Added events, and fields that I've collected from messages. I've also added data types for the fields I've seen, based on the data I have received. Some of that might need to be double checked. For instance, I was unaware until yesterday that `sis_source_id` and `sis_batch` ID can be strings, I have corrected that. I have tried to normalize the data types to the Canvas Data schema. I understand 'String' is used in the metadata table and that a lot of this data may be strings in other instances. I'm open to suggestions, but figured this was a good starting point.

There are also some fields I need internal input to define. I've left them blank, find them by looking for '_eventfielddescription_'.

Does not include the _Quizzes.Next_ events. Considerations for adding those in a separate document, or adding here?

test plan:
- consumed 5M+ messages in an auto generating test environment creating tables for events and adding columns when if new fields are seen. I believe I have everything that is currently sent.
- created a DDL with specific data types and then explicitly set those fields and data types in code
- continued importing and fixing datatype and length issues when found
- generated markdown with data types from database