### PR TITLE
Update data service event ( submission_updated ) documentation

### DIFF
--- a/doc/api/data_services/md/dynamic/data_service_canvas_submission.md
+++ b/doc/api/data_services/md/dynamic/data_service_canvas_submission.md
@@ -231,7 +231,7 @@ Submission
 | **missing** | Whether the submission is missing, which generally means past-due and not yet submitted. |
 | **score** | The raw score |
 | **submission_id** | The Canvas id of the new submission. |
-| **submission_type** | The types of submission ex: ('online_text_entry'|'online_url'|'online_upload'|'media_recording') |
+| **submission_type** | The types of submission ex: ('online_text_entry','online_url','online_upload','media_recording') |
 | **submitted_at** | The timestamp when the assignment was submitted. |
 | **workflow_state** | The state of the submission, such as 'submitted' or 'graded'. |
 | **updated_at** | The time at which this assignment was last modified in any way |


### PR DESCRIPTION
## Summary of the commit

Change the '|' to a ',' as it was attempting to make a new table column, causing documentation data to be cut off.

## Screenshots

#### Documentation Before Fix ( Web Preview )
![documentation before fix web preview](https://user-images.githubusercontent.com/47669041/134950621-ec3a5536-efc8-4f16-aef6-70b2651b53cf.png)

#### Documentation Before Fix ( Rendered Markdown Preview )
![documentation before fix](https://user-images.githubusercontent.com/47669041/134950269-49fae15c-d848-4463-b19e-75f12e1dd41e.png)

#### Documentation After Fix ( Rendered Markdown Preview )
![documentation after fix](https://user-images.githubusercontent.com/47669041/134950330-8dceec9e-6fb3-4d69-8726-fc6fce95a559.png)

## Test Plan:
 - Pull code
 - Render new markdown file and ensure new output is correct
 - Render it for the web preview
