### PR TITLE
Use SHA256 for due_date_cacher job strand name

### DIFF
--- a/lib/due_date_cacher.rb
+++ b/lib/due_date_cacher.rb
@@ -125,7 +125,7 @@ class DueDateCacher
     course = Course.find(course) unless course.is_a?(Course)
     inst_jobs_opts[:max_attempts] ||= 10
     if assignments.nil?
-      inst_jobs_opts[:singleton] ||= "cached_due_date:calculator:Users:#{course.global_id}:#{Digest::MD5.hexdigest(user_ids.sort.join(':'))}"
+      inst_jobs_opts[:singleton] ||= "cached_due_date:calculator:Users:#{course.global_id}:#{Digest::SHA256.hexdigest(user_ids.sort.join(':'))}"
     end
     assignments ||= Assignment.active.where(context: course).pluck(:id)
     return if assignments.empty?

--- a/spec/lib/due_date_cacher_spec.rb
+++ b/spec/lib/due_date_cacher_spec.rb
@@ -256,7 +256,7 @@ describe DueDateCacher do
       expect(DueDateCacher).to receive(:new).and_return(@instance)
       expect(@instance).to receive(:delay_if_production).
         with(
-          singleton: "cached_due_date:calculator:Users:#{@course.global_id}:#{Digest::MD5.hexdigest(student_1.id.to_s)}",
+          singleton: "cached_due_date:calculator:Users:#{@course.global_id}:#{Digest::SHA256.hexdigest(student_1.id.to_s)}",
           max_attempts: 10
         ).
         and_return(@instance)


### PR DESCRIPTION
This PR changes the due_date_catcher job strand name to be based SHA256.

This is one of a set of PRs to allow Canvas to run on a host with FIPS modules enabled.  FIPS modules disable Digest::MD5 calls, and so we would like to switch to other more modern hashing algorithms.

Test plan:
- spec spec/lib/due_date_cacher_spec.rb passes