### PR TITLE
Capitalized the first letter

### DIFF
--- a/app/views/quizzes/quizzes/history.html.erb
+++ b/app/views/quizzes/quizzes/history.html.erb
@@ -120,7 +120,7 @@
             <% if can_do(@submission, @current_user, :add_attempts) %>
               <%= form_for :quiz_submission, :url => context_url(@context, :context_quiz_extensions_url, @quiz.id, @submission.user_id), :html => {:method => :post} do |f| %>
                 <input type="hidden" name="extra_attempts" value="<%= (@current_submission.extra_attempts || 0) + 1 %>"/>
-                <button type="submit" class="btn"><%= t('buttons.allow_extra_attempt', "allow this student an extra attempt") %></button>
+                <button type="submit" class="btn"><%= t('buttons.allow_extra_attempt', "Allow this student an extra attempt") %></button>
               <% end %>
             <% end %>
           <% else %>


### PR DESCRIPTION
From:
<button type="submit" class="btn"><%= t('buttons.allow_extra_attempt', "allow this student an extra attempt") %></button>
To:
<button type="submit" class="btn"><%= t('buttons.allow_extra_attempt', "Allow this student an extra attempt") %></button>

This makes more sense to capitalize the word "Allow" rather than leave it uncapitalized. However, since it is a button, it should not have a full stop.

Test Plan:
- Submit a quiz or anything which allows viewing of the page with the button
- View page which shows the button
- Ensure that the text on the button is "Allow this student an extra attempt"