### PR TITLE
Include content migration hook settings in exported LTI config XML

### DIFF
--- a/lib/cc/basic_lti_links.rb
+++ b/lib/cc/basic_lti_links.rb
@@ -96,6 +96,14 @@ module CC
             ext_node.lticm :property, tool.shared_secret, 'name' => 'shared_secret'
           end
 
+          if cm_settings = tool.settings[:content_migration]
+            ext_node.lticm(:options, 'name' => 'content_migration') do |cm_node|
+              [:export_start_url, :import_start_url].each do |key|
+                cm_node.lticm(:property, cm_settings[key], 'name' => key.to_s) unless cm_settings[key].blank?
+              end
+            end
+          end
+
           extension_exclusions = [
             :custom_fields,
             :vendor_extensions,

--- a/spec/lib/cc/basic_lti_links_spec.rb
+++ b/spec/lib/cc/basic_lti_links_spec.rb
@@ -291,6 +291,21 @@ describe CC::BasicLTILinks do
 
       end
 
+      context "content migrations" do
+        it "adds content migrations settings" do
+          tool.settings[:content_migration] = {
+            export_start_url: "https://example.com/export",
+            import_start_url: "https://example.com/import"
+          }
+          subject.create_blti_link(tool, lti_doc)
+          xml_doc = Nokogiri::XML(xml) { |c| c.nonet.strict }
+          cm_xpath = '//blti:extensions/lticm:options[@name="content_migration"]'
+          export_xpath = "#{cm_xpath}/lticm:property[@name=\"export_start_url\"]"
+          import_xpath = "#{cm_xpath}/lticm:property[@name=\"import_start_url\"]"
+          expect(xml_doc.at_xpath(export_xpath).text).to eq tool.settings[:content_migration][:export_start_url]
+          expect(xml_doc.at_xpath(import_xpath).text).to eq tool.settings[:content_migration][:import_start_url]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds the content migration hooks to the exported XML for LTI tools. These settings were not included, so when a course was copied the import callback would not be called on the copied version of the tool.