### PR TITLE
Include LTI Resize code in Syllabus

### DIFF
--- a/app/jsx/bundles/syllabus.js
+++ b/app/jsx/bundles/syllabus.js
@@ -24,6 +24,7 @@ import SyllabusCalendarEventsCollection from 'compiled/collections/SyllabusCalen
 import SyllabusAppointmentGroupsCollection from 'compiled/collections/SyllabusAppointmentGroupsCollection'
 import SyllabusPlannerCollection from '../../coffeescripts/collections/SyllabusPlannerCollection'
 import SyllabusView from 'compiled/views/courses/SyllabusView'
+import { monitorLtiMessages } from 'lti/messages'
 
 // Setup the collections
 const collections = [
@@ -92,3 +93,4 @@ $(() => {
   SyllabusBehaviors.bindToMiniCalendar()
 })
 
+monitorLtiMessages()


### PR DESCRIPTION
This PR brings the LTI Resize code introduced in [this PR](https://github.com/instructure/canvas-lms/commit/8ee553cb3080ddce2dc6a9020b6dc886d821b375) available to the syllabus. Currently, this functionality is available on pages. Since the syllabus offers similar features including the ability to embed an LTI tool via Content Item Select it is useful to provide the same LTI features. 
