### PR TITLE
Fix path to browsers.yml relative to browser_support.rb

### DIFF
--- a/lib/browser_support.rb
+++ b/lib/browser_support.rb
@@ -26,7 +26,7 @@ BrowserSupport = Struct.new(:browser, :version) do
     end
 
     def configuration
-      @configuration ||= YAML.load_file(File.expand_path('../../config/browsers.yml', __FILE__))
+      @configuration ||= YAML.load_file(File.expand_path('../config/browsers.yml', __FILE__))
     end
 
     def minimum_browsers


### PR DESCRIPTION
Problem
The relative depth to browsers.yml is one level too high.

Solution
Set relative depth to one level up instead of two levels.