### PR TITLE
Add `created_at` to group categories API

### DIFF
--- a/lib/api/v1/group_category.rb
+++ b/lib/api/v1/group_category.rb
@@ -22,7 +22,7 @@ module Api::V1::GroupCategory
   include Api::V1::Progress
 
   API_GROUP_CATEGORY_JSON_OPTS = {
-    :only => %w(id name role self_signup group_limit auto_leader)
+    :only => %w(id name role self_signup group_limit auto_leader created_at)
   }
 
   def group_category_json(group_category, user, session, options = {})

--- a/spec/apis/v1/group_categories_api_spec.rb
+++ b/spec/apis/v1/group_categories_api_spec.rb
@@ -28,6 +28,7 @@ describe "Group Categories API", type: :request do
       'self_signup' => category.self_signup,
       'context_type' => category.context_type,
       "#{category.context_type.downcase}_id" => category.context_id,
+      'created_at' => category.created_at.iso8601,
       'group_limit' => category.group_limit,
       'groups_count' => category.groups.size,
       'unassigned_users_count' => category.unassigned_users.count(:all),


### PR DESCRIPTION
Test Plan:
* Group category APIs should return their respective
  object's `created_at` field