### PR TITLE
Make add app dialog remain open on document click

### DIFF
--- a/app/jsx/external_apps/components/AddApp.js
+++ b/app/jsx/external_apps/components/AddApp.js
@@ -225,7 +225,12 @@ export default createReactClass({
           {I18n.t('Add App')}
         </a>
 
-        <Modal open={this.state.modalIsOpen} onDismiss={this.closeModal} label={I18n.t('Add App')}>
+        <Modal 
+          open={this.state.modalIsOpen} 
+          onDismiss={this.closeModal}
+          label={I18n.t('Add App')}
+          shouldCloseOnDocumentClick={false}
+        >
           <Modal.Body>
             {this.errorMessage()}
             <form>{this.configOptions()}</form>


### PR DESCRIPTION
This dialog is large enough and complicated enough that it stinks when you're inputting
lots of data and happen to brush your trackpad or something causing it to close and lose
data. :(

Test Plan:
  - Go to external apps and add an app
  - When the modal to add the app opens, click outside of it.
  - The modal should stay open.