### PR TITLE
Correct spelling of "woops" error message to more common usage

### DIFF
--- a/app/jsx/not_found_page/NotFoundArtwork.js
+++ b/app/jsx/not_found_page/NotFoundArtwork.js
@@ -32,7 +32,7 @@ const NotFoundArtwork = () => (
         <SVGWrapper url="/images/not_found_page/empty-planet.svg" />
       </Container>
       <Heading level="h2" as="h1" margin="x-small 0 0">
-        {I18n.t('Woops... Looks like nothing is here!')}
+        {I18n.t('Whoops... Looks like nothing is here!')}
       </Heading>
       <Container margin="small" display="block">
         <Text level="h4" margin="x-small">

--- a/app/jsx/not_found_page/__tests__/NotFoundArtwork.test.js
+++ b/app/jsx/not_found_page/__tests__/NotFoundArtwork.test.js
@@ -30,7 +30,7 @@ test('renders the NotFoundArtwork component', () => {
 test('renders the NotFoundArtwork renders correct header', () => {
   const tree = mount(<NotFoundArtwork {...defaultProps()} />)
   const node = tree.find('Heading')
-  expect(node.text()).toBe('Woops... Looks like nothing is here!')
+  expect(node.text()).toBe('Whoops... Looks like nothing is here!')
 })
 
 test('renders the NotFoundArtwork component help description', () => {

--- a/spec/selenium/assignments/assignments_spec.rb
+++ b/spec/selenium/assignments/assignments_spec.rb
@@ -705,7 +705,7 @@ describe "assignments" do
     it "should not show the moderation page if it is not a moderated assignment ", priority: "2", test_id: 609653 do
       @assignment.update_attribute(:moderated_grading, false)
       get "/courses/#{@course.id}/assignments/#{@assignment.id}/moderate"
-      expect(f('#content h1').text).to eql "Woops... Looks like nothing is here!"
+      expect(f('#content h1').text).to eql "Whoops... Looks like nothing is here!"
     end
   end
 


### PR DESCRIPTION
Several people have pointed out that the error message with "woops" uses an unusual spelling, instead of the more common "whoops" as defined by Merriam-Webster. Attached is my somewhat amateur attempt to correct this, as well as the test cases. en-AU, en-CA, and en-GB localizations are left unmodified, as I cannot vouch for the local terminology.