### PR TITLE
Add 'host' and 'username' entry to 'development' database.yml.example

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -12,6 +12,8 @@ development:
   adapter: postgresql
   encoding: utf8
   database: canvas_development
+  host: localhost
+  username: canvas
   password: your_password
   timeout: 5000
 


### PR DESCRIPTION
In `config/database.yml.example` , both `production` and `test` have 7 config entries, while `development` only have 5 with `host` and `username` missing.

This PR add these two config entries to the sample config file.