### PR TITLE
Remove duplicated config in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,8 +104,6 @@ Layout/DotPosition:
   EnforcedStyle: trailing
 Layout/AlignHash:
   Enabled: false
-Layout/AlignParameters:
-  Enabled: false
 Style/Lambda:
   Enabled: false
 Style/WhileUntilModifier:


### PR DESCRIPTION
In .rubocop.yml
Line 11,12 are same as Line107,108
```yml
Layout/AlignParameters:
  Enabled: false
```
The duplicated config may raise a warning of some IDE tools.