### PR TITLE
Add federated attributes support for CAS logins

### DIFF
--- a/app/controllers/login/cas_controller.rb
+++ b/app/controllers/login/cas_controller.rb
@@ -62,7 +62,11 @@ class Login::CasController < ApplicationController
       reset_session_for_login
 
       pseudonym = @domain_root_account.pseudonyms.for_auth_configuration(st.user, aac)
-      pseudonym ||= aac.provision_user(st.user) if aac.jit_provisioning?
+      if pseudonym
+        aac.apply_federated_attributes(pseudonym, st.extra_attributes)
+      elsif aac.jit_provisioning?
+        pseudonym = aac.provision_user(st.user, st.extra_attributes)
+      end
 
       if pseudonym
         # Successful login and we have a user

--- a/app/models/authentication_provider/cas.rb
+++ b/app/models/authentication_provider/cas.rb
@@ -32,6 +32,11 @@ class AuthenticationProvider::CAS < AuthenticationProvider::Delegated
     [ :unknown_user_url ].freeze
   end
 
+  def self.recognized_federated_attributes
+    # we allow any attribute
+    nil
+  end
+
   def self.supports_debugging?
     debugging_enabled?
   end


### PR DESCRIPTION
This patch adds support for federated attributes to CAS authentication. It was tested at University of Wrocław.