### PR TITLE
Setting level-argument for logger, it was earlier set in the position…

### DIFF
--- a/lib/canvas_logger.rb
+++ b/lib/canvas_logger.rb
@@ -26,7 +26,7 @@ class CanvasLogger < ActiveSupport::Logger
     unless File.exist?(log_path)
       FileUtils.mkdir_p(File.dirname(log_path))
     end
-    super(log_path, level)
+    super(log_path, level: level)
     @log_path = log_path
     @skip_thread_context = options[:skip_thread_context]
   end


### PR DESCRIPTION
… where the shift-argument is expected in the logger.

This commit will cause the logs using the rails logger to no longer rotate no matter what the log level is. Previously the logs would not rotate only if the level was set to debug, because in this case the shift-argument was set to 0. For log level info for example the shift argument would be set to 1, causing the logs to rotate.

Closes gh-1856

Test plan:
- Specify "logger: rails" and "log_level: info" in logging.yml
- Observe that the logs will grow beyond 1 MB