### PR TITLE
Courses can also be looked up by the integrationID

### DIFF
--- a/doc/api/object_ids.md
+++ b/doc/api/object_ids.md
@@ -14,7 +14,7 @@ The following objects support SIS IDs in the API:
  * `sis_course_id`
  * `sis_group_id`
  * `sis_group_category_id`
- * `sis_integration_id` (for users)
+ * `sis_integration_id` (for users and courses)
  * `sis_login_id`
  * `sis_section_id`
  * `sis_term_id`


### PR DESCRIPTION
You can lookup courses by an integration ID with a URL like this:

https://instance.instructure.com/api/v1/courses/sis_integration_id:test-int-123