### PR TITLE
Add ability for LTI tools to send toast messages

### DIFF
--- a/app/models/lti/launch.rb
+++ b/app/models/lti/launch.rb
@@ -62,6 +62,10 @@ module Lti
       url.path.presence || '/'
     end
 
+    def tool_name(context)
+      ContextExternalTool.find_external_tool(analytics_id, context).name
+    end
+
     def analytics_id
       @analytics_id || URI.parse(resource_url).host || 'unknown'
     end

--- a/app/views/lti/_lti_message.html.erb
+++ b/app/views/lti/_lti_message.html.erb
@@ -32,7 +32,7 @@
 
 <div class="tool_content_wrapper
   <%= 'custom_height' unless @lti_launch.tool_dimensions[:selection_height] == '100%' %>"
-  data-tool-wrapper-id="<%= @lti_launch.post_message_token %>"
+  data-tool-wrapper-id="<%= @lti_launch.post_message_token %>" data-tool-name="<%= @lti_launch.tool_name(@context) %>"
 >
   <form action="<%= @lti_launch.resource_url %>"
         class="hide"

--- a/doc/api/lti_window_post_message.md
+++ b/doc/api/lti_window_post_message.md
@@ -201,6 +201,26 @@ window.parent.postMessage(
 )
 ```
 
+## lti.alertMessage
+
+Shows an alert using Canvas's alert system
+
+**Required properties:**
+- subject: "lti.alertMessage"
+- alertType: "success", "warning", or "error"
+- body: The contents of the alert.
+
+```js
+window.parent.postMessage(
+  {
+    subject: "lti.alertMessage",
+    body: "An warning to be shown",
+    alertType: "warning"
+  },
+  "*"
+)
+```
+
 ## lti.enableScrollEvents
 
 Sends a debounced postMessage event to the tool every time its containing

--- a/spec/javascripts/jsx/lti/messagesSpec.js
+++ b/spec/javascripts/jsx/lti/messagesSpec.js
@@ -50,10 +50,18 @@ function showMessage(show = true) {
   }
 }
 
-function alertMessage(message = 'Alert message') {
+function screenreaderAlertMessage(message = 'SR Alert message') {
   return {
     subject: 'lti.screenReaderAlert',
     body: message
+  }
+}
+
+function alertMessage(message = 'Alert message', alertType = 'success') {
+  return {
+    subject: 'lti.alertMessage',
+    body: message,
+    alertType
   }
 }
 
@@ -85,7 +93,7 @@ QUnit.module('Messages', suiteHooks => {
     ltiToolWrapperFixture.append(`
       <div id="content-wrapper" class="ic-Layout-contentWrapper">
         <div id="content" class="ic-Layout-contentMain" role="main">
-          <div class="tool_content_wrapper" data-tool-wrapper-id="b58b20b7-c097-43bd-9f6c-c08adbac0ea3" style="height: ${intialHeight}px;">
+          <div class="tool_content_wrapper" data-tool-wrapper-id="b58b20b7-c097-43bd-9f6c-c08adbac0ea3" data-tool-name="Test Tool" style="height: ${intialHeight}px;">
             <iframe src="about:blank" name="tool_content" id="tool_content" class="tool_launch" allowfullscreen="allowfullscreen" webkitallowfullscreen="true" mozallowfullscreen="true" tabindex="0" title="Tool Content" style="height:100%;width:100%;" allow="geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe>
           </div>
         </div>
@@ -158,7 +166,43 @@ QUnit.module('Messages', suiteHooks => {
 
   test('triggers a screen reader alert', () => {
     sinon.spy($, 'screenReaderFlashMessageExclusive')
-    ltiMessageHandler(postMessageEvent(alertMessage()))
+    ltiMessageHandler(postMessageEvent(screenreaderAlertMessage()))
     ok($.screenReaderFlashMessageExclusive.calledOnce)
+  })
+
+  test('triggers an success message', () => {
+    sinon.spy($, 'flashMessageSafe')
+    ltiMessageHandler(postMessageEvent(alertMessage()))
+    ok($.flashMessageSafe.calledOnce)
+    $.flashMessageSafe.restore()
+  })
+
+  test('triggers an error message', () => {
+    sinon.spy($, 'flashErrorSafe')
+    ltiMessageHandler(postMessageEvent(alertMessage('Alert message', 'error')))
+    ok($.flashErrorSafe.calledOnce)
+    $.flashErrorSafe.restore()
+  })
+
+  test('triggers a warning message', () => {
+    sinon.spy($, 'flashWarningSafe')
+    ltiMessageHandler(postMessageEvent(alertMessage('Alert message', 'warning')))
+    ok($.flashWarningSafe.calledOnce)
+    $.flashWarningSafe.restore()
+  })
+
+  test('prepends tool name to the message', () => {
+    ltiToolWrapperFixture.append(`
+    <div id="content-wrapper" class="ic-Layout-contentWrapper">
+      <div id="content" class="ic-Layout-contentMain" role="main">
+        <div class="tool_content_wrapper" data-tool-wrapper-id="b58b20b7-c097-43bd-9f6c-c08adbac0ea3" data-tool-name="Test Tool" style="height: ${intialHeight}px;">
+          <iframe src="about:blank" name="tool_content" id="tool_content" class="tool_launch" allowfullscreen="allowfullscreen" webkitallowfullscreen="true" mozallowfullscreen="true" tabindex="0" title="Tool Content" style="height:100%;width:100%;" allow="geolocation *; microphone *; camera *; midi *; encrypted-media *"></iframe>
+        </div>
+      </div>
+    </div>
+  `)
+    sinon.spy($, 'flashMessageSafe')
+    ltiMessageHandler(postMessageEvent(alertMessage()))
+    ok($.flashMessageSafe.calledWith('Test Tool: Alert message'))
   })
 })

--- a/ui/shared/lti/jquery/messages.js
+++ b/ui/shared/lti/jquery/messages.js
@@ -140,6 +140,24 @@ export function ltiMessageHandler(e) {
         )
         break
 
+      case 'lti.alertMessage': {
+        const contents =
+          typeof message.body === 'string' ? message.body : JSON.stringify(message.body)
+        const toolName = $('.tool_content_wrapper').data('tool-name')
+        const prependedMessage = `${toolName}: ${contents}`
+        switch (message.alertType) {
+          case 'success':
+            $.flashMessageSafe(prependedMessage)
+            break
+          case 'warning':
+            $.flashWarningSafe(prependedMessage)
+            break
+          case 'error':
+            $.flashErrorSafe(prependedMessage)
+            break
+        }
+        break
+      }
       case 'lti.enableScrollEvents': {
         const iframe = findDomForWindow(e.source)
         if (iframe) {

--- a/ui/shared/rails-flash-notifications/jquery/index.js
+++ b/ui/shared/rails-flash-notifications/jquery/index.js
@@ -26,31 +26,50 @@ function initFlashContainer() {
   helper.initScreenreaderHolder()
 }
 
+function makeSafeHtml(contentString) {
+  if (typeof contentString === 'object' && contentString.html) {
+    return contentString.html
+  }
+  return contentString
+}
+
 // Pops up a small notification box at the top of the screen.
-$.flashMessage = function(content, timeout = 3000) {
+$.flashMessage = function (content, timeout = 3000) {
   helper.createNode('success', content, timeout)
   createScreenreaderNodeWithDelay(content)
 }
 
+// Like flashMessage but does escapes html even if 'html' field given to be used
+// when the input comes from an external source (e.g. an LTI tool)
+$.flashMessageSafe = function (contentString, timeout) {
+  contentString = makeSafeHtml(contentString)
+  $.flashMessage(contentString.toString(), timeout)
+}
+
 // Pops up a small error box at the top of the screen.
-$.flashError = function(content, timeout) {
+$.flashError = function (content, timeout) {
   helper.createNode('error', content, timeout)
   createScreenreaderNodeWithDelay(content)
 }
 
 // Like flashError but does escapes html even if 'html' field given To be used
 // when the input comes from an external source (e.g. an LTI tool)
-$.flashErrorSafe = function(contentString, timeout) {
-  if (typeof contentString === 'object' && contentString.html) {
-    contentString = contentString.html
-  }
+$.flashErrorSafe = function (contentString, timeout) {
+  contentString = makeSafeHtml(contentString)
   $.flashError(contentString.toString(), timeout)
 }
 
 // Pops up a small warning box at the top of the screen.
-$.flashWarning = function(content, timeout = 3000) {
+$.flashWarning = function (content, timeout = 3000) {
   helper.createNode('warning', content, timeout)
   createScreenreaderNodeWithDelay(content)
+}
+
+// Like flashWarning but does escapes html even if 'html' field given to be used
+// when the input comes from an external source (e.g. an LTI tool)
+$.flashWarningSafe = function (contentString, timeout) {
+  contentString = makeSafeHtml(contentString)
+  $.flashWarning(contentString.toString(), timeout)
 }
 
 $.screenReaderFlashMessage = content => helper.createScreenreaderNode(content, false)


### PR DESCRIPTION
This adds the ability for LTI tools to send toast alert messages through the
Canvas alert system.  This enables them to get the benefit of having a
fully integrated alerting solution including screen reader
announcements.  It also enables messages to be visible regardless of
scroll location within the external tool's iframe.

To facilitate ease of knowing where the message is coming from, the name
of the external tool is prepended to the message sent by the tool.

Test Plan:
  - Have an LTI tool send a "lti.alertMessage" message
  - The alert should show as "Tool Name: Alert Message Text"
  
This is what the alert looks like: 
<img width="566" alt="Screen Shot 2021-09-03 at 2 00 25 PM" src="https://user-images.githubusercontent.com/606262/132066500-1546ba7d-eea3-4931-9d97-42674e49592f.png">
