### PR TITLE
Prevent page error when Dashcard position contains invalid characters.

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -155,7 +155,7 @@ module DashboardHelper
       presenter.to_h
     end
 
-    mapped.sort_by {|h| h[:position] || ::CanvasSort::Last}
+    mapped.sort_by {|h| Integer(h[:position] || ::CanvasSort::Last)}
   end
 
 end


### PR DESCRIPTION
When set_dashboard_positions is given a string instead of an integer, they are happily stored in the user record.
Later when the dashboard is rendered, Ruby tries to sort the dashcards by :position and this means that a string is compared against an int, crashing the application with "comparison of String with 2 failed" or something similar.

addresses Canvas Case #03910104

 Test Plan:
   - Call /api/v1/users/self/dashboard_positions with something that looks like an integer but actually isn't, such as {"dashboard_positions":{"course_508213":"0  ","course_598941":2,"course_598980":1,"course_661886":3}}
   - Ensure that there is no page error on next dashboard render.