### PR TITLE
Make locked profile pic left float

### DIFF
--- a/app/stylesheets/bundles/profile_edit.scss
+++ b/app/stylesheets/bundles/profile_edit.scss
@@ -100,10 +100,14 @@ li[id$=service_google_docs] {
   }
 }
 
-.profile_pic_link {
+.profile_pic {
   position: relative;
   float: direction(left);
   margin-#{direction(right)}: 5px;
+}
+
+.profile_pic_link {
+  @extend .profile_pic;
 
   .icon-edit {
     background: rgba(0, 0, 0, .75);

--- a/app/views/profile/profile.html.erb
+++ b/app/views/profile/profile.html.erb
@@ -66,7 +66,7 @@
         title: t('titles.click_to_change_profile_pic', "Click to change profile pic"),
         sr_content: t('Click to change profile picture for %{display_name}', :display_name => @user.short_name)) %>
   <% else %>
-    <%= avatar(@user, url: nil, edit: false) %>
+    <%= avatar(@user, url: nil, edit: false, class: "profile_pic") %>
   <% end %>
 <% end %>
 <h1 style="padding-top: 0.3em;"><%= t("%{user}'s Settings", :user => @user.short_name) %></h1>


### PR DESCRIPTION
**Summary:**
In the profile page, if the current user can edit the avatar, the picture will appear on the left side of the user name. While the current user cannot edit the avatar, the picture will appear on the top of the user name. It's better to unify the picture style with different states.

**Test Plan**
Enable 'User Avatars' in Admin Settings.

By default, after a user upload a image, the avatar_state would be 'approved'.
When current user can edit the avatar:
![approved](https://user-images.githubusercontent.com/1639290/58406117-7bfd6100-809b-11e9-9d9e-6f93025f1f97.png)

Then if change the 'avatar_state' of 'User' table in DB to 'locked', and user cannot edit the avatar:
![locked](https://user-images.githubusercontent.com/1639290/58406156-8fa8c780-809b-11e9-9f86-c85746823330.png)

Note: I failed to find an easy way to change  'avatar_state' of a user, although some test cases are defined in spec. 
https://github.com/instructure/canvas-lms/blob/fa26ddce1663e47a59a1162bc1bda48dd9e3fcbe/spec/lib/user_merge_spec.rb#L105
https://github.com/instructure/canvas-lms/blob/fa26ddce1663e47a59a1162bc1bda48dd9e3fcbe/spec/apis/v1/users_api_spec.rb#L834
https://github.com/instructure/canvas-lms/blob/fa26ddce1663e47a59a1162bc1bda48dd9e3fcbe/spec/apis/v1/users_api_spec.rb#L1662

In another PR https://github.com/instructure/canvas-lms/pull/1457 , I modified an API to allow admin to modify this field. Currently, maybe modify DB directly is the easiest way to see the difference.

**Solution:**
Copy left float style from editable style for uneditable pic, and make editable style inherit it.

P.S.
Learned from InstructureCon, I find that admin can change the state of user's avatar by following steps.
1. Login as an account admin.
2. Admin -> People -> Three dots beside '+People' -> Manage profile pictures
3. Lock the corresponding avatar.