### PR TITLE
Change canvas_quizzes dependencies to use https instead of git protocol

### DIFF
--- a/client_apps/canvas_quizzes/package.json
+++ b/client_apps/canvas_quizzes/package.json
@@ -54,7 +54,7 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-jsduck": "1.0.1",
     "grunt-sass": "^2.1.0",
-    "grunt-template-jasmine-requirejs": "git://github.com/amireh/grunt-template-jasmine-requirejs.git#0.2.0",
+    "grunt-template-jasmine-requirejs": "https://github.com/amireh/grunt-template-jasmine-requirejs.git#0.2.0",
     "jasmine_react": "1.2.4",
     "jasmine_rsvp": "1.0.0",
     "jasmine_xhr": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10841,9 +10841,9 @@ grunt-sass@^2.1.0:
     node-sass "^4.7.2"
     object-assign "^4.0.1"
 
-"grunt-template-jasmine-requirejs@git://github.com/amireh/grunt-template-jasmine-requirejs.git#0.2.0":
+"grunt-template-jasmine-requirejs@https://github.com/amireh/grunt-template-jasmine-requirejs.git#0.2.0":
   version "0.2.0"
-  resolved "git://github.com/amireh/grunt-template-jasmine-requirejs.git#87ff8c5f607431f00f65fafdc71df67fac88773f"
+  resolved "https://github.com/amireh/grunt-template-jasmine-requirejs.git#87ff8c5f607431f00f65fafdc71df67fac88773f"
 
 grunt@0.4.5:
   version "0.4.5"


### PR DESCRIPTION
The canvas_quizzes dependency for grunt-template-jasmine-requirejs usethe git protocol (`git://`). This is an issue when trying to build in a Docker environment AND when behind a corporate firewall. Git can be configured to prefer `https://` instead of `git://`; however, this configuration takes place in the host's gitconfig file and isn't visible to the git
implementation inside a container (unless you mount your host's gitconfig inside the container, which may or may not be desirable).

This commit changes canvas_quizzes' package.json file to use `https://` instead of `git://`. This resolves the issue of not being able to fetch the dependency from inside a container whilst behind a firewall since Docker will pick up the `https_proxy` environment variables from the host and use the proxy to fetch the dependency via https.

We have been using this change at SFU for many weeks without issue.

**Test plan:**

- check out the repo
- run `yarn`

Expected result:

- all dependencies should be fetched without **issue**

- check out the repo
- run `yarn`

**Expected result:**

- all dependencies should be fetched without issue


