### PR TITLE
Updated Selenium Testing Doc

### DIFF
--- a/doc/testing_with_selenium.md
+++ b/doc/testing_with_selenium.md
@@ -35,7 +35,7 @@ Gerrit host. See the README for details.
 the tests in. Homebrew is the easiest way to go:
 
 ```sh
-brew install chromedriver # necessary for running tests in Chrome
+brew cask install chromedriver # necessary for running tests in Chrome
 brew install geckodriver # necessary for running tests in Firefox
 ```
 


### PR DESCRIPTION
```bash
brew install chromedriver
```
returns an error because there is no available formula present. Brew presents a cask `chromedriver` as an alternative. So I've updated the bash command in the docs to reflect