### PR TITLE
Fix wrong config of format-message

### DIFF
--- a/packages/canvas-planner/src/i18n/indexLocales.js
+++ b/packages/canvas-planner/src/i18n/indexLocales.js
@@ -55,8 +55,8 @@ import zhHans from '../../config/locales/zh.json';
 import zhHant from '../../config/locales/zh_HK.json';
 
 export default {
-  enflip: flipAll(en), ar, bg, cs, da, de, el, 'en-AU': enAU, 'en-GB': enGB, en,
-  es, 'fa-IR': faIR, 'fr-CA': frCA, fr, he, ht, hu, hy, it, ja, ko, mi, nl, nn,
-  nb, pl, 'pt-BR': ptBR, pt, ro, ru, sq, sr, sv, tr, 'uk-UA': ukUA, vi,
-  'zh-Hans': zhHans, 'zh-Hant': zhHant,
+  enflip: flipAll(en), ar, bg, cs, da, de, el, 'en-au': enAU, 'en-gb': enGB, en,
+  es, 'fa-ir': faIR, 'fr-ca': frCA, fr, he, ht, hu, hy, it, ja, ko, mi, nl, nn,
+  nb, pl, 'pt-br': ptBR, pt, ro, ru, sq, sr, sv, tr, 'uk-ua': ukUA, vi,
+  'zh-cn': zhHans, 'zh-tw': zhHant,
 };


### PR DESCRIPTION
**Summary**
In canvas-planner, translations are managed by format-message, but the config is wrong for some locales. format-message use lower-case for region code, while current config use upper-case region code. This make all locales with language-region format won't work properly.

**Steps to reproduce:**

1. Change user language to 'English(United Kindom)‘.
2. Enter site without any content as student or enter 'Student view' as a teacher.
3. In the right side of 'Home' page, there's a section show 'todo' things, and shows 'nothing for now'.

**Expected behavior:**
With en-GB locale, the text should be ’To-do', which is defined in [en-GB.json](https://github.com/instructure/canvas-lms/blob/770b694f037bdad0dcd96097b262511d25c6ba95/packages/canvas-planner/config/locales/en_GB.json#L360).
Yet, it shows ‘To Do', which is defined in [en.json](https://github.com/instructure/canvas-lms/blob/770b694f037bdad0dcd96097b262511d25c6ba95/packages/canvas-planner/config/locales/en.json#L360).

Additionally, if locale is set to Chinese(简体中文 or 繁體中文), no translation of Chinese is used. Instead, English is shown. Although all text have already been translated to Chinese.

![image](https://user-images.githubusercontent.com/1639290/58622810-17424080-82ff-11e9-9a9c-f6b21ccc0d5b.png)

**Reason:**
In canvas-planner, translations are managed by format-message, and format-message use all lower-case for region locale. That means 'en-gb' for English(UK), 'zh-cn' for Chinese(China). The current config file [indexLocales.js](https://github.com/instructure/canvas-lms/blob/770b694f037bdad0dcd96097b262511d25c6ba95/packages/canvas-planner/src/i18n/indexLocales.js#L58) use upper-case for region code, ‘en-GB' for example. And wrongly use 'language-variant'(zh-Hans, zh-Hant) for Chinese which should be 'language-region'(zh-cn, zh-tw). 

More details of locale format can be found in [RFC4646 Tags for Identifying Languages](https://www.ietf.org/rfc/rfc4646.txt). After some tests, it is found that format-message only support locales with 'language' and 'language-region' format. So, when use fr-CA, it fallback to fr, and zh-Hans also fallback to en.

This patch fix the config of format-message for canvas-planner and make it works properly with all locales.