### PR TITLE
Use SHA256 for temporary user code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2103,7 +2103,7 @@ class ApplicationController < ActionController::Base
 
   def temporary_user_code(generate=true)
     if generate
-      session[:temporary_user_code] ||= "tmp_#{Digest::MD5.hexdigest("#{Time.now.to_i}_#{rand}")}"
+      session[:temporary_user_code] ||= "tmp_#{Digest::SHA256.hexdigest("#{Time.now.to_i}_#{rand}")}"
     else
       session[:temporary_user_code]
     end

--- a/spec/controllers/quizzes/quizzes_controller_spec.rb
+++ b/spec/controllers/quizzes/quizzes_controller_spec.rb
@@ -39,7 +39,7 @@ describe Quizzes::QuizzesController do
 
   def temporary_user_code(generate=true)
     if generate
-      session[:temporary_user_code] ||= "tmp_#{Digest::MD5.hexdigest("#{Time.now.to_i}_#{rand}")}"
+      session[:temporary_user_code] ||= "tmp_#{Digest::SHA256.hexdigest("#{Time.now.to_i}_#{rand}")}"
     else
       session[:temporary_user_code]
     end

--- a/spec/models/quizzes/quiz_statistics/student_analysis_spec.rb
+++ b/spec/models/quizzes/quiz_statistics/student_analysis_spec.rb
@@ -25,7 +25,7 @@ require 'csv'
 describe Quizzes::QuizStatistics::StudentAnalysis do
 
   def temporary_user_code
-    "tmp_#{Digest::MD5.hexdigest("#{Time.now.to_i}_#{rand}")}"
+    "tmp_#{Digest::SHA256.hexdigest("#{Time.now.to_i}_#{rand}")}"
   end
 
   def survey_with_logged_out_submission


### PR DESCRIPTION
This PR changes the algorithm to generate temporary user codes from MD5 to SHA256.  Temporary user codes seem to be used mainly by classic quizzes.

This is one of a set of PRs to allow Canvas to run on a host with FIPS modules enabled.  FIPS modules disable Digest::MD5 calls, and so we would like to switch to other more modern hashing algorithms.

Test plan:
- specs pass
- logout from canvas and login again
- create a classic quiz and preview it
- submit the preview
- verify that the summary displays correctly