### PR TITLE
Add number format to pt-BR

### DIFF
--- a/config/locales/locales.yml
+++ b/config/locales/locales.yml
@@ -1221,6 +1221,14 @@ pt-BR:
     formats:
       tiny: "%k:%M"
       tiny_on_the_hour: "%k:%M"
+  number: 
+    currency: 
+      format: 
+        delimiter: "."
+        separator: ","
+    format: 
+      delimiter: "."
+      separator: ","
 ru:
   bigeasy_locale: ru_RU
   date:


### PR DESCRIPTION
The number format for pt-BR is `123.456.789,00`. This change will establish this format at a higher level of preference than is given to the contents of pt-BR.yml, which at this time has these values incorrect.