### PR TITLE
Use SHA256 for random data in specs

### DIFF
--- a/spec/support/test_database_utils.rb
+++ b/spec/support/test_database_utils.rb
@@ -131,7 +131,7 @@ module TestDatabaseUtils
         sequences = get_sequences(connection)
         sequences.each do |sequence|
           # stable random-ish number <= 2**20 so that we don't overflow pre-migrated Version partitions
-          new_val = Digest::MD5.hexdigest("#{seed}#{i}#{sequence}")[0...5].to_i(16) + 1
+          new_val = Digest::SHA256.hexdigest("#{seed}#{i}#{sequence}")[0...5].to_i(16) + 1
           connection.execute("ALTER SEQUENCE #{connection.quote_table_name(sequence)} RESTART WITH #{new_val}")
         end
       end


### PR DESCRIPTION
This PR changes the algorithm used to generate random data in tests.

This is one of a set of PRs to allow Canvas to run on a host with FIPS modules enabled.  FIPS modules disable Digest::MD5 calls, and so we would like to switch to other more modern hashing algorithms.

Switch to using SHA256 to generate random data in tests.

Test plan:
- specs pass