### PR TITLE
Add colon to license label in course settings page

### DIFF
--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -334,8 +334,8 @@
         </td>
       </tr>
       <tr>
-        <td class="form-label"><%= f.label :license, :en => "License" %></td>
-        <td colspan="3">
+        <td class="form-label"><label for="license"><%= before_label('license', %{License}) %></label></td>
+        <td colspan="3" id="license">
           <% if can_manage %>
             <% cc, non_cc = Course.licenses.map { |id, attrs| [attrs[:readable_license].call, id]}.partition{|n, id| id.start_with?('cc')} %>
             <select name="course[license]" id="course_license">


### PR DESCRIPTION
In course settings page, all filed name is end with a colon except license.

This patch add colon to license field to unify the style in the page.

Before:
![before](https://user-images.githubusercontent.com/1639290/58546157-5dcc6800-8237-11e9-8ed1-57b96e222a39.png)

After:
![after](https://user-images.githubusercontent.com/1639290/58546332-b26fe300-8237-11e9-8552-e3fcbbd576d8.png)

