### PR TITLE
Remove cache-with-validation from set_no_cache_headers to prevent Safari caching images

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1283,7 +1283,7 @@ class ApplicationController < ActionController::Base
 
   def set_no_cache_headers
     response.headers["Pragma"] = "no-cache"
-    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Cache-Control"] = "no-store"
   end
 
   def set_page_view


### PR DESCRIPTION
 This update is to assist the Safari CORS issues with Canvas uploaded images that are served from an AWS S3 bucket. Safari errors out with CORS error. This is only when Safari makes a CORS OPTIONS validate request on the cached image, that other browsers do not make.

> FetchEvent.respondWith received an error: TypeError: Cross-origin redirection to https://instructure-uploads.s3.amazonaws.com/[the bucket link and params] denied by Cross-Origin Resource Sharing policy: Origin [the Canvas LMS DNS] is not allowed by Access-Control-Allow-Origin.

Only Safari is caching and making the validate request. Chrome and Firefox do not.
According to the Mozilla Cache-Control post, the "no-cache,no-store" is contradictory:

> **GOOD:** "Cache-Control: no-store"
> **BAD**: "Cache-Control: no-cache,no-store"
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

> no-cache:
> The response may be stored by any cache, even if the response is normally non-cacheable. However, the stored response MUST always go through validation with the origin server first before using it, therefore, you cannot use no-cache in-conjunction with immutable. If you mean to not store the response in any cache, use no-store instead. This directive is not effective in preventing caches from storing your response.
