### PR TITLE
Fix zip expand progress bar

### DIFF
--- a/app/coffeescripts/react_files/modules/UploadQueue.js
+++ b/app/coffeescripts/react_files/modules/UploadQueue.js
@@ -48,6 +48,9 @@ class UploadQueue {
     const uploader = fileOptions.expandZip
       ? new ZipUploader(fileOptions, folder, contextId, contextType)
       : new FileUploader(fileOptions, folder)
+    uploader.onProgress = () => {
+      this.onChange();
+    };
     uploader.cancel = () => {
       if (uploader._xhr != null) {
         uploader._xhr.abort()

--- a/app/coffeescripts/react_files/modules/ZipUploader.js
+++ b/app/coffeescripts/react_files/modules/ZipUploader.js
@@ -79,6 +79,18 @@ export default class ZipUploader extends BaseUploader {
       if (results.workflow_state === 'failed') {
         return this.deferred.reject()
       } else if (results.completion < 100) {
+        // The progress bar defaults to 50% complete to account for the actual
+        // file upload. When we start polling the progress and the job hasn't
+        // been worked, the completion is 0. So without this check, the progress
+        // bar would start at 50%, then render to 0%, then render to 50% once
+        // the job starts getting worked.
+        if (results.completion > 0) {
+          const progress = {
+            loaded: results.completion,
+            total: 100,
+          }
+          this.trackProgress(progress);
+        }
         setTimeout(() => {
           this.pullMigrationProgress(url)
         }, 1000)

--- a/lib/canvas/migration/worker/zip_file_worker.rb
+++ b/lib/canvas/migration/worker/zip_file_worker.rb
@@ -36,10 +36,18 @@ class Canvas::Migration::Worker::ZipFileWorker < Canvas::Migration::Worker::Base
 
       folder = cm.context.folders.find(cm.migration_settings[:folder_id])
 
-      progress = 0.0
       update_callback = lambda{|pct|
-        if pct - progress >= 1.0
-          cm.update_import_progress(pct)
+        percent_complete = pct * 100
+
+        scaled = percent_complete
+
+        if cm.import_immediately?
+          scaled = scaled / 2 + 50
+        end
+
+        # Only update if progress has incremented 1 percent
+        if scaled - cm.progress >= 1
+          cm.update_import_progress(percent_complete)
         end
       }
 

--- a/spec/coffeescripts/react_files/modules/UploadQueueSpec.js
+++ b/spec/coffeescripts/react_files/modules/UploadQueueSpec.js
@@ -17,14 +17,16 @@
  */
 
 import UploadQueue from 'compiled/react_files/modules/UploadQueue'
+import sinon from 'sinon'
 import $ from 'jquery'
 
-const mockFileOptions = (name = 'foo', type = 'bar') => ({
+const mockFileOptions = (name = 'foo', type = 'bar', expandZip = false) => ({
   file: {
     size: 1,
     name,
     type
-  }
+  },
+  expandZip,
 })
 const mockFileUploader = file => ({
   upload() {
@@ -102,4 +104,13 @@ test('getAllUploaders includes the current uploader', function() {
   equal(all.indexOf(sentinel), 0)
   this.queue.currentUploader = undefined
   this.queue.attemptNextUpload = original
+})
+
+test('Calls onChange', function() {
+  const spy = sinon.spy(this.queue, 'onChange');
+  const foo = mockFileOptions('foo', 'bar', true);
+  const uploader = this.queue.createUploader(foo);
+
+  uploader.onProgress();
+  equal(spy.calledOnce, true);
 })

--- a/spec/coffeescripts/react_files/modules/ZipUploaderSpec.js
+++ b/spec/coffeescripts/react_files/modules/ZipUploaderSpec.js
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2019 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ZipUploader from 'compiled/react_files/modules/ZipUploader';
+import * as uploader from 'jsx/shared/upload_file'
+import $ from 'jquery';
+import 'jquery.ajaxJSON';
+
+const mockFileOptions = function(name, type, size) {
+  return {
+    file: {
+      name,
+      type,
+      size,
+    },
+  };
+}
+
+QUnit.module('ZipUploader', {
+  setup() {
+    const folder = {id: 1};
+    this.uploader = new ZipUploader(mockFileOptions('foo', 'bar', 1), folder, '1', 'courses');
+  },
+  teardown() {
+    delete this.uploader;
+  }
+})
+
+test('posts to the files endpoint to kick off upload', function() {
+  sandbox.stub($, 'ajaxJSON');
+  this.uploader.upload();
+  equal($.ajaxJSON.calledWith('/api/v1/courses/1/content_migrations'), true, 'kicks off upload');
+})
+
+test('stores params from preflight for actual upload', function() {
+  const server = sinon.fakeServer.create()
+  const payload = {
+    pre_attachment: {
+      upload_url: "/upload/url",
+      upload_params: {
+        key: "value",
+      },
+    },
+    id: 1,
+  }
+  server.respondWith('POST', '/api/v1/courses/1/content_migrations', [
+    200,
+    {'Content-Type': 'application/json'},
+    JSON.stringify(payload),
+  ])
+  sandbox.stub(this.uploader, '_actualUpload')
+  this.uploader.upload()
+  server.respond()
+  equal(this.uploader.uploadData.upload_url, '/upload/url')
+  equal(this.uploader.uploadData.upload_params.key, 'value')
+  server.restore()
+})
+
+test('completes upload after preflight', function(assert) {
+  const done = assert.async()
+  const server = sinon.fakeServer.create()
+  const response = {
+    pre_attachment: {
+      upload_url: "/s3/upload/url",
+      upload_params: {
+        success_url: "/success/url",
+      },
+    },
+    id: 1,
+  }
+  server.respondWith('POST', '/api/v1/courses/1/content_migrations', [
+    200,
+    {'Content-Type': 'application/json'},
+    JSON.stringify(response),
+  ])
+  sandbox.stub(this.uploader, 'getContentMigration')
+  sandbox.stub(uploader, 'completeUpload').returns(Promise.resolve({id: 's3-id'}))
+  const promise = this.uploader.upload()
+  server.respond()
+  setTimeout(() => { this.uploader.deferred.resolve() }, 100)
+  return promise.then(() => {
+    ok(this.uploader.getContentMigration.calledOnce, 'got content migration')
+    server.restore()
+    done()
+  })
+})
+
+test('tracks progress', function(assert) {
+  const done = assert.async()
+  const server = sinon.fakeServer.create()
+  const post_response = {
+    pre_attachment: {
+      upload_url: "/s3/upload/url",
+      upload_params: {
+        success_url: "/success/url",
+      },
+    },
+    id: 1,
+  }
+  server.respondWith('POST', '/api/v1/courses/1/content_migrations', [
+    200,
+    {'Content-Type': 'application/json'},
+    JSON.stringify(post_response),
+  ])
+
+  const cm_response = {
+    progress_url: "/api/v1/progress/1",
+  }
+
+  const running_progress_response = {
+    id: "1",
+    context_id: "1",
+    context_type: "ContentMigration",
+    user_id: "1",
+    tag: "content_migration",
+    completion: 90.0,
+    workflow_state: "running",
+    url: "/api/v1/progress/1"
+  }
+
+  const completed_progress_response = {
+    id: "1",
+    context_id: "1",
+    context_type: "ContentMigration",
+    user_id: "1",
+    tag: "content_migration",
+    completion: 100.0,
+    workflow_state: "completed",
+    url: "/api/v1/progress/1"
+  }
+
+  sandbox.stub(this.uploader, 'trackProgress')
+  sandbox.stub(uploader, 'completeUpload').returns(Promise.resolve({id: 's3-id'}))
+  const promise = this.uploader.upload()
+
+  let count = 0;
+  const getJSONstub = sinon.stub($, 'getJSON').callsFake((url) => {
+    if (url === '/api/v1/courses/1/content_migrations/1') {
+      return Promise.resolve(cm_response);
+    } else if (url === '/api/v1/progress/1' && count === 0) {
+      count++;
+      return Promise.resolve(running_progress_response);
+    } else if (url === '/api/v1/progress/1') {
+      return Promise.resolve(completed_progress_response);
+    }
+  })
+
+  setTimeout(() => { this.uploader.deferred.resolve() }, 100)
+  server.respond()
+
+  return promise.then(() => {
+    ok(this.uploader.trackProgress.calledOnce, 'got track progress')
+    server.restore()
+    getJSONstub.restore()
+    done()
+  })
+})
+
+test('roundProgress returns back rounded values', function() {
+  sandbox.stub(this.uploader, 'getProgress').returns(0.18); // progress is [0 .. 1]
+  equal(this.uploader.roundProgress(), 18);
+})
+
+test('roundProgress returns back values no greater than 100', function() {
+  sandbox.stub(this.uploader, 'getProgress').returns(1.1); // something greater than 100%
+  equal(this.uploader.roundProgress(), 100);
+})
+
+test('getFileName returns back the option name if one exists', function() {
+  const folder = {id: 1};
+  const options = mockFileOptions('foo', 'bar', 1);
+  options.name = 'use this one';
+  this.uploader = new ZipUploader(options, folder);
+  equal(this.uploader.getFileName(), 'use this one');
+})
+
+test('getFileName returns back the actual file if no optinal name is given', function() {
+  const folder = {id: 1};
+  const options = mockFileOptions('foo', 'bar', 1);
+  this.uploader = new ZipUploader(options, folder);
+  equal(this.uploader.getFileName(), 'foo');
+})


### PR DESCRIPTION
Fix backend to update progress if progress has incremented 1 percent.
Fix frontend to re-render when a progress has been polled.

Test Plan:
  - Upload and expand a zip into a course.
  - Watch the network traffic and inspect the progress poll and you should see the completion number increment.
  - The progress bar should now grow stronger with each passing poll; it can do it, just like the little engine that could.
  - Now test uploading and expanding into user files.
  - Now test uploading and expanding into group files.