### PR TITLE
Fix for quiz timer issue #1769

### DIFF
--- a/app/models/quizzes/quiz.rb
+++ b/app/models/quizzes/quiz.rb
@@ -672,7 +672,7 @@ class Quizzes::Quiz < ActiveRecord::Base
     # set to lock date
     if lock_at && !submission.manually_unlocked
       if !end_at || lock_at < end_at
-        end_at = lock_at
+        lock_at = end_at
       end
     elsif !end_at || (fallback_end_at && fallback_end_at < end_at)
       end_at = fallback_end_at


### PR DESCRIPTION
Implements a fix for Issue #1769, where quiz timers would default to the latest availability time of a quiz, instead of granting the full time limit as set by the instructor.

I was able to recreate the issue as described. The fix was very simple: I simply set `lock_at `to equal `end_at `when there is no `end_at` set, or when `lock_at < end_at`. This means that the student should be granted the full time limit, regardless of when they start the quiz within the allotted Available from/Until times.

closes #1769 

Test Plan:
- Create a quiz with an Available from/Until time with a short range (I chose 1 minute)
- Set the Time Limit of the quiz to something greater than the Available from/Until range (I chose 5 minutes)
- Verify that the quiz timer grants the allotted Time Limit to the student for that attempt.
