### PR TITLE
Add API endpoints to edit and delete submission comments

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1206,7 +1206,12 @@ CanvasRails::Application.routes.draw do
         action: :select, as: 'select_provisional_grade'
     end
 
-    post '/courses/:course_id/assignments/:assignment_id/submissions/:user_id/comments/files', action: :create_file, controller: :submission_comments_api
+    scope(controller: :submission_comments_api) do
+      post '/courses/:course_id/assignments/:assignment_id/submissions/:user_id/comments/files', action: :create_file
+      put 'courses/:course_id/assignments/:assignment_id/submissions/:user_id/comments/:id', action: :update
+      delete 'courses/:course_id/assignments/:assignment_id/submissions/:user_id/comments/:id', action: :destroy
+    end
+
     post '/courses/:course_id/assignments/:assignment_id/submissions/:user_id/annotation_notification', action: :annotation_notification, controller: :submission_comments_api
 
     scope(controller: :gradebook_history_api) do


### PR DESCRIPTION
Teachers are able to edit and remove comments that they post on student submissions. However, there is no way to edit or delete submission comments programmatically using the API.

These changes add `DELETE` and `PUT` operations at `/api/v1/courses/:course_id:/assignments/:assignment_id/submissions/:user_id/comments/:id`. In addition, test cases and documentation have been added for the endpoints.

This is related to and potentially fixes the issue #1350.