### PR TITLE
Add I18n support for 'Unlimited' attempts in _quiz_show_teacher view.

### DIFF
--- a/app/views/quizzes/quizzes/_quiz_show_teacher.html.erb
+++ b/app/views/quizzes/quizzes/_quiz_show_teacher.html.erb
@@ -106,7 +106,7 @@
         </div>
         <div class="controls">
           <span class="value">
-            <%= @quiz.unlimited_attempts? ? "Unlimited" : @quiz.allowed_attempts %>
+            <%= @quiz.unlimited_attempts? ? t(:unlimited, "Unlimited") : @quiz.allowed_attempts %>
           </span>
         </div>
       </div>


### PR DESCRIPTION
**Summary**
All fields in quiz info view for teacher support I18n except the 'Attempts' field with 'Unlimited' value.

**Steps to reproduce**
Create a quiz, check 'Allow Multiple Attempts' and do not check 'Allowed Attempts'. Save it.

**Expected behavior**
All field names of this quiz should support I18n in detail view for teacher.

Yet, the 'Attempts' field with value of 'Unlimited' doesn't support I18n.
Screenshots with different locales are shown as follows:
English:
![image](https://user-images.githubusercontent.com/1639290/58856904-74ab0880-86d6-11e9-81b2-b2c6aa13aca9.png)

Chinese:
![image](https://user-images.githubusercontent.com/1639290/58856950-8c828c80-86d6-11e9-9a17-395e1967e191.png)
