### PR TITLE
Fixed typo in data migration

### DIFF
--- a/db/migrate/20200211143240_split_up_user_preferences.rb
+++ b/db/migrate/20200211143240_split_up_user_preferences.rb
@@ -5,7 +5,7 @@ class SplitUpUserPreferences < ActiveRecord::Migration[5.2]
   def up
     User.find_ids_in_ranges(:batch_size => 20_000) do |min_id, max_id|
       DataFixup::SplitUpUserPreferences.
-        delay_if_production(priority: Delayed::LOW_PRIORITY, n_strand => ["user_preference_migration", Shard.current.database_server.id]).
+        delay_if_production(priority: Delayed::LOW_PRIORITY, n_strand: ["user_preference_migration", Shard.current.database_server.id]).
         run(min_id, max_id)
     end
   end


### PR DESCRIPTION
During the update of the send_later syntax, a typo was introduced in the split user preferences data migration.
This commit fixes that typo so the migration will run again.

Test plan:
- Check out the code before the introduction of this migration
- Ensure you have filled your database with at least one user
- Check out the code including this new migration
- Run the migrations and check that there are no errors