### PR TITLE
Update documentation for CalenderEventsApiController#set_course_timeable_events

### DIFF
--- a/app/controllers/calendar_events_api_controller.rb
+++ b/app/controllers/calendar_events_api_controller.rb
@@ -962,6 +962,9 @@ class CalendarEventsApiController < ApplicationController
   #   A unique identifier that can be used to update the event at a later time
   #   If one is not specified, an identifier will be generated based on the start and end times
   #
+  # @argument events[][title] [Optional, String]
+  #   Title for the meeting. If not present, will default to the associated course's name
+  #
   def set_course_timetable_events
     get_context
     if authorized_action(@context, @current_user, :manage_calendar)

--- a/app/models/courses/timetable_event_builder.rb
+++ b/app/models/courses/timetable_event_builder.rb
@@ -69,6 +69,7 @@ module Courses
     # with :start_at, :end_at required
     # and optionally :location_name (other attributes could be added here if so desired)
     # :code can be used to give it a unique identifier for syncing (otherwise will be generated based on the times)
+    # :title can be used to give a title to the event (otherwise a the name of the associated course will be used)
     def create_or_update_events(event_hashes)
       timetable_codes = event_hashes.map{|h| h[:code]}
       raise "timetable codes can't be blank" if timetable_codes.any?(&:blank?)


### PR DESCRIPTION
events[][title] is a allowed parameter for the `POST CalenderEventsApiController#set_course_timetable_events` call, however the API documentation does not list this. Since we want to use this parameter we would like the API documentation to be up-to-date in this regard.

Test Plan:
  - Check /doc/api/calendar_events.html#method.calendar_events_api.set_course_timetable_events to see if events[][title] is listed as parameter
  - Check you can actually set the events title using this call :>. (relevant code at app/models/courses/timetable_event_builder.rb:162)