### PR TITLE
Add option to use SHA512 for stored file digests

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -142,7 +142,8 @@ class Attachment < ActiveRecord::Base
       :path_prefix => file_store_config['path_prefix'],
       :s3_access => 'private',
       :thumbnails => { :thumb => '128x128' },
-      :thumbnail_class => 'Thumbnail'
+      :thumbnail_class => 'Thumbnail',
+      :use_sha512_digests => file_store_config['use_sha512_digests'],
   )
 
   # These callbacks happen after the attachment data is saved to disk/s3, or

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -31,7 +31,8 @@ class Thumbnail < ActiveRecord::Base
       :path_prefix => Attachment.file_store_config['path_prefix'],
       :s3_access => 'private',
       :keep_profile => true,
-      :thumbnail_max_image_size_pixels => Setting.get('thumbnail_max_image_size_pixels', 100_000_000).to_i
+      :thumbnail_max_image_size_pixels => Setting.get('thumbnail_max_image_size_pixels', 100_000_000).to_i,
+      :use_sha512_digests => Attachment.file_store_config['use_sha512_digests'],
   )
 
   before_save :set_namespace

--- a/config/file_store.yml.example
+++ b/config/file_store.yml.example
@@ -3,6 +3,10 @@ development:
   # the secure option in this file is deprecated, use the ssl option in domain.yml instead
   # secure: false
   path_prefix: tmp/files
+  # whether to use sha512 instead of md5 for file digests. this is used only for local storage.
+  # when changing this on an existing site, also run the migration fixup to
+  # recompute existing file digests:  DataFixup::MigrateAttachmentDigests.run
+  # use_sha512_digests: true
 
 test:
   storage: local

--- a/gems/canvas_unzip/lib/canvas_unzip.rb
+++ b/gems/canvas_unzip/lib/canvas_unzip.rb
@@ -200,7 +200,7 @@ class CanvasUnzip
     end
 
     # yields byte count
-    def extract(dest_path, overwrite=false, maximum_size=DEFAULT_BYTE_LIMIT)
+    def extract(dest_path, overwrite=false, maximum_size=DEFAULT_BYTE_LIMIT, digest_class: Digest::SHA256)
       dir = self.directory? ? dest_path : File.dirname(dest_path)
       FileUtils.mkdir_p(dir) unless File.exist?(dir)
       return unless self.file?
@@ -210,7 +210,7 @@ class CanvasUnzip
         raise DestinationFileExists, "Destination '#{dest_path}' already exists"
       end
 
-      digest = Digest::MD5.new
+      digest = digest_class.new
       ::File.open(dest_path, "wb") do |os|
         if type == :zip
           entry.get_input_stream do |is|

--- a/lib/data_fixup/migrate_attachment_digests.rb
+++ b/lib/data_fixup/migrate_attachment_digests.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2021 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+# this datafixup is not intended to have a corresponding migration. it will be
+# manually applied
+module DataFixup::MigrateAttachmentDigests
+  # run this to migrate all local md5 attachment hashes to sha512. this only
+  # works for local file storage
+  def self.run
+    # for s3 storage we use the md5 provided in the etag, so we don't want to change those
+    raise 'Cannot migrate attachment digests when configured for s3 storage' if Attachment.s3_storage?
+
+    Attachment.find_ids_in_ranges do |min_id, max_id|
+      delay_if_production(n_strand: ["DataFixup:MigrateAttachmentDigests", Shard.current.database_server.id],
+          priority: Delayed::LOWER_PRIORITY).
+        run_for_attachment_range(min_id, max_id)
+    end
+  end
+
+  def self.run_for_attachment_range(min_id, max_id)
+    update_count = 0
+    max_seconds = Setting.get("max_seconds_per_migrate_attachment_batch", nil).presence&.to_f
+
+    start = Time.now
+    Attachment.where(id: min_id..max_id, instfs_uuid: nil, root_attachment_id: nil).where("length(md5) = 32").order(:id).find_each do |attachment|
+      recompute_attachment_digest(attachment)
+      update_count += 1
+      if max_seconds && Time.now >= start + max_seconds
+        self.requeue(attachment.id + 1, max_id)
+        break
+      end
+    end
+
+    sleep_interval_per_batch = Setting.get("sleep_interval_per_migrate_attachment_batch", nil)&.to_f || 0
+    sleep(sleep_interval_per_batch) if update_count > 0
+  end
+
+  def self.recompute_attachment_digest(attachment)
+    digest = Digest::SHA512.new
+    read_bytes = false
+    attachment.open do |chunk|
+      digest.update(chunk)
+      read_bytes ||= chunk.length > 0
+    end
+
+    if read_bytes
+      attachment.children_and_self.update(md5: digest)
+    else
+      Rails.logger.warn("unable to read attachment #{attachment.global_id}: #{attachment.errors.inspect}")
+    end
+  rescue StandardError => e
+    Rails.logger.warn("unable to read attachment #{attachment.global_id}: #{e}")
+  end
+
+  def self.requeue(*args)
+    delay(n_strand: ["DataFixup:MigrateAttachmentDigests", Shard.current.database_server.id],
+        priority: Delayed::LOWER_PRIORITY).
+      run_for_attachment_range(*args)
+  end
+end

--- a/lib/tasks/db_attachment_migration.rake
+++ b/lib/tasks/db_attachment_migration.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc "migrate local attachment hashes from md5 to sha512"
+  task :migrate_attachments_to_sha512 => :environment do |t,args|
+    # for s3 storage we use the md5 provided in the etag, so we don't want to change those
+    raise 'Cannot migrate attachment digests when configured for s3 storage' if Attachment.s3_storage?
+
+    DataFixup::MigrateAttachmentDigests.run
+  end
+end

--- a/lib/unzip_attachment.rb
+++ b/lib/unzip_attachment.rb
@@ -115,7 +115,7 @@ class UnzipAttachment
         Tempfile.open(filename) do |f|
           begin
             file_size = 0
-            md5 = entry.extract(f.path, true) do |bytes|
+            md5 = entry.extract(f.path, true, digest_class: Attachment.digest_class) do |bytes|
               file_size += bytes
             end
             zip_stats.charge_quota(file_size)

--- a/spec/lib/data_fixup/migrate_attachment_digests_spec.rb
+++ b/spec/lib/data_fixup/migrate_attachment_digests_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2021 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+
+describe DataFixup::MigrateAttachmentDigests do
+  describe "run" do
+    it "creates delayed jobs to update attachments" do
+      attachment1 = attachment_model(uploaded_data: default_uploaded_data)
+      expect(DataFixup::MigrateAttachmentDigests).to receive(:delay_if_production).at_least(:once).and_return(DataFixup::MigrateAttachmentDigests)
+      DataFixup::MigrateAttachmentDigests.run
+    end
+
+    it "updates attachments with md5 digests" do
+      attachment1 = attachment_model(uploaded_data: default_uploaded_data)
+      attachment2 = attachment_model(uploaded_data: default_uploaded_data)
+      attachment1.update(md5: 'eff033fad1e01d0b43a9caf8521ad576')
+      attachment2.update(md5: 'eff033fad1e01d0b43a9caf8521ad576')
+      DataFixup::MigrateAttachmentDigests.run
+      attachment1.reload
+      attachment2.reload
+      expect(attachment1.md5.length).to eq(128)
+      expect(attachment1.md5).to eq attachment2.md5
+    end
+
+    it "ignores inst-fs attachments" do
+      attachment1 = attachment_model(instfs_uuid: 'uuid1',
+                                     uploaded_data: default_uploaded_data)
+      attachment1.update(md5: '01234567890123456789012345678901')
+      DataFixup::MigrateAttachmentDigests.run
+      expect(attachment1.md5).to eq '01234567890123456789012345678901'
+    end
+
+    it "ignores attachments with non-md5 digests" do
+      attachment1 = attachment_model(uploaded_data: default_uploaded_data)
+      attachment1.update(md5: '0123456789')
+      DataFixup::MigrateAttachmentDigests.run
+      expect(attachment1.md5).to eq '0123456789'
+    end
+
+    it "raises error for s3 storage" do
+      allow(Attachment).to receive(:s3_storage?).and_return(true)
+      expect { DataFixup::MigrateAttachmentDigests.run }.to raise_exception(RuntimeError)
+    end
+  end
+
+  describe "run_for_attachment_range" do
+    it "only processes attachments inside the range" do
+      attachment1 = attachment_model(uploaded_data: default_uploaded_data)
+      attachment1.update(md5: '1'*32)
+      attachment2 = attachment_model(uploaded_data: default_uploaded_data)
+      expect(DataFixup::MigrateAttachmentDigests).to receive(:recompute_attachment_digest).exactly(:once)
+      DataFixup::MigrateAttachmentDigests.run_for_attachment_range(attachment1.id, attachment1.id)
+    end
+
+    it "processes all attachments inside the range" do
+      attachment1 = attachment_model(uploaded_data: default_uploaded_data)
+      attachment1.update(md5: '1'*32)
+      attachment2 = attachment_model(uploaded_data: default_uploaded_data)
+      expect(DataFixup::MigrateAttachmentDigests).to receive(:recompute_attachment_digest).exactly(:twice)
+      DataFixup::MigrateAttachmentDigests.run_for_attachment_range(attachment1.id, attachment2.id)
+    end
+  end
+
+  describe "recompute_attachment_digest" do
+    ConfigFile.stub('file_store', { 'use_sha512_digests' => false })
+    let(:file_contents) { 'file contents' }
+    let(:attachment) { attachment_model(uploaded_data: default_uploaded_data) }
+
+    it "calculates the sha512 hash correctly" do
+      DataFixup::MigrateAttachmentDigests.recompute_attachment_digest(attachment)
+      expect(attachment.reload.md5).
+        to eq 'bfaaf6564b32aa18aaab9b3448d2a12a3e011e4897f0266b71fb12879786ecee10928cf9386a6b59924551bbf3bfd51b8ca50942bdb13f81e5dfadaaa80ca938'
+    end
+
+    it "preserves the contents unmodified" do
+      file_contents = attachment.open.read
+      DataFixup::MigrateAttachmentDigests.recompute_attachment_digest(attachment)
+      expect(attachment.open.read).to eql(file_contents)
+    end
+  end
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -455,6 +455,20 @@ describe Attachment do
         @attachment.save
       end
     end
+
+    context "digest classes" do
+      it "should calculate the md5 from uploaded data" do
+        expect(Attachment).to receive(:digest_class).and_return(Digest::MD5)
+        @attachment = attachment_model(:uploaded_data => default_uploaded_data)
+        expect(@attachment.md5).to eql("eff033fad1e01d0b43a9caf8521ad576")
+      end
+
+      it "should calculate the sha512 from uploaded data" do
+        expect(Attachment).to receive(:digest_class).and_return(Digest::SHA512)
+        @attachment = attachment_model(:uploaded_data => default_uploaded_data)
+        expect(@attachment.md5).to eql("bfaaf6564b32aa18aaab9b3448d2a12a3e011e4897f0266b71fb12879786ecee10928cf9386a6b59924551bbf3bfd51b8ca50942bdb13f81e5dfadaaa80ca938")
+      end
+    end
   end
 
   context "ensure_media_object" do


### PR DESCRIPTION
This PR adds the ability to use SHA512 for locally stored file digests.  This change only affects local file storage, and the default remains MD5.

This is one of a set of PRs to allow Canvas to run on a host with FIPS modules enabled.  FIPS modules disable Digest::MD5 calls, and so we would like to switch to other more modern hashing algorithms.

Configuration for the digest is done using a new 'use_sha512_digests' setting
in config/file_store.yml.  The allowed values are:
- false: continue to use md5 sums  (default)
- true: always use SHA512 digests for new files

Migration: When changing `use_sha512_digests` to true, existing files
and attachments will continue to function as before and new uploads will
use SHA512. This means that new uploads will not match existing files
for deduplciation purposes until the existing MD5s are recomputed.

To recompute hashes on existing attachments, run the rake task:
  rake db:migrate_attachments_to_sha512

Implementation: We're using the md5 column in the attachments table to store the SHA512
hash. This isn't ideal, but instfs SHA512 file hashes are already stored in
that column and s3 uses etags in that column. The column could be renamed to `digest`
in a future commit.

Test plan:
- all tests should be run with local file storage
- spec/models/attachment_spec.rb, spec/lib/unzip_attachment_spec.rb pass
- spec/lib/data_fixup/migrate_attachment_digests_spec.rb passes
- using the default file_store config with local file storage:
  - regression test file uploads
  - regression test uploading a zip file and unzipping
  - regression test uploading images in the RCE
  - regression test thumbnails for uploaded images
- add `use_sha512_digests: true` to config/file_store.yml and repeat the
above regression tests
- migration test:
  - remove `use_sha512_digests` from config/file_store.yml and restart
  rails
  - upload the following new files (never before uploaded to this instance):
    - an image
    - a non-empty zip file and have canvas expand it
  - add `use_sha512_digests: true` to config/file_store.yml and restart
  rails
  - run `rake db:migrate_attachments_to_sha512` and wait for all the
    DataFixup:MigrateAttachmentDigests jobs to finish
  - verify that the new uploaded files still work
  - verify in the db that the uploaded attachments contain a sha512 digest
  in the md5 column
  - upload the same image and zip file to a new course
  - verify in the db that the new attachments have the root_attachment_id
  field set to the previously uploaded files