### PR TITLE
Updated sentence

### DIFF
--- a/ui/features/quiz_log_auditing/react/components/event_stream/event.js
+++ b/ui/features/quiz_log_auditing/react/components/event_stream/event.js
@@ -116,7 +116,7 @@ class Event extends React.Component {
         )
 
       case K.EVT_PAGE_BLURRED:
-        return I18n.t('page_blurred', 'Stopped viewing the Canvas quiz-taking page...')
+        return I18n.t('page_blurred', 'Stopped viewing the Canvas quiz-taking page.')
 
       case K.EVT_PAGE_FOCUSED:
         return I18n.t('page_focused', 'Resumed.')


### PR DESCRIPTION
From:
return I18n.t('page_blurred', 'Stopped viewing the Canvas quiz-taking page...')
To:
return I18n.t('page_blurred', 'Stopped viewing the Canvas quiz-taking page.')

It does not make sense to have '...' and doesn't look like it quite fits in. Having a simple '.' looks better, as well as doesn't imply anything like '...' does.

Test Plan:
- When taking a quiz intentionally blur the page and finish the quiz.
- Look at the quiz log and ensure it only states "Stopped viewing the Canvas quiz-taking page."