### PR TITLE
Add I18n support for conversation message

### DIFF
--- a/app/messages/conversation_created.email.erb
+++ b/app/messages/conversation_created.email.erb
@@ -26,7 +26,7 @@
 
 
 <% if asset.conversation.subject.present? %>
-  Subject: <%= asset.conversation.subject %>
+  <%= t "Subject: %{subject}", subject: asset.conversation.subject %>
 <% end %>
 
 <%= asset.body %>

--- a/app/messages/conversation_message.email.erb
+++ b/app/messages/conversation_message.email.erb
@@ -25,7 +25,7 @@
 <% end %>
 
 <% if asset.conversation.subject.present? %>
-  Subject: <%= asset.conversation.subject %>
+  <%= t "Subject: %{subject}", subject: asset.conversation.subject %>
 <% end %>
 
 <%= asset.body %>


### PR DESCRIPTION
In 
app/messages/conversation_created.email.erb
and
app/messages/conversation_message.email.erb
The word 'Subject:' can not be translated.

This patch add I18n support for these two files.