### PR TITLE
Forbid anonymous to iterate all people's avatar images.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -176,7 +176,7 @@ class UsersController < ApplicationController
     :user_dashboard, :toggle_hide_dashcard_color_overlays,
     :masquerade, :external_tool, :dashboard_sidebar, :settings, :activity_stream,
     :activity_stream_summary, :pandata_events_token, :dashboard_cards,
-    :user_graded_submissions]
+    :user_graded_submissions, :avatar_image]
   before_action :require_registered_user, :only => [:delete_user_service,
     :create_user_service]
   before_action :reject_student_view_student, :only => [:delete_user_service,


### PR DESCRIPTION
**Summary**
Currently, anonymous user can iterate and download all avatar images from Canvas.
I think this is a security issue.

**Reproduce**
1. With a Canvas instance with 'User Avatars' enabled.
2. An user upload his/her avatar image(profile image) in personal settings.

Given the user's internal id (the id in DB table 'users') is 12345.
Anyone can access the image with the following URL
https://the.canvas.site/images/users/123456

For example, you can view my avatar image with the following URL without logging in the system.
https://training.instructure.com/images/users/9228544

Furthermore, an attacker can iterate and download all avatar images by iterating the user id, which is an auto increment number.

**Expected Behavior**
Anonymous user can view the avatar images in some cases, in notification emails for example.
But, anonymous user should not has the ability to iterate all avatar images.

**Solution**
Only logged in user can access 'avatar_image_url'. Add method 'avatar_image' to 'before_action :require_user'