### PR TITLE
Allow account admin to modify the state of profile pic via API

### DIFF
--- a/lib/api/v1/user.rb
+++ b/lib/api/v1/user.rb
@@ -91,8 +91,9 @@ module Api::V1::User
 
       json[:merged_into_user_id] = user.merged_into_user_id if user.deleted? && user.merged_into_user_id
 
-      if includes.include?("avatar_url") && user.account.service_enabled?(:avatars)
-        json[:avatar_url] = avatar_url_for_user(user)
+      if user.account.service_enabled?(:avatars)
+        json[:avatar_url] = avatar_url_for_user(user) if includes.include?('avatar_url')
+        json[:avatar_state] = user.avatar_state if includes.include?('avatar_state')
       end
 
       json[:last_name] = user.last_name if includes.include?("last_name")

--- a/spec/apis/v1/users_api_spec.rb
+++ b/spec/apis/v1/users_api_spec.rb
@@ -1698,6 +1698,7 @@ describe "Users API", type: :request do
                         })
         user = User.find(json["id"])
         json.delete("avatar_url")
+        json.delete("avatar_state")
         expect(json).to eq({
                              "name" => "Tobias Funke",
                              "sortable_name" => "Funke, Tobias",
@@ -1908,6 +1909,21 @@ describe "Users API", type: :request do
                         })
         user = User.find(json["id"])
         expect(user.avatar_image_source).to eql to_set["type"]
+        expect(user.avatar_state).to eql :locked
+      end
+
+      it "is able to set avatar state manually by an admin" do
+        @student.avatar_state = "approved"
+        @student.save!
+
+        json = api_call(:put, @path, @path_options, {
+                          user: {
+                            avatar: {
+                              state: "locked"
+                            }
+                          }
+                        })
+        user = User.find(json["id"])
         expect(user.avatar_state).to eql :locked
       end
 


### PR DESCRIPTION
**Summary**
This patch allow account admin to 'lock' the profile pic via API.

**Background**
Currently, account admin cannot lock a profile pic via API. So, it's very difficult for admins to use 'official' photos and forbid users to  change it.

Here is the logic of profile pic:

1. ’Enable Profiles' not checked in account settings
Profile pic only shown on the top of menu.

2. 'Enable Profiles' checked and the 'avatar_state' of user is not 'locked'
Profile pic shows in multiple tools, and user can edit their own pic.

3. 'Enable Profiles' checked and the 'avatar_state' of user is 'locked'
Profile pic shows in multiple tools, and user can not edit their own pic.

So, if an account admin doesn't want users to use self-uploaded pic, it's better to 'lock' the avatar_state. Yet, it seems no API support this function. In the community, some people has to override users pic every day. See [https://community.canvaslms.com/thread/14576-show-official-photo-not-avatar-in-attendance](url)
This solution cannot forbid users upload their own pic, and their may fell strange that their pic will be override in the next day.

Or, use customized CSS and JS to hide the edit function. See[https://community.canvaslms.com/thread/25996-how-can-i-hide-with-css-the-ability-for-users-to-click-their-profile-avatar-in-order-to-change-it](url)
Users still can upload their own pic with some tricks.

**Solution**
This patch will allow account admins to 'lock' the pic and solve this problem.
To achieve this goal, a new parameter **user[avatar][state]** is added to 

> PUT /api/v1/users/:id

An account admin can set the state to 'locked' to lock the profile pic. Even more, an account admin can lock some users' profile pic and allow others to customize it.

**P.S.**
I also find in 'route.rb', there is a route can modify the avatar_state directly.
```ruby
put 'images/users/:user_id' => 'users#update_avatar_image', as: :update_avatar_image
```
I failed to find where to invoke this, and this route is added in the at least 5 years ago.
This route doesn't support invoke by Restful API. 
I think add Restful API support to it can also achieve the same goal.