### PR TITLE
Add points_possible to censored quiz_question API

### DIFF
--- a/lib/api/v1/quiz_question.rb
+++ b/lib/api/v1/quiz_question.rb
@@ -125,7 +125,7 @@ module Api::V1::QuizQuestion
     attr_whitelist = %w[
       id position quiz_group_id quiz_id assessment_question_id
       assessment_question question_name question_type question_text answers matches
-      formulas variables answer_tolerance formula_decimal_places
+      formulas variables answer_tolerance formula_decimal_places points_possible
     ]
     question_data.keep_if { |k, _v| attr_whitelist.include?(k.to_s) }
 


### PR DESCRIPTION
Currently the API does not return points_possible for questions from the quiz_question API when returning a "censored" response. Since currently Graders get censored responses from this API, this makes it very difficult to grade questions via the API.