### PR TITLE
Fix scope typo (auth/userinfo -> /auth/userinfo)

### DIFF
--- a/doc/api/oauth_endpoints.md
+++ b/doc/api/oauth_endpoints.md
@@ -206,7 +206,7 @@ See <a href="http://tools.ietf.org/html/rfc6749#section-4.1.3">Section 4.1.3</a>
   }
   </pre>
 
-  <p>If scope=auth/userinfo was specified in the
+  <p>If scope=/auth/userinfo was specified in the
   <a href=oauth_endpoints.html#get-login-oauth2-auth>GET login/oauth2/auth</a> request (ex: when using Canvas as an authentication service)
   then the response that results from
   <a href=oauth_endpoints.html#post-login-oauth2-token>POST login/oauth2/token</a> would be:</p>


### PR DESCRIPTION
This super-simple commit just fixes a typo that calls the `/auth/userinfo` scope `auth/userinfo`.