### PR TITLE
Make make_unique_filename deal with extensions starting with digits

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1813,7 +1813,7 @@ class Attachment < ActiveRecord::Base
     addition = 1
     dir = File.dirname(filename)
     dir = dir == "." ? "" : "#{dir}/"
-    extname = filename[/(\.[A-Za-z][A-Za-z0-9]*)+$/] || ''
+    extname = filename[/(\.[A-Za-z][A-Za-z0-9]*)*(\.[A-Za-z0-9]*)$/] || ''
     basename = File.basename(filename, extname)
 
     until block.call(new_name = "#{dir}#{basename}-#{addition}#{extname}")

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1164,6 +1164,10 @@ describe Attachment do
       expect(Attachment.make_unique_filename('blah.tar.bz2', ['blah.tar.bz2'])).to eq 'blah-1.tar.bz2'
     end
 
+    it "deals with extensions starting with a digit" do
+      expect(Attachment.make_unique_filename('blah.3dm', ['blah.3dm'])).to eq 'blah-1.3dm'
+    end
+
     it "does not treat numbers after a decimal point as extensions" do
       expect(Attachment.make_unique_filename('section 11.5.doc', ['section 11.5.doc'])).to eq 'section 11.5-1.doc'
       expect(Attachment.make_unique_filename('3.3.2018 footage.mp4', ['3.3.2018 footage.mp4'])).to eq '3.3.2018 footage-1.mp4'


### PR DESCRIPTION
Fix an issue where Attachment#make_unique_filename would improperly rename files with extensions starting with digits (e.g. Rhino .3dm files). A file `myfile.3dm` would be renamed to `myfile.3dm-1` rather than `myfile-1.3dm`.

 Test Plan:
   - Upload a file called `myfile.3dm`
   - Upload a different file with the same name
   - Ensure the new file is named `myfile-1.3dm`