### PR TITLE
Add updatedSince filter for submissionsConnection

### DIFF
--- a/app/graphql/types/course_type.rb
+++ b/app/graphql/types/course_type.rb
@@ -216,6 +216,9 @@ module Types
       if filter[:graded_since]
         submissions = submissions.where("graded_at > ?", filter[:graded_since])
       end
+      if filter[:updated_since]
+        submissions = submissions.where("submissions.updated_at > ?", filter[:updated_since])
+      end
 
       (order_by || []).each { |order|
         direction = order[:direction] == 'descending' ? "DESC NULLS LAST" : "ASC"

--- a/app/graphql/types/submission_filter_input_type.rb
+++ b/app/graphql/types/submission_filter_input_type.rb
@@ -32,5 +32,6 @@ module Types
 
     argument :submitted_since, DateTimeType, required: false
     argument :graded_since, DateTimeType, required: false
+    argument :updated_since, DateTimeType, required: false
   end
 end

--- a/spec/graphql/types/course_type_spec.rb
+++ b/spec/graphql/types/course_type_spec.rb
@@ -328,6 +328,17 @@ describe Types::CourseType do
           GQL
         ).to eq [ @student2a1_submission.id.to_s ]
       end
+
+      it "updated_since" do
+        @student2a1_submission.update_attribute(:updated_at, 1.week.from_now)
+        expect(
+          course_type.resolve(<<~GQL, current_user: @teacher)
+            submissionsConnection(
+              filter: { updatedSince: "#{1.day.from_now.iso8601}" }
+            ) { nodes { _id } }
+          GQL
+        ).to eq [ @student2a1_submission.id.to_s ]
+      end
     end
   end
 


### PR DESCRIPTION
Add :updatedSince filter for submissionsConnection

Introduces a filter for submissionsConnection that will filter results based on the submissions table's `updated_at` column. This mirrors the functionality of `submittedSince` and `gradedSince`, but serves to find results where the assignment grade has been changed **_or_** the submission was changed (e.g. resubmitted).

Test Plan:

- Use a collection of assignment submissions with previous timestamps for gradedAt, submittedAt, updatedAt
- Update one submission by grading it
- Update a different submission by re-submitting it
- Run a GraphQL query (either through cURL, Postman, or GraphiQL) to verify that both edited items are included in the results, and nothing else. Example query:
```
query AssignmentGradesQuery {
  course(sisId: "UNIV-FRSH101-600-202103") {
    sisId
    submissionsConnection(filter: {updatedSince: "2021-08-09T10:47:58-07:00"}) {
      nodes {
        assignment {
          _id
        }
        grade
        user {
          sisId
        }
        updatedAt
        submittedAt
        gradedAt
        enteredScore
      }
    }
  }
}
```

Our integration updates this data within Starfish, so that users can continue working in Canvas and use both tools to better support students. Without this filter, we have to pull all submissions, whether they're updated or not, which increases the load on the API (Canvas) by fetching unchanged data points. We tried using the `:gradedSince` option, but that would not capture newly submitted assignments, while the `:submittedSince` would not catch things with updated grades, while this new filter will capture all relevant changes.