### PR TITLE
Adding a space after self-enrolled URL, before period

### DIFF
--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -451,7 +451,7 @@
               <%= t 'course_open_enrollment', <<-TEXT, :url => enroll_url(@context.self_enrollment_code || '{{ self_enrollment_code }}'), :url2 => register_url, :code => @context.self_enrollment_code || '{{ self_enrollment_code }}', :wrapper => '<b>\1</b>'
                     This course has enabled open enrollment. Students can
                     self-enroll in the course once you share with them this URL:
-                    *%{url}*. Alternatively, they can sign up at *%{url2}* and
+                    *%{url}* . Alternatively, they can sign up at *%{url2}* and
                     use the following join code: *%{code}*
                   TEXT
               %>

--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -450,8 +450,7 @@
             <% if @context.root_account.self_registration? %>
               <%= t 'course_open_enrollment', <<-TEXT, :url => enroll_url(@context.self_enrollment_code || '{{ self_enrollment_code }}'), :url2 => register_url, :code => @context.self_enrollment_code || '{{ self_enrollment_code }}', :wrapper => '<b>\1</b>'
                     This course has enabled open enrollment. Students can
-                    self-enroll in the course once you share with them this URL:
-                    *%{url}* . Alternatively, they can sign up at *%{url2}* and
+                    self-enroll in the course once you share with them this URL: *%{url}* or they can sign up at *%{url2}* and
                     use the following join code: *%{code}*
                   TEXT
               %>


### PR DESCRIPTION
Course creators occasionally accidentally include the period when copy/pasting the self-enroll URL, and less tech-savvy students may not know to remove it