### PR TITLE
Add score statistics to the assignments API as an 'include' option

### DIFF
--- a/app/controllers/assignment_groups_api_controller.rb
+++ b/app/controllers/assignment_groups_api_controller.rb
@@ -27,10 +27,11 @@ class AssignmentGroupsApiController < ApplicationController
   #
   # Returns the assignment group with the given id.
   #
-  # @argument include[] ["assignments"|"discussion_topic"|"assignment_visibility"|"submission"]
+  # @argument include[] ["assignments"|"discussion_topic"|"assignment_visibility"|"submission"|"score_statistics"]
   #   Associations to include with the group. "discussion_topic" and "assignment_visibility" and "submission"
-  #   are only valid if "assignments" is also included. The "assignment_visibility" option additionally
-  #   requires that the Differentiated Assignments course feature be turned on.
+  #   are only valid if "assignments" is also included. "score_statistics" is only valid if "submission" and
+  #   "assignments" are also included. The "assignment_visibility" option additionally requires that the Differentiated Assignments
+  #   course feature be turned on.
   #
   # @argument override_assignment_dates [Boolean]
   #   Apply assignment overrides for each assignment, defaults to true.

--- a/app/controllers/assignment_groups_controller.rb
+++ b/app/controllers/assignment_groups_controller.rb
@@ -101,9 +101,10 @@ class AssignmentGroupsController < ApplicationController
   # Returns the paginated list of assignment groups for the current context.
   # The returned groups are sorted by their position field.
   #
-  # @argument include[] [String, "assignments"|"discussion_topic"|"all_dates"|"assignment_visibility"|"overrides"|"submission"|"observed_users"|"can_edit"]
+  # @argument include[] [String, "assignments"|"discussion_topic"|"all_dates"|"assignment_visibility"|"overrides"|"submission"|"observed_users"|"can_edit"|"score_statistics"]
   #  Associations to include with the group. "discussion_topic", "all_dates", "can_edit",
   #  "assignment_visibility" & "submission" are only valid if "assignments" is also included.
+  #  "score_statistics" requires that the "assignments" and "submission" options are included.
   #  The "assignment_visibility" option additionally requires that the Differentiated Assignments course feature be turned on.
   #  If "observed_users" is passed along with "assignments" and "submission", submissions for observed users will also be included as an array.
   #
@@ -344,6 +345,7 @@ class AssignmentGroupsController < ApplicationController
 
   def index_groups_json(context, current_user, groups, assignments, submissions = [])
     include_overrides = include_params.include?('overrides')
+    include_score_statistics = include_params.include?('score_statistics')
 
     assignments_by_group = assignments.group_by(&:assignment_group_id)
     preloaded_attachments = user_content_attachments(assignments, context)
@@ -368,6 +370,7 @@ class AssignmentGroupsController < ApplicationController
         assignment_visibilities: assignment_visibilities(context, assignments),
         exclude_response_fields: assignment_excludes,
         include_overrides: include_overrides,
+        include_score_statistics: include_score_statistics,
         submissions: submissions,
         closed_grading_period_hash: closed_grading_period_hash,
         master_course_status: mc_status

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -3289,6 +3289,18 @@ class Assignment < ActiveRecord::Base
     grader_comments_visible_to_graders?
   end
 
+  # This only checks whether this assignment allows score statistics to be shown.
+  # You must also check submission.eligible_for_showing_score_statistics
+  def can_view_score_statistics?(user)
+    # The assignment must have points_possible > 0,
+    return false unless (points_possible.present? && points_possible > 0)
+
+    # Students can only see statistics when count >= 5 and not disabled by the instructor
+    # Instructor can see statistics at any time.
+    count = score_statistic&.count || 0
+    context.grants_right?(user, :read_as_admin) || (count >= 5 && !context.hide_distribution_graphs)
+  end
+
   def grader_ids_to_anonymous_ids
     @grader_ids_to_anonymous_ids ||= moderation_graders.each_with_object({}) do |grader, map|
       map[grader.user_id.to_s] = grader.anonymous_id

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2521,6 +2521,13 @@ class Submission < ActiveRecord::Base
     end
   end
 
+  # You must also check the assignment.can_view_score_statistics
+  def eligible_for_showing_score_statistics?
+    # This checks whether this submission meets the requirements in order
+    # for the submitter to be able to see score statistics for the assignment
+    (score.present? && !hide_grade_from_student?)
+  end
+
   def posted?
     # NOTE: This really should be a call to assignment.course.post_policies_enabled?
     # but we're going to leave it the way it is for the next few months (until

--- a/app/presenters/grade_summary_assignment_presenter.rb
+++ b/app/presenters/grade_summary_assignment_presenter.rb
@@ -43,9 +43,9 @@ class GradeSummaryAssignmentPresenter
     @originality_reports.present?
   end
 
-  def hide_distribution_graphs?
-    submission_count = @summary.assignment_stats[assignment.id]&.count || 0
-    submission_count < 5 || assignment.context.hide_distribution_graphs?
+  def show_distribution_graph?
+    @assignment.score_statistic = @summary.assignment_stats[assignment.id] # Avoid another query
+    @assignment.can_view_score_statistics?(@current_user)
   end
 
   def is_unread?

--- a/app/views/gradebooks/grade_summary.html.erb
+++ b/app/views/gradebooks/grade_summary.html.erb
@@ -135,7 +135,6 @@
       <%
          submission = assignment_presenter.submission
          assignment = assignment_presenter.assignment
-         can_view_distribution = can_do(@context, @current_user, :read_as_admin) || !assignment_presenter.hide_distribution_graphs?
       %>
     <tr class="<%= assignment_presenter.classes %>"
         data-muted="<%= assignment_presenter.hide_grade_from_student? %>"
@@ -294,7 +293,7 @@
           <a href="#"
             class="toggle_score_details_link tooltip"
             aria-label="<%= t('See scoring details') %>"
-          <% if assignment_presenter.has_scoring_details? && can_view_distribution %>
+          <% if assignment_presenter.has_scoring_details? && assignment_presenter.show_distribution_graph? %>
             aria-expanded="false"
             aria-controls="grade_info_<%= assignment.id %>"
           <% else %>
@@ -434,7 +433,7 @@
       <tr id="grade_info_<%= assignment.id %>" class="comments grade_details <%= 'assignment_graded' if assignment_presenter.graded? %>" style="display: none;">
         <% if assignment_presenter.should_display_details? %>
           <td colspan="6" style="padding-bottom: 20px;">
-            <% if assignment_presenter.has_grade_distribution? && can_view_distribution %>
+            <% if assignment_presenter.has_grade_distribution? && assignment_presenter.show_distribution_graph? %>
               <table id="score_details_<%= assignment.id %>" class="ic-Table ic-Table--condensed score_details_table">
                 <thead>
                   <tr>

--- a/lib/api/v1/assignment_group.rb
+++ b/lib/api/v1/assignment_group.rb
@@ -63,6 +63,10 @@ module Api::V1::AssignmentGroup
           in_closed_grading_period_hash(group.context, assignments)
       end
 
+      if includes.include?('score_statistics')
+        ActiveRecord::Associations::Preloader.new.preload(assignments, :score_statistic)
+      end
+
       hash['assignments'] = assignments.map do |assignment|
         overrides = if opts[:overrides].present?
           opts[:overrides].select { |override| override.assignment_id == assignment.id }
@@ -79,6 +83,7 @@ module Api::V1::AssignmentGroup
           override_dates: opts[:override_assignment_dates],
           preloaded_user_content_attachments: user_content_attachments,
           include_visibility: includes.include?('assignment_visibility'),
+          include_score_statistics: includes.include?('score_statistics'),
           assignment_visibilities: opts[:assignment_visibilities].try(:[], assignment.id),
           exclude_response_fields: exclude_fields,
           overrides: overrides,


### PR DESCRIPTION
Provides an API for the information in the grade distribution graphs shown in the web UI on the 'Grades' screen to students.

The permissions model is identical: students can view grade grade distribution (min, max, mean) only if all of the following:
- The 'hide_distribution_graphs' setting is NOT enabled by the instructor in the course's settings
- There are at least 5 graded submissions
- The student's submission is graded, and the grade is visible to them.

Instructors (or anyone with the read_admin permission) can always view distributions when they are looking at a student with a graded assignment.

Test Plan:
  - Make API requests to the GET endpoints for individual assignments, assignment groups, and for listing all assignments for a course
  - Test these API endpoints with and without the include[]=score_statistics flag.
  - Verify that the statistics match those shown in the grade distribution graphs on in the web UI
  - Verify that the statistics are only available in the API when there are 5 graded submissions and when not disabled by the instructor (this behavior should match the distribution graphs in the web UI)

My ultimate goal is to add this functionality to the iOS app, once this gets merged.