### PR TITLE
Removed media query to hide assignment availability

### DIFF
--- a/app/stylesheets/bundles/new_assignments.scss
+++ b/app/stylesheets/bundles/new_assignments.scss
@@ -69,14 +69,6 @@
   .default-dates .status-description { font-weight: bold; }
 }
 
-@media screen and (max-width: 1280px) {
-  #course_home_content {
-    .assignment-date-available {
-      visibility: hidden;
-    }
-  }
-}
-
 .form-dialog-content.ag-weights-content {
   bottom: 59px;
   display: flex;


### PR DESCRIPTION
Removed media query that hides assignment availability within the home tab on screens smaller than 1280px. There appears to be no reason the assignment availability should be hidden and hiding the availability removes the information for users on smaller screens and creates an excess of whitespace. 