### PR TITLE
automate dev setup with gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,21 @@
+FROM gitpod/workspace-postgres
+
+RUN sudo apt-get update 
+RUN sudo apt -y install zlib1g-dev libxml2-dev libsqlite3-dev libpq-dev libxmlsec1-dev curl build-essential redis-server
+
+# Install Ruby
+ENV RUBY_VERSION=2.6
+RUN rm /home/gitpod/.rvmrc && touch /home/gitpod/.rvmrc && echo "rvm_gems_path=/home/gitpod/.rvm" > /home/gitpod/.rvmrc
+RUN bash -lc "rvm install ruby-$RUBY_VERSION && rvm use ruby-$RUBY_VERSION --default && gem install bundler"
+
+# Install Node and Yarn
+ENV NODE_VERSION=10.16.0
+RUN bash -c ". .nvm/nvm.sh && \
+        nvm install ${NODE_VERSION} && \
+        nvm alias default ${NODE_VERSION} && \
+        npm install -g yarn"
+ENV PATH=/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+RUN sudo apt-get update && sudo apt-get -y install yarn=1.10.1-1

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,38 @@
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 3000
+    onOpen: ignore
+  - port: 5432
+    onOpen: ignore
+  - port: 6379
+    onOpen: ignore
+
+tasks:
+  - name: Canvas Server
+    before: |
+      redis-server &
+    init: >
+      ./bin/gitpod_setup.sh
+    command: >
+      bundle exec rails server
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
+    addComment: false
+    # add a "Review in Gitpod" button to pull requests (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false
+    # add a check to pull requests (defaults to true)
+    addCheck: true

--- a/bin/gitpod_setup.sh
+++ b/bin/gitpod_setup.sh
@@ -1,0 +1,40 @@
+# Get a version of Canvas LMS running as quickly as possible (e.g. for a development environment)
+# https://github.com/instructure/canvas-lms/wiki/Quick-Start
+
+# Install Canvas Dependencies
+bundle install
+yarn install --pure-lockfile
+
+# Data Setup
+for config in amazon_s3 delayed_jobs domain file_store outgoing_mail security external_migration; do cp -v config/$config.yml.example config/$config.yml; done 
+
+# Dynamic settings configuration
+cp config/dynamic_settings.yml.example config/dynamic_settings.yml
+
+# File Generation
+bundle exec rails canvas:compile_assets
+
+# Database configuration
+cp config/database.yml.example config/database.yml
+createdb canvas_development
+
+# Database population
+export CANVAS_LMS_ADMIN_EMAIL=snatarajan@instructure.com && export CANVAS_LMS_ADMIN_PASSWORD=password && export CANVAS_LMS_STATS_COLLECTION=opt_out && export CANVAS_LMS_ACCOUNT_NAME=inst
+bundle exec rails db:initial_setup
+
+# Test database configuration
+psql -c 'CREATE USER canvas' -d postgres
+psql -c 'ALTER USER canvas CREATEDB' -d postgres
+createdb -U canvas canvas_test
+psql -c 'GRANT ALL PRIVILEGES ON DATABASE canvas_test TO canvas' -d canvas_test
+psql -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO canvas' -d canvas_test
+psql -c 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO canvas' -d canvas_test
+RAILS_ENV=test bundle exec rails db:test:reset
+
+# Performance Tweaks
+# Installing redis will significantly improve your Canvas performance
+echo -e "development:\n  cache_store: redis_store" > config/cache_store.yml
+echo -e "development:\n  servers:\n  - redis://localhost" > config/redis.yml
+# Enable class caching
+echo -n 'config.cache_classes = true
+' > config/environments/development-local.rb


### PR DESCRIPTION
Automate canvas dev setup using gitpod. see [dev-setup](https://github.com/instructure/canvas-lms/wiki/Quick-Start) page

what is gitpod?
Gitpod is based on Kubernetes, GitHub, and the new Eclipse Theia project — a VS Code-like IDE that runs in modern browsers. You can think of it as an online IDE with deep GitHub integration (and soon other platforms), providing fully-featured development environments with a single click for any GitHub project, issue, branch or pull request.

Test Plan
a) Register for gitpod account via github.
b) Install chrome extension for gitpod
    click on gitpod button

    OR
    https://gitpod.io#{url to the pull request}

c) Verify that cloud code editor opens. Click on `open port` tab and click on "Open Browser" on 3000 port. Verify that canvas-lms web application opens.
dm san-nat for login/password

d) Use the menu option, open a new terminal & run 
bundle exec rspec spec/models/assignment_spec.rb
Modify one of the tests and run the test.