### PR TITLE
Only serve from brotli folder if S3 uploading is enabled

### DIFF
--- a/lib/canvas/cdn.rb
+++ b/lib/canvas/cdn.rb
@@ -42,7 +42,7 @@ module Canvas
       def add_brotli_to_host_if_supported(request)
         # there is a /br/ folder on the s3 bucket that has evertying we publish,
         # but encoded as brotli instead of gzip
-        "#{config.host}#{'/br' if config.host && supports_brotli?(request)}"
+        "#{config.host}#{'/br' if config.host && config.enabled && supports_brotli?(request)}"
       end
 
       def supports_brotli?(request)


### PR DESCRIPTION
Currently, if the user has a `canvas_cdn.yml` file, Canvas will always append `/br` to the configured CDN host if the client's browser supports brotli. This is an issue if the user has `enabled: false` set in the YAML as Canvas won't build the `/br` directory unless it is uploading assets to S3.

This fix simply checks to see if S3 uploading is also enabled when performing other checks to see if the brotli S3 bucket should be used.

Test Plan:
  - Toggle the `enabled` value in `canvas_cdn.yml` and observe the generated URLs when loading a page.