### PR TITLE
Add support for expanding the Course Integration ID

### DIFF
--- a/doc/api/tools_variable_substitutions.md
+++ b/doc/api/tools_variable_substitutions.md
@@ -504,6 +504,15 @@ returns the current course sis source id.
 ```
 1234
 ```
+## Canvas.course.integrationId
+returns the current course integration id.
+
+**Availability**: *when launched in a course*
+
+
+```
+1234
+```
 ## Canvas.course.startAt
 returns the current course start date.
 

--- a/lib/lti/variable_expander.rb
+++ b/lib/lti/variable_expander.rb
@@ -509,6 +509,15 @@ module Lti
                        -> { @context.sis_source_id },
                        COURSE_GUARD
 
+    # returns the current course integration id.
+    # @example
+    #   ```
+    #   1234
+    #   ```
+    register_expansion 'Canvas.course.integrationId', [],
+                       -> { @context.integration_id },
+                       COURSE_GUARD
+
     # returns the current course start date.
     # @example
     #   ```

--- a/spec/lib/lti/variable_expander_spec.rb
+++ b/spec/lib/lti/variable_expander_spec.rb
@@ -921,6 +921,13 @@ module Lti
           expect(exp_hash[:test]).to eq 'course1'
         end
 
+        it 'has substitution for $Canvas.course.integrationId' do
+          course.integration_id = 'integration1'
+          exp_hash = {test: '$Canvas.course.integrationId'}
+          variable_expander.expand_variables!(exp_hash)
+          expect(exp_hash[:test]).to eq 'integration1'
+        end
+
         it 'has substitution for $Canvas.enrollment.enrollmentState' do
           allow(Lti::SubstitutionsHelper).to receive(:new).and_return(substitution_helper)
           allow(substitution_helper).to receive(:enrollment_state).and_return('active')


### PR DESCRIPTION
When performing a LTI launch this allows the course integration ID be expanded in the custom data that is made available in an LTI launch.