### PR TITLE
Fix example for lti.showModuleNavigation in docs

### DIFF
--- a/doc/api/lti_window_post_message.md
+++ b/doc/api/lti_window_post_message.md
@@ -135,7 +135,7 @@ Toggles the module navigation footer based on the message's content.
 ```js
 window.parent.postMessage(
   {
-    subject: "lti.frameResize",
+    subject: "lti.showModuleNavigation",
     show: true
   },
   "*"


### PR DESCRIPTION
Subject for postMessage was incorrect in the example for lti.showModuleNavigation