### PR TITLE
Update redis.rb

### DIFF
--- a/Gemfile.d/redis.rb
+++ b/Gemfile.d/redis.rb
@@ -16,7 +16,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 group :redis do
-  gem 'redis', '4.1.3'
+  gem 'redis', '4.1.4'
   gem 'redis-scripting', '1.0.1'
 
   gem 'digest-murmurhash', '1.1.1'


### PR DESCRIPTION
Update of ruby gem to 4.1.4 will make production log more clean from redis related errors.
Ruby gem v. 4.2.x requires changes in code.