### PR TITLE
Fix the location of the LTI privacy_level key in docs

### DIFF
--- a/doc/api/lti_dev_key_config.md
+++ b/doc/api/lti_dev_key_config.md
@@ -125,12 +125,12 @@ also found in the placements sub-menu in the left-navigation of this documentati
          "domain":"thebesttool.com",
          "tool_id":"the-best-tool",
          "platform":"canvas.instructure.com",
+         "privacy_level":"public",
          "settings":{  
             "text":"Launch The Best Tool",
             "icon_url":"https://some.icon.url/tool-level.png",
             "selection_height": 800,
             "selection_width": 800,
-            "privacy_level":"public",
             "placements":[  
                {  
                   "text":"User Navigation Placement",
@@ -371,6 +371,31 @@ object for placement-specific target_link_uri's</p>
       </td>
     </tr>
 
+<!-- privacy_level -->  
+    <tr class="request-param ">
+      <td>privacy_level</td>
+      <td>
+
+        Required
+
+      </td>
+      <td>string</td>
+
+
+
+      <td class="param-desc">
+
+<p>What level of user information to send to the external tool.</p>
+
+
+        <p class="param-values">
+          <span class="allowed">Allowed values:</span> <code class="enum">anonymous</code>, <code class="enum">public</code>
+        </p>
+
+      </td>
+    </tr>
+
+
 <!-- settings -->      
     <tr class="request-param ">
       <td>settings</td>
@@ -429,30 +454,6 @@ object for placement-specific target_link_uri's</p>
       <td class="param-desc">
 
 <p>The display width of the iframe. This may be ignored or overidden for some LTI placements due to other UI requirements set by Canvas. Tools are advised to experiment with this setting to see what makes the most sense for their application.</p>
-
-<!-- privacy_level -->  
-    <tr class="request-param ">
-      <td>privacy_level</td>
-      <td>
-
-        Required
-
-      </td>
-      <td>string</td>
-
-
-
-      <td class="param-desc">
-
-<p>What level of user information to send to the external tool.</p>
-
-
-        <p class="param-values">
-          <span class="allowed">Allowed values:</span> <code class="enum">anonymous</code>, <code class="enum">public</code>
-        </p>
-
-      </td>
-    </tr>
 
 <!-- text -->          
       </td>

--- a/doc/api/lti_dev_key_config.md
+++ b/doc/api/lti_dev_key_config.md
@@ -114,7 +114,6 @@ also found in the placements sub-menu in the left-navigation of this documentati
 {  
    "title":"The Best Tool",
    "description":"1.3 Test Tool used for documentation purposes.",
-   "privacy_level":"public",
    "oidc_initiation_url":"https://your.oidc_initiation_url",
    "target_link_uri":"https://your.target_link_uri",
    "scopes":[
@@ -131,6 +130,7 @@ also found in the placements sub-menu in the left-navigation of this documentati
             "icon_url":"https://some.icon.url/tool-level.png",
             "selection_height": 800,
             "selection_width": 800,
+            "privacy_level":"public",
             "placements":[  
                {  
                   "text":"User Navigation Placement",
@@ -223,30 +223,6 @@ also found in the placements sub-menu in the left-navigation of this documentati
 
       </td>
     </tr>    
-
-<!-- privacy_level -->  
-    <tr class="request-param ">
-      <td>privacy_level</td>
-      <td>
-
-        Required
-
-      </td>
-      <td>string</td>
-
-
-
-      <td class="param-desc">
-
-<p>What level of user information to send to the external tool.</p>
-
-
-        <p class="param-values">
-          <span class="allowed">Allowed values:</span> <code class="enum">anonymous</code>, <code class="enum">public</code>
-        </p>
-
-      </td>
-    </tr>
 
 <!-- oidc_initiation_url -->  
     <tr class="request-param ">
@@ -453,6 +429,30 @@ object for placement-specific target_link_uri's</p>
       <td class="param-desc">
 
 <p>The display width of the iframe. This may be ignored or overidden for some LTI placements due to other UI requirements set by Canvas. Tools are advised to experiment with this setting to see what makes the most sense for their application.</p>
+
+<!-- privacy_level -->  
+    <tr class="request-param ">
+      <td>privacy_level</td>
+      <td>
+
+        Required
+
+      </td>
+      <td>string</td>
+
+
+
+      <td class="param-desc">
+
+<p>What level of user information to send to the external tool.</p>
+
+
+        <p class="param-values">
+          <span class="allowed">Allowed values:</span> <code class="enum">anonymous</code>, <code class="enum">public</code>
+        </p>
+
+      </td>
+    </tr>
 
 <!-- text -->          
       </td>


### PR DESCRIPTION
Previously it was in the wrong place and was thus ignored.

Fixes #1794. Thanks @simonnorr and @andrew-gardener for the help in
identifying this issue.