### PR TITLE
Added filter on start_at and end_at for account courses api.

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -537,9 +537,24 @@ class AccountsController < ApplicationController
   #   The filter to search by. "course" searches for course names, course codes,
   #   and SIS IDs. "teacher" searches for teacher names
   #
+  # @argument starts_before [Optional, Date]
+  #   If set, only return courses that start before the value (inclusive)
+  #   or their enrollment term starts before the value (inclusive)
+  #   or both the course's start_at and the enrollment term's start_at are set to null.
+  #   The value should be formatted as: yyyy-mm-dd or ISO 8601 YYYY-MM-DDTHH:MM:SSZ.
+  #
+  # @argument ends_after [Optional, Date]
+  #   If set, only return courses that end after the value (inclusive)
+  #   or their enrollment term ends after the value (inclusive)
+  #   or both the course's end_at and the enrollment term's end_at are set to null.
+  #   The value should be formatted as: yyyy-mm-dd or ISO 8601 YYYY-MM-DDTHH:MM:SSZ.
+  #
   # @returns [Course]
   def courses_api
     return unless authorized_action(@account, @current_user, :read_course_list)
+
+    starts_before = CanvasTime.try_parse(params[:starts_before])
+    ends_after = CanvasTime.try_parse(params[:ends_after])
 
     params[:state] ||= %w{created claimed available completed}
     params[:state] = %w{created claimed available completed deleted} if Array(params[:state]).include?('all')
@@ -607,6 +622,20 @@ class AccountsController < ApplicationController
       @courses = @courses.associated_courses
     elsif !params[:blueprint_associated].nil?
       @courses = @courses.not_associated_courses
+    end
+
+    if starts_before || ends_after
+      @courses = @courses.joins(:enrollment_term)
+      if starts_before
+        @courses = @courses.where("
+        (courses.start_at IS NULL AND enrollment_terms.start_at IS NULL)
+        OR courses.start_at <= ? OR enrollment_terms.start_at <= ?", starts_before, starts_before)
+      end
+      if ends_after
+        @courses = @courses.where("
+        (courses.conclude_at IS NULL AND enrollment_terms.end_at IS NULL)
+        OR courses.conclude_at >= ? OR enrollment_terms.end_at >= ?", ends_after, ends_after)
+      end
     end
 
     if params[:by_teachers].is_a?(Array)

--- a/spec/apis/v1/accounts_api_spec.rb
+++ b/spec/apis/v1/accounts_api_spec.rb
@@ -965,6 +965,98 @@ describe "Accounts API", type: :request do
       end
     end
 
+    describe "?starts_before" do
+      before :once do
+        @me = @user
+        [:c1, :c2, :c3, :c4].each do |course|
+          instance_variable_set("@#{course}".to_sym, course_model(:name => course.to_s, :account => @a1, :start_at => 2.days.ago))
+        end
+
+        @c2.start_at = 1.week.ago
+        @c2.save!
+
+        term = @c3.root_account.enrollment_terms.create! :start_at => 3.days.ago.change(:usec => 0)
+        @c3.start_at = nil
+        @c3.enrollment_term = term
+        @c3.save!
+
+        @c4.start_at = nil
+        @c4.save!
+
+        @user = @me
+      end
+
+      it "should not apply if not specified" do
+        json = api_call(:get, "/api/v1/accounts/#{@a1.id}/courses",
+                        { :controller => 'accounts', :action => 'courses_api',
+                           :account_id => @a1.to_param, :format => 'json' })
+        expect(json.collect{|row| row['name']}).to eql ['c1', 'c2', 'c3', 'c4']
+      end
+
+      it "should filter inclusively and include null values" do
+        date = @c3.enrollment_term.start_at
+        json = api_call(:get, "/api/v1/accounts/#{@a1.id}/courses?starts_before=#{date.iso8601}",
+                        { :controller => 'accounts', :action => 'courses_api',
+                          :account_id => @a1.to_param, :format => 'json', :starts_before => date.iso8601 })
+        expect(json.collect{|row| row['name']}).to eql ['c2', 'c3', 'c4']
+      end
+
+      it "should filter and sort without asploding" do
+        date = @c3.enrollment_term.start_at
+        json = api_call(:get, "/api/v1/accounts/#{@a1.id}/courses?starts_before=#{date.iso8601}&sort=course_name&order=desc",
+                        { :controller => 'accounts', :action => 'courses_api',
+                          :account_id => @a1.to_param, :format => 'json', :starts_before => date.iso8601,
+                          :sort => 'course_name', :order => 'desc' })
+        expect(json.collect{|row| row['name']}).to eql ['c4', 'c3', 'c2']
+      end
+    end
+
+    describe "?ends_after" do
+      before :once do
+        @me = @user
+        [:c1, :c2, :c3, :c4].each do |course|
+          instance_variable_set("@#{course}".to_sym, course_model(:name => course.to_s, :account => @a1, :conclude_at => 2.days.from_now))
+        end
+
+        @c2.conclude_at = 1.week.from_now
+        @c2.save!
+
+        term = @c3.root_account.enrollment_terms.create! :end_at => 3.days.from_now.change(:usec => 0)
+        @c3.conclude_at = nil
+        @c3.enrollment_term = term
+        @c3.save!
+
+        @c4.conclude_at = nil
+        @c4.save!
+
+        @user = @me
+      end
+
+      it "should not apply if not specified" do
+        json = api_call(:get, "/api/v1/accounts/#{@a1.id}/courses",
+                        { :controller => 'accounts', :action => 'courses_api',
+                           :account_id => @a1.to_param, :format => 'json' })
+        expect(json.collect{|row| row['name']}).to eql ['c1', 'c2', 'c3', 'c4']
+      end
+
+      it "should filter inclusively and include null values" do
+        date = @c3.enrollment_term.end_at
+        json = api_call(:get, "/api/v1/accounts/#{@a1.id}/courses?ends_after=#{date.iso8601}",
+                        { :controller => 'accounts', :action => 'courses_api',
+                          :account_id => @a1.to_param, :format => 'json', :ends_after => date.iso8601 })
+        expect(json.collect{|row| row['name']}).to eql ['c2', 'c3', 'c4']
+      end
+
+      it "should filter and sort without asploding" do
+        date = @c3.enrollment_term.end_at
+        json = api_call(:get, "/api/v1/accounts/#{@a1.id}/courses?ends_after=#{date.iso8601}&sort=course_name&order=desc",
+                        { :controller => 'accounts', :action => 'courses_api',
+                          :account_id => @a1.to_param, :format => 'json', :ends_after => date.iso8601,
+                          :sort => 'course_name', :order => 'desc' })
+        expect(json.collect{|row| row['name']}).to eql ['c4', 'c3', 'c2']
+      end
+    end
+
     describe "?by_teachers" do
       before :once do
         @me = @user


### PR DESCRIPTION
Changed AccountsController.courses_api to support filtering courses
that start before a value and end after a value. Courses that have
a null value for the field will still be returned. The term's respective
field will also be checked. Either the course or term field passing
the filter will cause the course to be returned.

Test Plan:
  - Jenkins passes