### PR TITLE
Include missing scopes in error message

### DIFF
--- a/app/controllers/oauth2_provider_controller.rb
+++ b/app/controllers/oauth2_provider_controller.rb
@@ -38,7 +38,7 @@ class Oauth2ProviderController < ApplicationController
     raise Canvas::Oauth::RequestError, :invalid_client_id unless provider.has_valid_key?
     raise Canvas::Oauth::RequestError, :invalid_redirect unless provider.has_valid_redirect?
     if provider.key.require_scopes?
-      raise Canvas::Oauth::RequestError, :invalid_scope unless provider.valid_scopes?
+      raise Canvas::Oauth::InvalidScopeError, provider.missing_scopes unless provider.valid_scopes?
     end
 
     session[:oauth2] = provider.session_hash

--- a/lib/canvas/oauth/grant_types/client_credentials.rb
+++ b/lib/canvas/oauth/grant_types/client_credentials.rb
@@ -34,7 +34,7 @@ module Canvas::Oauth
 
       def validate_type
         raise Canvas::Oauth::InvalidRequestError, @provider.error_message unless @provider.valid?
-        raise Canvas::Oauth::RequestError, :invalid_scope unless @provider.valid_scopes?
+        raise Canvas::Oauth::InvalidScopeError, @provider.missing_scopes unless @provider.valid_scopes?
       end
 
       def generate_token

--- a/lib/canvas/oauth/invalid_scope_error.rb
+++ b/lib/canvas/oauth/invalid_scope_error.rb
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2018 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+module Canvas::Oauth
+  class InvalidScopeError < RequestError
+    def initialize(missing_scopes)
+      super("A requested scope is invalid, unknown, malformed, or exceeds the scope granted by the resource owner. "\
+        "The following scopes were requested, but not granted: #{missing_scopes.to_sentence}")
+    end
+
+    def to_render_data
+      {
+        status: 400,
+        json: {
+          error: :invalid_scope,
+          error_description: @message
+        }
+      }
+    end
+
+    def http_status
+      400
+    end
+  end
+end

--- a/lib/canvas/oauth/provider.rb
+++ b/lib/canvas/oauth/provider.rb
@@ -99,6 +99,10 @@ module Canvas::Oauth
       @scopes.present? && @scopes.all? { |scope| key.scopes.include?(scope) }
     end
 
+    def missing_scopes
+      @scopes.reject { |scope| key.scopes.include?(scope) }
+    end
+
     def self.is_oob?(uri)
       uri == OAUTH2_OOB_URI
     end

--- a/lib/canvas/oauth/request_error.rb
+++ b/lib/canvas/oauth/request_error.rb
@@ -50,11 +50,6 @@ module Canvas::Oauth
         error_description: "incorrect client"
       }.freeze,
 
-      invalid_scope: {
-        error: :invalid_scope,
-        error_description: 'A requested scope is invalid, unknown, malformed, or exceeds the scope granted by the resource owner.'
-      }.freeze,
-
       authorization_code_not_supplied: {
         error: :invalid_request,
         error_description: "You must provide the code parameter when using the authorization_code grant type"

--- a/spec/controllers/oauth2_provider_controller_spec.rb
+++ b/spec/controllers/oauth2_provider_controller_spec.rb
@@ -51,6 +51,7 @@ describe Oauth2ProviderController do
         }
         assert_status(400)
         expect(response.body).to match /A requested scope is invalid/
+        expect(response.body).to include 'not|valid'
       end
 
       it 'renders 400 when scopes empty' do


### PR DESCRIPTION
Since there are quite a lot of possible scopes, it can be difficult to make sure every requested scope is enabled. The error message when a requested scope is missing, doesn't include the scope, which makes this even more difficult. This PR adds a list of missing scopes to the error message.

Test Plan:
  - Set up a developer key with scopes enabled
  - Using a tool like [oauth2-client-shell](https://github.com/neverendingqs/oauth2-client-shell) request access at https://\<canvas-install-url\>/login/oauth2/auth with at least a single scope which is not enabled on the developer key
  - Observe the error message (it should contain the requested scope which is missing, but none of the scopes which are requested, but not enabled).