### PR TITLE
Remove redis `auth` from unsupported commands

### DIFF
--- a/gems/canvas_cache/lib/canvas_cache/redis.rb
+++ b/gems/canvas_cache/lib/canvas_cache/redis.rb
@@ -361,7 +361,6 @@ module CanvasCache
       # one-off in script/console if you aren't using twemproxy, or in specs:
       ALLOWED_UNSUPPORTED = %w[
         keys
-        auth
         quit
         flushall
         flushdb


### PR DESCRIPTION
Canvas lists a number of Redis commands that are (or were) unsupported by twemproxy and prevents them from being used outside specs or rails console. This includes the `auth` command, which means that Canvas can not connect to a redis instance using password authentication.

Via @maths22 in IRC, Canvas no longer uses twemproxy, so the restriction on `auth` can be removed.

![Screen Shot 2021-11-18 at 11 54 24](https://user-images.githubusercontent.com/146111/142487342-7ec85048-c88b-4089-820a-39a1af903d53.png)
