### PR TITLE
Use SHA256 uuids during importing

### DIFF
--- a/app/models/importers/context_module_importer.rb
+++ b/app/models/importers/context_module_importer.rb
@@ -201,7 +201,7 @@ module Importers
     def self.add_module_item_from_migration(context_module, hash, level, context, item_map, migration)
       hash = hash.with_indifferent_access
       hash[:migration_id] ||= hash[:item_migration_id]
-      hash[:migration_id] ||= Digest::MD5.hexdigest(hash[:title]) if hash[:title]
+      hash[:migration_id] ||= Digest::SHA256.hexdigest(hash[:title]) if hash[:title]
       existing_item = context_module.content_tags.where(id: hash[:id]).first if hash[:id].present?
       existing_item ||= context_module.content_tags.where(migration_id: hash[:migration_id]).first if hash[:migration_id]
       existing_item ||= ContentTag.new(:context_module => context_module, :context => context)

--- a/app/models/importers/link_parser.rb
+++ b/app/models/importers/link_parser.rb
@@ -57,7 +57,7 @@ module Importers
     end
 
     def placeholder(old_value)
-      "#{LINK_PLACEHOLDER}_#{Digest::MD5.hexdigest(old_value)}"
+      "#{LINK_PLACEHOLDER}_#{Digest::SHA256.hexdigest(old_value)}"
     end
 
     def convert_link(node, attr, item_type, mig_id, field)

--- a/app/models/master_courses/master_template.rb
+++ b/app/models/master_courses/master_template.rb
@@ -197,7 +197,7 @@ class MasterCourses::MasterTemplate < ActiveRecord::Base
       obj = submittable # i.e. use the same migration id as the topic on a graded topic's assignment - same restrictions
     end
     key = obj.is_a?(ActiveRecord::Base) ? obj.global_asset_string : obj.to_s
-    "#{self.class.migration_id_prefix(self.shard.id, self.id)}#{Digest::MD5.hexdigest(prepend + key)}"
+    "#{self.class.migration_id_prefix(self.shard.id, self.id)}#{Digest::SHA256.hexdigest(prepend + key)}"
   end
 
   def add_child_course!(child_course_or_id)

--- a/gems/plugins/qti_exporter/lib/qti/converter.rb
+++ b/gems/plugins/qti_exporter/lib/qti/converter.rb
@@ -142,7 +142,7 @@ class Converter < Canvas::Migration::Migrator
     begin
       manifest_file = File.join(@dest_dir_2_1, MANIFEST_FILE)
       Qti.convert_files(manifest_file).each do |attachment|
-        mig_id = Digest::MD5.hexdigest(attachment)
+        mig_id = Digest::SHA256.hexdigest(attachment)
         mig_id = ::Canvas::Migration::MigratorHelper.prepend_id(mig_id, id_prepender)
         @course[:file_map][mig_id] = {
           :migration_id => mig_id,

--- a/lib/canvas/migration/helpers/selective_content_formatter.rb
+++ b/lib/canvas/migration/helpers/selective_content_formatter.rb
@@ -192,7 +192,7 @@ module Canvas::Migration::Helpers
         if atts.length == 1 && atts[0]['file_name'] == folder_name
           content_list << item_hash('attachments', atts[0])
         else
-          mig_id = Digest::MD5.hexdigest(folder_name)
+          mig_id = Digest::SHA256.hexdigest(folder_name)
           folder = {type: 'folders', property: "#{property_prefix}[folders][id_#{mig_id}]", title: folder_name, migration_id: mig_id, sub_items: []}
           content_list << folder
           atts.each {|att| folder[:sub_items] << item_hash('attachments', att)}

--- a/lib/cc/cc_helper.rb
+++ b/lib/cc/cc_helper.rb
@@ -118,7 +118,7 @@ module CCHelper
       key = object.to_s
     end
     # make it obvious if we're using new identifiers now
-    (global ? "g" : "i") + Digest::MD5.hexdigest(prepend + key)
+    (global ? "g" : "i") + Digest::SHA256.hexdigest(prepend + key)
   end
 
   def self.ims_date(date=nil,default=Time.now)

--- a/lib/cc/importer/standard/converter.rb
+++ b/lib/cc/importer/standard/converter.rb
@@ -105,7 +105,7 @@ module CC::Importer::Standard
 
         if File.exists?(full_path)
           # try to make it work even if the file wasn't technically included in the manifest :/
-          mig_id = Digest::MD5.hexdigest(path)
+          mig_id = Digest::SHA256.hexdigest(path)
           file = {:path_name => path, :migration_id => mig_id,
             :file_name => File.basename(path), :type => 'FILE_TYPE'}
           add_course_file(file)

--- a/lib/cc/importer/standard/webcontent_converter.rb
+++ b/lib/cc/importer/standard/webcontent_converter.rb
@@ -62,7 +62,7 @@ module CC::Importer::Standard
           end
           sub_file = {}
           sub_file[:path_name] = file_ref[:href]
-          sub_file[:migration_id] = Digest::MD5.hexdigest(sub_file[:path_name])
+          sub_file[:migration_id] = Digest::SHA256.hexdigest(sub_file[:path_name])
           sub_file[:file_name] = File.basename sub_file[:path_name]
           sub_file[:type] = 'FILE_TYPE'
           add_course_file(sub_file)

--- a/spec/lib/canvas/migration/helpers/selective_content_formatter_spec.rb
+++ b/spec/lib/canvas/migration/helpers/selective_content_formatter_spec.rb
@@ -137,9 +137,9 @@ describe Canvas::Migration::Helpers::SelectiveContentFormatter do
                                                 'a5' => {'path_name' => 'a5.html', 'file_name' => 'a5.html', 'migration_id' => 'a5'},
                                       }}.to_json)
       expect(@formatter.get_content_list('attachments')).to eq [{:type => "folders",
-                                                             :property => "copy[folders][id_0cc175b9c0f1b6a831c399e269772661]",
+                                                             :property => "copy[folders][id_ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb]",
                                                              :title => "a",
-                                                             :migration_id => "0cc175b9c0f1b6a831c399e269772661",
+                                                             :migration_id => "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
                                                              :sub_items =>
                                                                      [{:type => "attachments",
                                                                        :property => "copy[attachments][id_a1]",
@@ -152,9 +152,9 @@ describe Canvas::Migration::Helpers::SelectiveContentFormatter do
                                                                        :migration_id => "a2",
                                                                        :path => "a"}]},
                                                             {:type => "folders",
-                                                             :property => "copy[folders][id_a7e86136543b019d72468ceebf71fb8e]",
+                                                             :property => "copy[folders][id_c14cddc033f64b9dea80ea675cf280a015e672516090a5626781153dc68fea11]",
                                                              :title => "a/b",
-                                                             :migration_id => "a7e86136543b019d72468ceebf71fb8e",
+                                                             :migration_id => "c14cddc033f64b9dea80ea675cf280a015e672516090a5626781153dc68fea11",
                                                              :sub_items =>
                                                                      [{:type => "attachments",
                                                                        :property => "copy[attachments][id_a3]",
@@ -162,9 +162,9 @@ describe Canvas::Migration::Helpers::SelectiveContentFormatter do
                                                                        :migration_id => "a3",
                                                                        :path => "a/b"}]},
                                                             {:type => "folders",
-                                                             :property => "copy[folders][id_cff49f359f080f71548fcee824af6ad3]",
+                                                             :property => "copy[folders][id_d76a7b72669c9cec266b566bdec68efbc8d4f22d1f2689bbf0146bf0b88fdbe9]",
                                                              :title => "a/b/c",
-                                                             :migration_id => "cff49f359f080f71548fcee824af6ad3",
+                                                             :migration_id => "d76a7b72669c9cec266b566bdec68efbc8d4f22d1f2689bbf0146bf0b88fdbe9",
                                                              :sub_items =>
                                                                      [{:type => "attachments",
                                                                        :property => "copy[attachments][id_a4]",

--- a/spec/lib/cc/importer/common_cartridge_converter_spec.rb
+++ b/spec/lib/cc/importer/common_cartridge_converter_spec.rb
@@ -41,7 +41,7 @@ describe "Standard Common Cartridge importing" do
 
   it "should import webcontent" do
     expect(@course.attachments.count).to eq 10
-    atts = %w{I_00001_R I_00006_Media I_media_R f3 f4 f5 8612e3db71e452d5d2952ff64647c0d8 I_00003_R_IMAGERESOURCE 7acb90d1653008e73753aa2cafb16298 6a35b0974f59819404dc86d48fe39fc3}
+    atts = %w{I_00001_R I_00006_Media I_media_R f3 f4 f5 1990144ed5e490199a7690092fbf38634bd5259834697f6e4373ad165e81f44c I_00003_R_IMAGERESOURCE 255f039da8af813a0f967fe389cb0f820c4ef0d4dc5e969eeb4592efe782b31a abbc5cb34ba838d9ff41c49f1b1117ffd41d4ab8e1d681f0920fbd76990d237c}
     atts.each do |mig_id|
       expect(@course.attachments.where(migration_id: mig_id)).to be_exists
     end
@@ -49,7 +49,7 @@ describe "Standard Common Cartridge importing" do
 
   it "should import files as assignments with intended_use set" do
     assignment = @course.assignments.where(:migration_id => "f5").first
-    att = @course.attachments.where(:migration_id => "8612e3db71e452d5d2952ff64647c0d8").first
+    att = @course.attachments.where(:migration_id => "1990144ed5e490199a7690092fbf38634bd5259834697f6e4373ad165e81f44c").first
     expect(assignment.description).to match_ignoring_whitespace(%{<img src="/courses/#{@course.id}/files/#{att.id}/preview">})
     expect(assignment.title).to eq "Assignment 2"
   end
@@ -234,7 +234,7 @@ describe "Standard Common Cartridge importing" do
 
     it "should import webcontent" do
       expect(@course.attachments.active.count).to eq 10
-      mig_ids = %w{I_00001_R I_00006_Media I_media_R f3 f4 I_00003_R_IMAGERESOURCE 7acb90d1653008e73753aa2cafb16298 6a35b0974f59819404dc86d48fe39fc3}
+      mig_ids = %w{I_00001_R I_00006_Media I_media_R f3 f4 I_00003_R_IMAGERESOURCE 255f039da8af813a0f967fe389cb0f820c4ef0d4dc5e969eeb4592efe782b31a abbc5cb34ba838d9ff41c49f1b1117ffd41d4ab8e1d681f0920fbd76990d237c}
       mig_ids.each do |mig_id|
         atts = @course.attachments.where(migration_id: mig_id).to_a
         expect(atts.length).to eq 1
@@ -263,7 +263,7 @@ describe "Standard Common Cartridge importing" do
                         "everything" => "0",
                         "folders" =>
                                 {"I_00006_Media" => true,
-                                 "6a35b0974f59819404dc86d48fe39fc3" => true,
+                                 "abbc5cb34ba838d9ff41c49f1b1117ffd41d4ab8e1d681f0920fbd76990d237c" => true,
                                  "I_00001_R" => true},
                         "all_quizzes" => "1",
                         "all_context_external_tools" => "0",
@@ -281,8 +281,8 @@ describe "Standard Common Cartridge importing" do
                         "all_announcements" => "0",
                         "attachments" =>
                                 {"I_00006_Media" => true,
-                                 "7acb90d1653008e73753aa2cafb16298" => true,
-                                 "6a35b0974f59819404dc86d48fe39fc3" => true,
+                                 "255f039da8af813a0f967fe389cb0f820c4ef0d4dc5e969eeb4592efe782b31a" => true,
+                                 "abbc5cb34ba838d9ff41c49f1b1117ffd41d4ab8e1d681f0920fbd76990d237c" => true,
                                  "I_00003_R_IMAGERESOURCE" => true,
                                  "I_00001_R" => true},
                         "context_modules" => {"I_00000" => true},

--- a/spec/models/importers/course_content_importer_spec.rb
+++ b/spec/models/importers/course_content_importer_spec.rb
@@ -231,15 +231,15 @@ describe Course do
       migration = build_migration(@course, params)
       setup_import(@course, 'assessments.json', migration)
 
-      aqb1 = @course.assessment_question_banks.where(migration_id: "i05dab0b3d55dae214bd0c4787bd6d20f").first
+      aqb1 = @course.assessment_question_banks.where(migration_id: "ic0f7230f2694436788cedf4d6e93ce252483978f878b8050a390d5940e78737b").first
       expect(aqb1.assessment_questions.count).to eq 3
-      aqb2 = @course.assessment_question_banks.where(migration_id: "iaac763df0de1199ef143b2ab8f237e76").first
+      aqb2 = @course.assessment_question_banks.where(migration_id: "i71b5a954dcd0e22e59adc1032a75e8c2e1b8176f203bdf110a9ac97e4fed1754").first
       expect(aqb2.assessment_questions.count).to eq 2
       expect(migration.workflow_state).to eq('imported')
     end
 
     it "should not create assessment question banks if they are not selected" do
-      params = {"copy" => {"assessment_question_banks" => {"i05dab0b3d55dae214bd0c4787bd6d20f" => true},
+      params = {"copy" => {"assessment_question_banks" => {"ic0f7230f2694436788cedf4d6e93ce252483978f878b8050a390d5940e78737b" => true},
                            "quizzes" => {"i7ed12d5eade40d9ee8ecb5300b8e02b2" => true,
                                          "ife86eb19e30869506ee219b17a6a1d4e" => true}}}
 
@@ -247,7 +247,7 @@ describe Course do
       setup_import(@course, 'assessments.json', migration)
 
       expect(@course.assessment_question_banks.count).to eq 1
-      aqb1 = @course.assessment_question_banks.where(migration_id: "i05dab0b3d55dae214bd0c4787bd6d20f").first
+      aqb1 = @course.assessment_question_banks.where(migration_id: "ic0f7230f2694436788cedf4d6e93ce252483978f878b8050a390d5940e78737b").first
       expect(aqb1.assessment_questions.count).to eq 3
       expect(@course.assessment_questions.count).to eq 3
 


### PR DESCRIPTION
This PR changes the digest used to generate import UUIDS from MD5 to SHA256.

This is one of a set of PRs to allow Canvas to run on a host with FIPS modules enabled.  FIPS modules disable Digest::MD5 calls, and so we would like to switch to other more modern hashing algorithms.

Test plan:
  - specs pass
  - regression test course copies and Canvas cartridge imports
  - regression test blueprint copies