### PR TITLE
Fix typo in copperMaker.js

### DIFF
--- a/app/jsx/canvas_cropper/cropperMaker.js
+++ b/app/jsx/canvas_cropper/cropperMaker.js
@@ -30,13 +30,13 @@ import CanvasCropper from './cropper'
     // @param props: properties
     //    imgFile: the File object returned from the native file open dialog
     //    width: desired width in px of the final cropped image
-    //    height: desired height in px if the final cropped image
+    //    height: desired height in px of the final cropped image
     constructor (root, props) {
       this.root = root;                     // DOM node we render into
       this.imgFile = props.imgFile;
       this.onImageLoaded = props.onImageLoaded;
       this.width = props.width || 128;
-      this.height = props.width || 128;
+      this.height = props.height || 128;
       this.cropper = null;
     }
     unmount () {


### PR DESCRIPTION
**Summary:**
In Fudan University, we prefer use an official 3:4 rectangle photo as the user's avatar image. Yet, we need to change the crop size. During our work, we noticed that a square crop size was always used no matter what we set. Finally, we found the typo in cropperMaker.js

According to the comment in the file: 

> height: desired height in px if the final cropped image

 I think it's a typo.

```JavaScript
this.height = props.width || 128;
```

should be

```JavaScript
this.height = props.height || 128;
```

This patch won't change the current behavior of Canvas, since the size of the avatar is defined in 'AvatarDialogView.js' with 128x128.
