### PR TITLE
Fix typo in student_planner_spec (Selenium)

### DIFF
--- a/spec/selenium/dashboard/planner/student_planner_spec.rb
+++ b/spec/selenium/dashboard/planner/student_planner_spec.rb
@@ -202,7 +202,7 @@ describe "student planner" do
       user_session(@student1)
     end
 
-    it "opens the sidebar to creata a new To-Do item.", priority: "1", test_id: 3263157 do
+    it "opens the sidebar to create a new To-Do item.", priority: "1", test_id: 3263157 do
       go_to_list_view
       todo_modal_button.click
       expect(todo_save_button).to be_displayed


### PR DESCRIPTION
There was a typo in `canvas-lms/spec/selenium/dashboard/planner/student_planner_spec.rb`. That has been fixed now. This should not change any behaviour and thus, we can be sure that this does not introduce any new bugs.

Test Plan:
  - No special testing needed, since no behaviour was changed.