### PR TITLE
Add ERB-rendering of `config/logging.yml`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -65,8 +65,8 @@ module CanvasRails
     # Run "rake -D time" for a list of tasks for finding time zone names. Comment line to use default local time.
     config.time_zone = 'UTC'
 
-    log_config = File.exist?(Rails.root+"config/logging.yml") && YAML.load_file(Rails.root+"config/logging.yml")[Rails.env]
-    log_config = { 'logger' => 'rails', 'log_level' => 'debug' }.merge(log_config || {})
+    log_config = Rails.application.config_for(:logging) rescue {}
+    log_config = { 'logger' => 'rails', 'log_level' => 'debug' }.merge(log_config)
     opts = {}
     require 'canvas_logger'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,8 +65,8 @@ module CanvasRails
     # Run "rake -D time" for a list of tasks for finding time zone names. Comment line to use default local time.
     config.time_zone = 'UTC'
 
-    log_config = Rails.application.config_for(:logging) rescue {}
-    log_config = { 'logger' => 'rails', 'log_level' => 'debug' }.merge(log_config)
+    log_config = File.exist?(Rails.root+"config/logging.yml") && Rails.application.config_for(:logging)
+    log_config = { 'logger' => 'rails', 'log_level' => 'debug' }.merge(log_config || {})
     opts = {}
     require 'canvas_logger'
 


### PR DESCRIPTION
## Changes
* Use built-in Rails helper `config_for` for automatic ERB-rendering and YAML-parsing of `config/logging.yml`

This keeps it consistent with how Rails parses other config files in that directory and also makes it easier to specify parameters using environment variables.

See [railties/lib/rails/application.rb#L207](https://github.com/rails/rails/blob/d9bfafd9b8af6d3ee099d6a3d431744b70666aac/railties/lib/rails/application.rb#L207) for more information on `config_for`