### PR TITLE
Fix some JSON in API docs.

### DIFF
--- a/app/controllers/authentication_providers_controller.rb
+++ b/app/controllers/authentication_providers_controller.rb
@@ -20,7 +20,7 @@
 #
 # @model AuthenticationProvider
 #     {
-#       "id": "1",
+#       "id": "AuthenticationProvider",
 #       "description": "",
 #       "properties": {
 #         "identifier_format": {
@@ -144,6 +144,7 @@
 #
 # @model FederatedAttributesConfig
 #     {
+#       "id" : "FederatedAttributesConfig",
 #       "description": "A mapping of Canvas attribute names to attribute names that a provider may send, in order to update the value of these attributes when a user logs in. The values can be a FederatedAttributeConfig, or a raw string corresponding to the \"attribute\" property of a FederatedAttributeConfig. In responses, full FederatedAttributeConfig objects are returned if JIT provisioning is enabled, otherwise just the attribute names are returned.",
 #       "properties": {
 #         "admin_roles": {
@@ -195,6 +196,7 @@
 #
 # @model FederatedAttributeConfig
 #     {
+#       "id": "FederatedAttributeConfig",
 #       "description": "A single attribute name to be federated when a user logs in",
 #       "properties": {
 #         "attribute": {

--- a/app/controllers/developer_key_account_bindings_controller.rb
+++ b/app/controllers/developer_key_account_bindings_controller.rb
@@ -50,7 +50,7 @@
 #            "description": "True if the requested context owns the binding",
 #            "example": "true",
 #            "type": "boolean"
-#          },
+#          }
 #       }
 #     }
 class DeveloperKeyAccountBindingsController < ApplicationController

--- a/app/controllers/group_categories_controller.rb
+++ b/app/controllers/group_categories_controller.rb
@@ -77,7 +77,7 @@
 #         },
 #         "sis_group_category_id": {
 #           "description": "The SIS identifier for the group category. This field is only included if the user has permission to manage or view SIS information.",
-#           "type": "String"
+#           "type": "string"
 #         },
 #         "sis_import_id": {
 #           "description": "The unique identifier for the SIS import. This field is only included if the user has permission to manage SIS information.",

--- a/app/controllers/jwts_controller.rb
+++ b/app/controllers/jwts_controller.rb
@@ -22,6 +22,7 @@
 #
 # @model JWT
 #    {
+#      "id": "JWT",
 #      "properties": {
 #        "token": {
 #           "description": "The signed, encrypted, base64 encoded JWT",

--- a/app/controllers/lti/originality_reports_api_controller.rb
+++ b/app/controllers/lti/originality_reports_api_controller.rb
@@ -91,11 +91,11 @@ module Lti
 #         },
 #         "tool_setting": {
 #            "description": "A ToolSetting object containing optional 'resource_type_code' and 'resource_url'",
-#            "type": "ToolSetting"
+#            "$ref": "ToolSetting"
 #         },
 #         "error_report": {
 #            "description": "A message describing the error. If set, the workflow_state will become 'error.'",
-#            "type": "String"
+#            "type": "string"
 #         },
 #         "submission_time": {
 #            "description": "The submitted_at date time of the submission.",

--- a/app/controllers/lti/plagiarism_assignments_api_controller.rb
+++ b/app/controllers/lti/plagiarism_assignments_api_controller.rb
@@ -21,7 +21,7 @@ module Lti
 #
 # @model LtiAssignment
 #     {
-#       "id": "Assignment",
+#       "id": "LtiAssignment",
 #       "description": "A Canvas assignment",
 #       "properties": {
 #         "id": {

--- a/app/controllers/lti/submissions_api_controller.rb
+++ b/app/controllers/lti/submissions_api_controller.rb
@@ -94,7 +94,7 @@ module Lti
 #         },
 #         "attachments": {
 #           "description": "Files that are attached to the submission",
-#           "type": "File"
+#           "$ref": "File"
 #         }
 #       }
 #     }

--- a/app/controllers/lti/tool_configurations_api_controller.rb
+++ b/app/controllers/lti/tool_configurations_api_controller.rb
@@ -30,9 +30,10 @@
 #         },
 #         "settings": {
 #           "description": "The tool configuration JSON",
-#           "example": { name: "LTI 1.3 Tool" },
+#           "example": { "name": "LTI 1.3 Tool" },
 #           "type": "object"
 #         }
+#       }
 #     }
 
 class Lti::ToolConfigurationsApiController < ApplicationController

--- a/app/controllers/master_courses/master_templates_controller.rb
+++ b/app/controllers/master_courses/master_templates_controller.rb
@@ -47,7 +47,7 @@
 #        },
 #       "latest_migration": {
 #         "description": "Details of the latest migration",
-#         "type": "BlueprintMigration"
+#         "$ref": "BlueprintMigration"
 #        }
 #     }
 #   }

--- a/app/controllers/web_zip_exports_controller.rb
+++ b/app/controllers/web_zip_exports_controller.rb
@@ -23,7 +23,7 @@
 #
 # @model WebZipExport
 #     {
-#       "id": "WebZip",
+#       "id": "WebZipExport",
 #       "description": "",
 #       "properties": {
 #         "id": {


### PR DESCRIPTION
I am writing a wrapper for the Canvas API and wanted to automatically generating the proper datastructures by parsing the description/documentation of these objects. This PR simply makes the JSON parseable and more comformable.