### PR TITLE
Use SHA256 for temporary ids in classic quizzes

### DIFF
--- a/app/models/assessment_question.rb
+++ b/app/models/assessment_question.rb
@@ -345,7 +345,7 @@ class AssessmentQuestion < ActiveRecord::Base
   end
 
   def self.variable_id(variable)
-    Digest::MD5.hexdigest(["dropdown", variable, "instructure-key"].join(","))
+    Digest::SHA256.hexdigest(["dropdown", variable, "instructure-key"].join(","))
   end
 
   def clone_for(question_bank, dup=nil, options={})

--- a/app/models/quizzes/quiz_question/base.rb
+++ b/app/models/quizzes/quiz_question/base.rb
@@ -140,20 +140,20 @@ class Quizzes::QuizQuestion::Base
     responses.each do |response|
       found = nil
       if response[:text].try(:strip).present?
-        answer_md5 = Digest::MD5.hexdigest(response[:text].strip)
+        answer_digest = Digest::SHA256.hexdigest(response[:text].strip)
       end
 
       answers.each do |answer|
-        if answer[:id] == response[:answer_id] || answer[:id] == answer_md5
+        if answer[:id] == response[:answer_id] || answer[:id] == answer_digest
           found = true
           answer[:responses] += 1
           answer[:user_ids] << response[:user_id]
         end
       end
 
-      if !found && answer_md5 && (@question_data.is_type?(:numerical) || @question_data.is_type?(:short_answer))
+      if !found && answer_digest && (@question_data.is_type?(:numerical) || @question_data.is_type?(:short_answer))
         answers << {
-          :id => answer_md5,
+          :id => answer_digest,
           :responses => 1,
           :user_ids => [response[:user_id]],
           :text => response[:text]

--- a/app/models/quizzes/quiz_question/fill_in_multiple_blanks_question.rb
+++ b/app/models/quizzes/quiz_question/fill_in_multiple_blanks_question.rb
@@ -111,7 +111,7 @@ class Quizzes::QuizQuestion::FillInMultipleBlanksQuestion < Quizzes::QuizQuestio
         answers.each do |answer|
           found = false
           if (txt = response[:"answer_for_#{answer[:blank_id]}"].try(:strip)).present?
-            answer_md5 = Digest::MD5.hexdigest(txt)
+            answer_digest = Digest::SHA256.hexdigest(txt)
           end
           answer[:responses] += 1 if response[:correct]
           answer[:answer_matches].each do |right|
@@ -122,9 +122,9 @@ class Quizzes::QuizQuestion::FillInMultipleBlanksQuestion < Quizzes::QuizQuestio
             end
           end
           if !found
-            if answer_md5
+            if answer_digest
               match = {
-                :id => answer_md5,
+                :id => answer_digest,
                 :responses => 1,
                 :user_ids => [response[:user_id]],
                 :text => response["answer_for_#{answer[:blank_id]}".to_sym]

--- a/gems/canvas_quiz_statistics/lib/canvas_quiz_statistics/util.rb
+++ b/gems/canvas_quiz_statistics/lib/canvas_quiz_statistics/util.rb
@@ -23,7 +23,7 @@ require 'html_text_helper'
 module CanvasQuizStatistics
   module Util
     def self.digest(str)
-      Digest::MD5.hexdigest((str || '').to_s.strip)
+      Digest::SHA1.hexdigest((str || '').to_s.strip)
     end
 
     # Converts a hash to use symbol keys.

--- a/lib/tasks/canvas/quizzes.rake
+++ b/lib/tasks/canvas/quizzes.rake
@@ -55,7 +55,7 @@ namespace :canvas do
       File.write(out_path, events.to_json(include_root: false))
 
       puts "\tBlob size: #{File.size(out_path)}b (#{(File.size(out_path) / 1000).round}K)"
-      puts "\tBlob signature: #{Digest::MD5.hexdigest(File.read(out_path))}"
+      puts "\tBlob signature: #{Digest::SHA256.hexdigest(File.read(out_path))}"
       puts "Done. Bye!"
       puts '*' * 80
     end

--- a/spec/helpers/quizzes_helper_spec.rb
+++ b/spec/helpers/quizzes_helper_spec.rb
@@ -190,7 +190,8 @@ describe QuizzesHelper do
 
   context 'fill_in_multiple_blanks_question' do
     before(:each) do
-      @question_text = %q|<input name="question_1_1813d2a7223184cf43e19db6622df40b" 'value={{question_1}}' />|
+      @name  = "question_1_#{AssessmentQuestion.variable_id('color')}"
+      @question_text = %Q|<input name="#{@name}" 'value={{question_1}}' />|
       @answer_list = []
       @answers = []
 
@@ -206,7 +207,7 @@ describe QuizzesHelper do
         :answers => @answers
       )
 
-      expect(html).to eq %q|<input name="question_1_1813d2a7223184cf43e19db6622df40b" 'value=red' readonly="readonly" aria-label='Fill in the blank, read surrounding text' />|
+      expect(html).to eq %Q|<input name="#{@name}" 'value=red' readonly="readonly" aria-label='Fill in the blank, read surrounding text' />|
     end
 
     it 'should sanitize user input' do
@@ -221,7 +222,7 @@ describe QuizzesHelper do
         :answers => @answers
       )
 
-      expect(html).to eq %q|<input name="question_1_1813d2a7223184cf43e19db6622df40b" 'value=&gt;&lt;script&gt;alert()&lt;/script&gt;&lt;img' readonly="readonly" aria-label='Fill in the blank, read surrounding text' />|
+      expect(html).to eq %Q|<input name="#{@name}" 'value=&gt;&lt;script&gt;alert()&lt;/script&gt;&lt;img' readonly="readonly" aria-label='Fill in the blank, read surrounding text' />|
       expect(html).to be_html_safe
     end
 
@@ -236,7 +237,7 @@ describe QuizzesHelper do
       expect(html).to match /Fill in the blank/
     end
     it 'should handle equation img tags in the question text' do
-      broken_question_text = "\"<p>Rubisco is a <input class='question_input' type='text' autocomplete='off' style='width: 120px;' name=\\\"question_8_26534e6c8737f63335d5d98ca4136d09\\\" value='{{question_8_26534e6c8737f63335d5d98ca4136d09}}' > responsible for the first enzymatic step of carbon <input class='question_input' type='text' autocomplete='off' style='width: 120px;' name='question_8_f8e302199c03689d87c52e942b56e1f4' value='{{question_8_f8e302199c03689d87c52e942b56e1f4}}' >. <br><br>equation here: <img class=\\\"equation_image\\\" title=\\\"\\sum\\frac{k}{l}\\\" src=\\\"/equation_images/%255Csum%255Cfrac%257Bk%257D%257Bl%257D\\\" alt=\\\"\\sum\\frac{k}{l}\\\"></p>\""
+      broken_question_text = "\"<p>Rubisco is a <input class='question_input' type='text' autocomplete='off' style='width: 120px;' name=\\\"question_8_#{AssessmentQuestion.variable_id('kindof')}\\\" value='{{question_8_26534e6c8737f63335d5d98ca4136d09}}' > responsible for the first enzymatic step of carbon <input class='question_input' type='text' autocomplete='off' style='width: 120px;' name='question_8_#{AssessmentQuestion.variable_id('role')}' value='{{question_8_f8e302199c03689d87c52e942b56e1f4}}' >. <br><br>equation here: <img class=\\\"equation_image\\\" title=\\\"\\sum\\frac{k}{l}\\\" src=\\\"/equation_images/%255Csum%255Cfrac%257Bk%257D%257Bl%257D\\\" alt=\\\"\\sum\\frac{k}{l}\\\"></p>\""
       @answer_list = [
         { blank_id: 'kindof', answer: 'protein'},
         {blank_id: 'role', answer: 'fixing'}
@@ -251,7 +252,7 @@ describe QuizzesHelper do
       expect(html).to match /value='protein'/
     end
     it "should sanitize the answer blocks in the noisy question data" do
-      broken_question_text = "<p><span>\"Roses are <input\n class='question_input'\n type='text'\n autocomplete='off'\n style='width: 120px;'\n name='question_244_ec9a1c7e5a9f3a6278e9055d8dec00f0'\n value='{{question_244_ec9a1c7e5a9f3a6278e9055d8dec00f0}}' />\n, violets are <input\n class='question_input'\n type='text'\n autocomplete='off'\n style='width: 120px;'\n name='question_244_01731fa53c4cf2f32e893d5c3dbae9c1'\n value='{{question_244_01731fa53c4cf2f32e893d5c3dbae9c1}}' />\n\")</span></p>"
+      broken_question_text = "<p><span>\"Roses are <input\n class='question_input'\n type='text'\n autocomplete='off'\n style='width: 120px;'\n name='question_244_#{AssessmentQuestion.variable_id('color1')}'\n value='{{question_244_ec9a1c7e5a9f3a6278e9055d8dec00f0}}' />\n, violets are <input\n class='question_input'\n type='text'\n autocomplete='off'\n style='width: 120px;'\n name='question_244_#{AssessmentQuestion.variable_id('color2')}'\n value='{{question_244_01731fa53c4cf2f32e893d5c3dbae9c1}}' />\n\")</span></p>"
       html = fill_in_multiple_blanks_question(
         question: {question_text: ActiveSupport::SafeBuffer.new(broken_question_text)},
         answer_list: [

--- a/spec/models/quizzes/quiz_statistics/student_analysis_spec.rb
+++ b/spec/models/quizzes/quiz_statistics/student_analysis_spec.rb
@@ -487,7 +487,7 @@ describe Quizzes::QuizStatistics::StudentAnalysis do
     qs = q.generate_submission(@student)
     qs.submission_data = {
       "question_#{q.quiz_data[0][:id]}" => "<em>short_answer</em>",
-      "question_#{q.quiz_data[1][:id]}_10ca8479f89652b254a5c6ec90ab9ab8" => "<em>fimb</em>",
+      "question_#{q.quiz_data[1][:id]}_#{AssessmentQuestion.variable_id("myblank")}" => "<em>fimb</em>",
       "question_#{q.quiz_data[2][:id]}" => "<em>essay</em>",
       "question_#{q.quiz_data[3][:id]}" => "<em>numerical</em>",
       "question_#{q.quiz_data[4][:id]}" => "<em>calculated</em>",

--- a/spec/models/quizzes/submission_grader_spec.rb
+++ b/spec/models/quizzes/submission_grader_spec.rb
@@ -517,7 +517,17 @@ describe Quizzes::SubmissionGrader do
     it "should score a multiple_dropdowns_question" do
       q = multiple_dropdowns_question_data
 
-      user_answer = Quizzes::SubmissionGrader.score_question(q, { "question_1630873_4e6185159bea49c4d29047379b400ad5"=>"6994", "question_1630873_3f507e80e33ef092a02948a064433ec5"=>"5988", "question_1630873_78635a3709b540a59678c806b102d038"=>"9908", "question_1630873_657b11f1c17376f178c4d80c4c25d0ab"=>"1121", "question_1630873_02c8346333761ffe9bbddee7b1c5a537"=>"4390", "question_1630873_1865cbc77c83d7571ed8b3a108d11d3d"=>"7604", "question_1630873_94239fc44b4f8aaf36bd3596768f4816"=>"6955", "question_1630873_cd073d17d0d9558fb2be7d7bf9a1c840"=>"3353", "question_1630873_69d0969351d989767d7096f28daf7461"=>"3390"})
+      user_answer = Quizzes::SubmissionGrader.score_question(q, {
+        "question_1630873_#{AssessmentQuestion.variable_id("structure1")}"=>"4390",
+        "question_1630873_#{AssessmentQuestion.variable_id("event1")}"=>"3390",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure2")}"=>"6955",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure3")}"=>"5988",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure4")}"=>"7604",
+        "question_1630873_#{AssessmentQuestion.variable_id("event2")}"=>"3353",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure5")}"=>"9908",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure6")}"=>"6994",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure7")}"=>"1121",
+      })
       expect(user_answer.delete(:points)).to be_within(0.01).of(0.44)
       expect(user_answer).to eq({
         :question_id => 1630873, :correct => "partial", :text => "",
@@ -541,7 +551,17 @@ describe Quizzes::SubmissionGrader do
         :answer_id_for_structure7 => 1121,
       })
 
-      user_answer = Quizzes::SubmissionGrader.score_question(q, { "question_1630873_4e6185159bea49c4d29047379b400ad5"=>"1883", "question_1630873_3f507e80e33ef092a02948a064433ec5"=>"5988", "question_1630873_78635a3709b540a59678c806b102d038"=>"878", "question_1630873_657b11f1c17376f178c4d80c4c25d0ab"=>"9570", "question_1630873_02c8346333761ffe9bbddee7b1c5a537"=>"1522", "question_1630873_1865cbc77c83d7571ed8b3a108d11d3d"=>"9532", "question_1630873_94239fc44b4f8aaf36bd3596768f4816"=>"1228", "question_1630873_cd073d17d0d9558fb2be7d7bf9a1c840"=>"599", "question_1630873_69d0969351d989767d7096f28daf7461"=>"5498"})
+      user_answer = Quizzes::SubmissionGrader.score_question(q, {
+        "question_1630873_#{AssessmentQuestion.variable_id("structure1")}"=>"1522",
+        "question_1630873_#{AssessmentQuestion.variable_id("event1")}"=>"5498",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure2")}"=>"1228",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure3")}"=>"5988",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure4")}"=>"9532",
+        "question_1630873_#{AssessmentQuestion.variable_id("event2")}"=>"599",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure5")}"=>"878",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure6")}"=>"1883",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure7")}"=>"9570",
+      })
       expect(user_answer).to eq({
         :question_id => 1630873, :correct => false, :points => 0, :text => "",
         :answer_for_structure1 => 1522,
@@ -564,7 +584,17 @@ describe Quizzes::SubmissionGrader do
         :answer_id_for_structure7 => 9570,
       })
 
-      user_answer = Quizzes::SubmissionGrader.score_question(q, { "question_1630873_4e6185159bea49c4d29047379b400ad5"=>"6994", "question_1630873_3f507e80e33ef092a02948a064433ec5"=>"7676", "question_1630873_78635a3709b540a59678c806b102d038"=>"9908", "question_1630873_657b11f1c17376f178c4d80c4c25d0ab"=>"1121", "question_1630873_02c8346333761ffe9bbddee7b1c5a537"=>"4390", "question_1630873_1865cbc77c83d7571ed8b3a108d11d3d"=>"7604", "question_1630873_94239fc44b4f8aaf36bd3596768f4816"=>"6955", "question_1630873_cd073d17d0d9558fb2be7d7bf9a1c840"=>"3353", "question_1630873_69d0969351d989767d7096f28daf7461"=>"3390"})
+      user_answer = Quizzes::SubmissionGrader.score_question(q, {
+        "question_1630873_#{AssessmentQuestion.variable_id("structure1")}"=>"4390",
+        "question_1630873_#{AssessmentQuestion.variable_id("event1")}"=>"3390",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure2")}"=>"6955",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure3")}"=>"7676",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure4")}"=>"7604",
+        "question_1630873_#{AssessmentQuestion.variable_id("event2")}"=>"3353",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure5")}"=>"9908",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure6")}"=>"6994",
+        "question_1630873_#{AssessmentQuestion.variable_id("structure7")}"=>"1121",
+      })
       expect(user_answer).to eq({
         :question_id => 1630873, :correct => true, :points => 0.5, :text => "",
         :answer_for_structure1 => 4390,
@@ -591,12 +621,12 @@ describe Quizzes::SubmissionGrader do
     it "should score a fill_in_multiple_blanks_question" do
       q = fill_in_multiple_blanks_question_data
       user_answer = Quizzes::SubmissionGrader.score_question(q, {
-        "question_1_8238a0de6965e6b81a8b9bba5eacd3e2" => "control",
-        "question_1_a95fbffb573485f87b8c8aca541f5d4e" => "patrol",
-        "question_1_3112b644eec409c20c346d2a393bd45e" => "soul",
-        "question_1_fb1b03eb201132f7c1a5824cf9ebecb7" => "toll",
-        "question_1_90811a00aaf122ea20ab5c28be681ac9" => "assplode",
-        "question_1_ce36b05cfdedbc990a188907fc29d37b" => "old",
+        "question_1_#{AssessmentQuestion.variable_id("answer1")}" => "control",
+        "question_1_#{AssessmentQuestion.variable_id("answer2")}" => "patrol",
+        "question_1_#{AssessmentQuestion.variable_id("answer3")}" => "soul",
+        "question_1_#{AssessmentQuestion.variable_id("answer4")}" => "toll",
+        "question_1_#{AssessmentQuestion.variable_id("answer5")}" => "assplode",
+        "question_1_#{AssessmentQuestion.variable_id("answer6")}" => "old",
       })
       expect(user_answer).to eq(
         { :question_id => 1, :correct => true, :points => 50.0, :text => "",
@@ -616,12 +646,12 @@ describe Quizzes::SubmissionGrader do
       )
 
       user_answer = Quizzes::SubmissionGrader.score_question(q, {
-        "question_1_8238a0de6965e6b81a8b9bba5eacd3e2" => "control",
-        "question_1_a95fbffb573485f87b8c8aca541f5d4e" => "patrol",
-        "question_1_3112b644eec409c20c346d2a393bd45e" => "soul",
-        "question_1_fb1b03eb201132f7c1a5824cf9ebecb7" => "toll",
-        "question_1_90811a00aaf122ea20ab5c28be681ac9" => "wut",
-        "question_1_ce36b05cfdedbc990a188907fc29d37b" => "old",
+        "question_1_#{AssessmentQuestion.variable_id("answer1")}" => "control",
+        "question_1_#{AssessmentQuestion.variable_id("answer2")}" => "patrol",
+        "question_1_#{AssessmentQuestion.variable_id("answer3")}" => "soul",
+        "question_1_#{AssessmentQuestion.variable_id("answer4")}" => "toll",
+        "question_1_#{AssessmentQuestion.variable_id("answer5")}" => "wut",
+        "question_1_#{AssessmentQuestion.variable_id("answer6")}" => "old",
       })
       expect(user_answer.delete(:points)).to be_within(0.1).of(41.6)
       expect(user_answer).to eq(
@@ -642,11 +672,11 @@ describe Quizzes::SubmissionGrader do
       )
 
       user_answer = Quizzes::SubmissionGrader.score_question(q, {
-        "question_1_a95fbffb573485f87b8c8aca541f5d4e" => "0",
-        "question_1_3112b644eec409c20c346d2a393bd45e" => "fail",
-        "question_1_fb1b03eb201132f7c1a5824cf9ebecb7" => "wrong",
-        "question_1_90811a00aaf122ea20ab5c28be681ac9" => "wut",
-        "question_1_ce36b05cfdedbc990a188907fc29d37b" => "oh well",
+        "question_1_#{AssessmentQuestion.variable_id("answer2")}" => "0",
+        "question_1_#{AssessmentQuestion.variable_id("answer3")}" => "fail",
+        "question_1_#{AssessmentQuestion.variable_id("answer4")}" => "wrong",
+        "question_1_#{AssessmentQuestion.variable_id("answer5")}" => "wut",
+        "question_1_#{AssessmentQuestion.variable_id("answer6")}" => "oh well",
       })
       expect(user_answer).to eq(
         { :question_id => 1, :correct => false, :points => 0, :text => "",
@@ -666,14 +696,14 @@ describe Quizzes::SubmissionGrader do
       )
 
       # one blank to fill in
-      user_answer = Quizzes::SubmissionGrader.score_question(fill_in_multiple_blanks_question_one_blank_data, { "question_2_10ca8479f89652b254a5c6ec90ab9ab8" => " DUmB \n " })
+      user_answer = Quizzes::SubmissionGrader.score_question(fill_in_multiple_blanks_question_one_blank_data, { "question_2_3f6f6611d3ce3d57964ae3011b12cad298e2d5f265b4dad9ff56742bac74af5f" => " DUmB \n " })
       expect(user_answer).to eq(
         { :question_id => 2, :correct => true, :points => 3.75, :text => "",
           :answer_for_myblank => " DUmB \n ",
           :answer_id_for_myblank => 1235, }
       )
 
-      user_answer = Quizzes::SubmissionGrader.score_question(fill_in_multiple_blanks_question_one_blank_data, { "question_2_10ca8479f89652b254a5c6ec90ab9ab8" => "wut" })
+      user_answer = Quizzes::SubmissionGrader.score_question(fill_in_multiple_blanks_question_one_blank_data, { "question_2_3f6f6611d3ce3d57964ae3011b12cad298e2d5f265b4dad9ff56742bac74af5f" => "wut" })
       expect(user_answer).to eq(
         { :question_id => 2, :correct => false, :points => 0, :text => "",
           :answer_for_myblank => "wut",
@@ -728,7 +758,7 @@ describe Quizzes::SubmissionGrader do
       # @quiz = @course.quizzes.create!(:title => "new quiz", :shuffle_answers => true)
       q = {:position=>1, :name=>"Question 1", :correct_comments=>"", :question_type=>"fill_in_multiple_blanks_question", :assessment_question_id=>7903, :incorrect_comments=>"", :neutral_comments=>"", :id=>1, :points_possible=>50, :question_name=>"Question 1", :answers=>[], :question_text=>"<p><span>Ayo my quality [answer1].</p>"}
       expect {
-        Quizzes::SubmissionGrader.score_question(q, { "question_1_8238a0de6965e6b81a8b9bba5eacd3e2" => "bleh" })
+        Quizzes::SubmissionGrader.score_question(q, { "question_1_a6e3a7e113750bdf295818b3a4e63e77f19109fbc86f395fb3857e11441c1877" => "bleh" })
       }.not_to raise_error
     end
   end


### PR DESCRIPTION
This PR changes the algorithm to generate temporary quiz ids from MD5 to SHA256.

This is one of a set of PRs to allow Canvas to run on a host with FIPS modules enabled.  FIPS modules disable Digest::MD5 calls, and so we would like to switch to other more modern hashing algorithms.

Test plan:
- specs pass
- regression testing of classic quizzes, in particular:
  - fill in multiple blanks questions
  - multiple dropdowns questions