### PR TITLE
Prevent page error when Dashcard position contains string

### DIFF
--- a/app/presenters/course_for_menu_presenter.rb
+++ b/app/presenters/course_for_menu_presenter.rb
@@ -42,7 +42,7 @@ class CourseForMenuPresenter
       id: course.id,
       isFavorited: course.favorite_for_user?(@user) && @user.account.feature_enabled?(:unfavorite_course_from_dashboard),
       image: course.feature_enabled?(:course_card_images) ? course.image : nil,
-      position: @user.dashboard_positions[course.asset_string] || nil,
+      position: @user.dashboard_positions[course.asset_string].to_i || nil,
     }.tap do |hash|
       if @opts[:tabs]
         tabs = course.tabs_available(@user, {

--- a/app/presenters/course_for_menu_presenter.rb
+++ b/app/presenters/course_for_menu_presenter.rb
@@ -42,7 +42,12 @@ class CourseForMenuPresenter
       id: course.id,
       isFavorited: course.favorite_for_user?(@user) && @user.account.feature_enabled?(:unfavorite_course_from_dashboard),
       image: course.feature_enabled?(:course_card_images) ? course.image : nil,
-      position: @user.dashboard_positions[course.asset_string].to_i || nil,
+      position: if @user.dashboard_positions[course.asset_string].present? == true
+                    @user.dashboard_positions[course.asset_string].to_i
+                else
+                    nil
+                end
+       # @user.dashboard_positions[course.asset_string].to_i || nil,
     }.tap do |hash|
       if @opts[:tabs]
         tabs = course.tabs_available(@user, {

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -97,7 +97,7 @@ describe DashboardHelper do
         mapped_courses = map_courses_for_menu(courses)
         expect(mapped_courses.map {|h| h[:id]}).to eq [course3.id, course2.id, course1.id]
       end
-      
+
       it "handles sorting even when positions are strings" do
         course1 = @account.courses.create!
         course2 = @account.courses.create!
@@ -109,6 +109,23 @@ describe DashboardHelper do
         courses = [course1, course2, course3]
         user.dashboard_positions[course1.asset_string] = 3
         user.dashboard_positions[course2.asset_string] = "2"
+        user.dashboard_positions[course3.asset_string] = 1
+        user.save!
+        @current_user = user
+        mapped_courses = map_courses_for_menu(courses)
+        expect(mapped_courses.map {|h| h[:id]}).to eq [course3.id, course2.id, course1.id]
+      end
+      it "handles sorting even when positions are nil" do
+        course1 = @account.courses.create!
+        course2 = @account.courses.create!
+        course3 = @account.courses.create!
+        user = user_model
+        course1.enroll_student(user)
+        course2.enroll_student(user)
+        course3.enroll_student(user)
+        courses = [course1, course2, course3]
+        user.dashboard_positions[course1.asset_string] = nil
+        user.dashboard_positions[course2.asset_string] = 2
         user.dashboard_positions[course3.asset_string] = 1
         user.save!
         @current_user = user

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -97,6 +97,24 @@ describe DashboardHelper do
         mapped_courses = map_courses_for_menu(courses)
         expect(mapped_courses.map {|h| h[:id]}).to eq [course3.id, course2.id, course1.id]
       end
+      
+      it "handles sorting even when positions are strings" do
+        course1 = @account.courses.create!
+        course2 = @account.courses.create!
+        course3 = @account.courses.create!
+        user = user_model
+        course1.enroll_student(user)
+        course2.enroll_student(user)
+        course3.enroll_student(user)
+        courses = [course1, course2, course3]
+        user.dashboard_positions[course1.asset_string] = 3
+        user.dashboard_positions[course2.asset_string] = "2"
+        user.dashboard_positions[course3.asset_string] = 1
+        user.save!
+        @current_user = user
+        mapped_courses = map_courses_for_menu(courses)
+        expect(mapped_courses.map {|h| h[:id]}).to eq [course3.id, course2.id, course1.id]
+      end
     end
   end
 end


### PR DESCRIPTION
When set_dashboard_positions is given a string instead of an integer, they are happily stored in the user record.
Later when the dashboard is rendered, Ruby tries to sort the dashcards by :position and this means that a string is compared against an int, crashing the application with "comparison of String with 2 failed" or something similar.

Test Plan:
- Added new test case in dashboard_helper_spec.rb as suggested by @claydiffrient in the previous pull request #1407 

```
Jonathans-MacBook-Pro:canvas-lms jonathannovecio$ docker-compose run --rm web bundle exec rspec spec/helpers/dashboard_helper_spec.rb
Starting canvas-lms_postgres_1 ... done
Starting canvas-lms_redis_1    ... done
/home/docker/.gem/ruby/2.4.0/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/encodedregistry.rb:150: warning: constant ::Fixnum is deprecated
/home/docker/.gem/ruby/2.4.0/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/encodedregistry.rb:216: warning: constant ::Fixnum is deprecated
DEPRECATION WARNING: `secrets.secret_token` is deprecated in favor of `secret_key_base` and will be removed in Rails 6.0. (called from <top (required)> at /usr/src/app/config/environment.rb:28)
Run options: exclude {:pact_live_events=>true}

Randomized with seed 47507
........

Finished in 9.01 seconds (files took 27.31 seconds to load)
8 examples, 0 failures

Randomized with seed 47507

```