### PR TITLE
Add Email to allowed include[] fields for nested User on Enrollment API

### DIFF
--- a/lib/api/v1/user.rb
+++ b/lib/api/v1/user.rb
@@ -281,7 +281,7 @@ module Api::V1::User
         json[:sis_user_id] = pseudonym.try(:sis_user_id)
       end
       json[:html_url] = course_user_url(enrollment.course_id, enrollment.user_id)
-      user_includes = includes & %w{avatar_url group_ids uuid}
+      user_includes = includes & %w{avatar_url group_ids uuid email}
 
       json[:user] = user_json(enrollment.user, user, session, user_includes, @context, nil, []) if includes.include?(:user)
       if includes.include?('locked')


### PR DESCRIPTION
Add email to the list of allowed include[] fields on the enrollment API so nested user blocks can include the email address of the user. This is to avoid thousands of extra API calls to get user email addresses.

 Test Plan:
   - Test that email shows in nested user JSON when on include[] list and caller has appropriate permissions (admin, instructor, etc.)
   - Test that email does not show in nested user JSON when on include[] list and caller does not have appropriate permissions (admin, instructor, etc.)