### PR TITLE
Fix syntax in the config/dynamic_settings.yml.example file

### DIFF
--- a/config/dynamic_settings.yml.example
+++ b/config/dynamic_settings.yml.example
@@ -72,7 +72,7 @@ development:
       clone_url_strand.yml: |
         lti1.instructure.com: lti1
         lti2.instructure.com: lti2
-      csp_logging.yml |
+      csp_logging.yml: |
         host: https://csplogging.inscloudgate.net/
         shared_secret: s00p3r_s3cr3t
   store:


### PR DESCRIPTION
In order to deploy Canvas with this guide: https://github.com/instructure/canvas-lms/wiki/Production-Start
1. cp config/dynamic_settings.yml.example config/dynamic_settings.yml
2. RAILS_ENV=production bundle exec rake db:initial_setup
(other steps are skipped)
**Expected result**: migrations are running, the rest of the initialization is fine.
**Actual result**: 
rake aborted!
Psych::SyntaxError: (<unknown>): could not find expected ':' while scanning a simple key at line 75 column 7
/var/canvas/vendor/bundle/ruby/2.4.0/gems/safe_yaml-1.0.4/lib/safe_yaml/load.rb:149:in `load'
/var/canvas/config/application.rb:197:in `load'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/safe_yaml-1.0.4/lib/safe_yaml.rb:29:in `safe_load'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/safe_yaml-1.0.4/lib/safe_yaml.rb:12:in `load_with_options'
/var/canvas/lib/config_file.rb:45:in `load'
/var/canvas/lib/canvas/dynamic_settings.rb:75:in `root_fallback_proxy'
/var/canvas/lib/canvas/dynamic_settings.rb:113:in `find'
/var/canvas/lib/canvas.rb:87:in `cache_store_config_for'
/var/canvas/config/initializers/cache_store.rb:28:in `block in <top (required)>'
/var/canvas/config/initializers/cache_store.rb:70:in `<top (required)>'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:286:in `load'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:286:in `block in load'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:258:in `load_dependency'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:286:in `load'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/engine.rb:655:in `block in load_config_initializer'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/notifications.rb:168:in `instrument'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/engine.rb:654:in `load_config_initializer'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/engine.rb:612:in `block (2 levels) in <class:Engine>'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/engine.rb:611:in `each'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/engine.rb:611:in `block in <class:Engine>'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/initializable.rb:30:in `instance_exec'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/initializable.rb:30:in `run'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/initializable.rb:59:in `block in run_initializers'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/initializable.rb:48:in `each'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/initializable.rb:48:in `tsort_each_child'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/initializable.rb:58:in `run_initializers'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/application.rb:353:in `initialize!'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/railtie.rb:185:in `public_send'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/railtie.rb:185:in `method_missing'
/var/canvas/config/environment.rb:28:in `<top (required)>'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:292:in `require'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:292:in `block in require'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:258:in `load_dependency'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.6.2/lib/active_support/dependencies.rb:292:in `require'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/application.rb:329:in `require_environment!'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/railties-5.1.6.2/lib/rails/application.rb:445:in `block in run_tasks_blocks'
/var/canvas/lib/tasks/db_load_data.rake:206:in `block (2 levels) in <top (required)>'
/var/canvas/vendor/bundle/ruby/2.4.0/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'