### PR TITLE
Add integration_id to GraphQL user type

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -89,6 +89,21 @@ module Types
       end
     end
 
+    field :integration_id, String, null: true
+    def integration_id
+      domain_root_account = context[:domain_root_account]
+      if domain_root_account.grants_any_right?(context[:current_user], :read_sis, :manage_sis) ||
+        object.grants_any_right?(context[:current_user], :read_sis, :manage_sis)
+        Loaders::AssociationLoader.for(User, :pseudonyms).
+          load(object).
+          then do
+            pseudonym = SisPseudonym.for(object, domain_root_account, type: :implicit, require_sis: false,
+                root_account: domain_root_account, in_region: true)
+            pseudonym&.integration_id
+          end
+      end
+    end
+
     field :enrollments, [EnrollmentType], null: false do
       argument :course_id, ID,
         "only return enrollments for this course",


### PR DESCRIPTION
Add integration_id to GraphQL user type

Introduces the `integration_id` value for users into the GraphQL `user` type, serving it through user connections similarly to `sis_id`. This value is used by some schools to connect with 3rd party tools, so this addition will ensure full compatibility for tools looking to upgrade from the REST API to the GraphQL API.

The permissions for this data point mirror the SIS data ("Only included if the user has permission to view SIS information."), so it is only displayed for users that have SIS data permissions, just like with the REST API. The data is from the same `pseudonyms` table, so the structure of the code is identical to the `sis_id` (I'm unfamiliar with the codebase/language, so if there is a better way of sharing the loader between the two fields, please feel free to point me in the right direction on that).

I did not find an issue to associate with the PR, but there is an existing "Idea Conversation": https://community.canvaslms.com/t5/Idea-Conversations/Availability-Integration-ID-for-Users-in-GraphQL-API/idi-p/412573

Test Plan:

- Configure an integration_id value for one or more users.
- Run a GraphQL query (either through cURL, Postman, or GraphiQL) that includes user nodes (Example Query: ```query LastActivityQuery { course(sisId: "UNIV-FRSH101-600-202102") { sisId, enrollmentsConnection { nodes { user { sisId, integrationId }, lastActivityAt, updatedAt } } } }```) as: 
1.  Admin with SIS permissions
2. Admin without SIS permissions
3. Instructor with SIS permissions
4. Instructor without SIS permissions
- Observe that the correct integration_id appears when running the query as a user with SIS permissions, and null when run as a user without permissions.