### PR TITLE
Fix adding students to a conference

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -256,6 +256,7 @@ class ConferencesController < ApplicationController
             @conference.add_invitee(u)
           end
           @conference.save
+          @conference.reload # Refresh the conference from the database to get an updated list of users.
           format.html { redirect_to named_context_url(@context, :context_conference_url, @conference.id) }
           format.json { render :json => @conference.as_json(:permissions => {:user => @current_user, :session => session},
                                                             :url => named_context_url(@context, :context_conference_url, @conference)) }

--- a/spec/controllers/conferences_controller_spec.rb
+++ b/spec/controllers/conferences_controller_spec.rb
@@ -165,6 +165,22 @@ describe ConferencesController do
       post 'update', params: {:course_id => @course.id, :id => @conference, :web_conference => {:title => "Something else"}}, :format => 'json'
       expect(response).to be_successful
     end
+
+    it "should return user ids" do
+      user_session(@teacher)
+      @conference = @course.web_conferences.create!(conference_type: "Wimba", user: @teacher)
+      params = {
+        course_id: @course.id,
+        id: @conference,
+        web_conference: {
+          title: "Something else",
+        },
+      }
+      post :update, params: params, format: :json
+      body = JSON.parse(response.body)
+      expect(body["user_ids"]).to include(@teacher.id)
+      expect(body["user_ids"]).to include(@student.id)
+    end
   end
 
   describe "POST 'join'" do


### PR DESCRIPTION
Fix backend to refresh the conference data to get an updated list of
users.

Test Plan:
  - Create a conference and only add one student.
  - Now edit that conference and add another student.
  - If you edit that conference again, that second student should have a checkmark indicating they are an invitee to the conference now.