### PR TITLE
Point Unsplash setup instructions to Wiki

### DIFF
--- a/app/views/plugins/_unsplash_settings.html.erb
+++ b/app/views/plugins/_unsplash_settings.html.erb
@@ -19,8 +19,8 @@
 <%= fields_for :settings, OpenObject.new(settings) do |f| %>
   <table style="width: 500px;" class="formtable">
     <tr>
-      <td colspan="2"><%= mt(:description, <<-TEXT, unsplash_url: 'https://unsplash.com/documentation#registering-your-application')
-You will need to register a [new app on Unsplash](%{unsplash_url}).
+      <td colspan="2"><%= mt(:description, <<-TEXT, unsplash_wiki_url: 'https://github.com/instructure/canvas-lms/wiki/Canvas-Integration#unsplash')
+Please [follow the steps](%{unsplash_wiki_url}) to setup a new application on Unsplash.
 TEXT
       %></td>
     </tr>


### PR DESCRIPTION
👋 I had messaged @claydiffrient to see if we could add some extra clarification for developers registering with the API.

Specifically for our API review team, It would be helpful to have users following this process note that they're creating a Canvas LMS application when applying for the Unsplash API. That will speed our team's review up.

I [updated the wiki entry](https://github.com/instructure/canvas-lms/wiki/Canvas-Integration#unsplash), so I thought it was best to point this line here.