### PR TITLE
Add a feature option to hide global announcements from the dashboard

### DIFF
--- a/app/views/shared/_dashboard_messages.html.erb
+++ b/app/views/shared/_dashboard_messages.html.erb
@@ -20,9 +20,11 @@
 <%# TODO: aria roles for these. maybe use list/listitem or region
     http://www.w3.org/TR/wai-aria/roles#document_structure_roles %>
 <% js_bundle :past_global_alert %>
-<div id='announcementWrapper'>
-  <%= render :partial => 'shared/account_notification', :collection => @announcements %>
-</div>
+<% if !@current_user.feature_enabled?(:disable_dashboard_account_notification_header) %>
+  <div id='announcementWrapper'>
+    <%= render :partial => 'shared/account_notification', :collection => @announcements %>
+  </div>
+<% end %>
 <%= render :partial => 'users/current_conference', :collection => @current_conferences %>
 <%= render :partial => 'users/scheduled_conference', :collection => @scheduled_conferences %>
 <%= render :partial => 'users/welcome' %>

--- a/config/feature_flags/00_standard.yml
+++ b/config/feature_flags/00_standard.yml
@@ -27,6 +27,17 @@ high_contrast:
       distinct and easier to identify. Note: Institution branding will be disabled.
   applies_to: User
   autoexpand: true
+disable_dashboard_account_notification_header:
+  state: allowed
+  display_name:
+    features.disable_dashboard_account_notification_header: Hide Global Announcements on the Dashboard
+  description:
+    disable_dashboard_account_notification_header: |-
+      This stops global announcements from appearing on the top of the dashboard, which can sometimes 
+      clutter the screen on certain devices. Global announcements can still be accessed under Account
+      > Global Announcements.
+  applies_to: User
+  autoexpand: true
 disable_alert_timeouts:
   state: allowed
   display_name:


### PR DESCRIPTION
Global announcements sometimes clutter up the main dashboard for people that don't have very large screens. Additionally, there is no way to automatically hide the announcements, so users are forced to dismiss each new announcement to use the dashboard. With extremely long announcements like the one shown below, this can become a major inconvenience.

<img width="1440" alt="Screen Shot 2021-03-10 at 12 04 21 PM" src="https://user-images.githubusercontent.com/29586909/110678039-d9e13700-81a3-11eb-9513-a6afe015acfa.png">

This pull request adds a setting that allows users to have global announcements not show up on the Dashboard, while still allowing users to view it in the Global Announcements section of the Account tab. Additionally, important notifications and required actions that would normally appear at the top will still appear there regardless of this setting. This setting can be toggled under "Feature Options" in the user's profile settings.

<img width="871" alt="Screen Shot 2021-03-10 at 12 13 32 PM" src="https://user-images.githubusercontent.com/29586909/110678377-3fcdbe80-81a4-11eb-82ab-b3717b7c3715.png">

Site admins can also restrict whether this setting is available or forcefully enable global announcements to appear at the top going to the Feature Options tab in Site Admin Settings, scrolling down to the "user" section at the bottom, and pressing on/allow changes/off next to "Hide Global Announcements on the Dashboard".