### PR TITLE
Use smaller line spacing for code blocks

### DIFF
--- a/app/stylesheets/components/_ic-code.scss
+++ b/app/stylesheets/components/_ic-code.scss
@@ -35,6 +35,7 @@ pre {
   display: block;
   padding: $ic-sp * 0.75;
   margin: 0 0 $ic-sp;
+  line-height: 1.2;
   word-break: break-all;
   word-wrap: break-word;
   white-space: pre;


### PR DESCRIPTION
This addresses a use case with courses that have significant code
components on quizzes, in particular if the questions are sensitive to
whitespace with how lines line up with each other (e.g. on format string
questions), which might be difficult to use for students with dyslexia
or similar issues.

Motivation: I had this exact issue in a course I took this term and had to use
the Stylus browser extension to fix it.

# Before
![image](https://user-images.githubusercontent.com/6652840/85340816-a8043500-b49b-11ea-8bdb-3679847e2aa8.png)


# After
![image](https://user-images.githubusercontent.com/6652840/85340781-94f16500-b49b-11ea-9de8-36d4b49efcfb.png)

Test Plan:
- Confirm that `<pre>` code blocks have smaller line spacing than the
  default 1.5.