### PR TITLE
Add devcontainer configuration for GitHub Codespaces.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.208.0/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
+ARG VARIANT="hirsute"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# Install stuff that doesn't rely on the repo being present.
+RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive && \
+    sudo apt-get -y install ruby-dev postgresql zlib1g-dev libxml2-dev libsqlite3-dev libpq-dev libxmlsec1-dev curl build-essential pkg-config
+    # sudo gem install bundle && \
+    # sudo gem install bundler -v 2.2.30 && \
+    # sudo gem install nokogumbo scrypt sanitize
+
+USER vscode 
+RUN echo '\
+# Ensure that the devcontainer is ready before giving the user a shell.\n\
+if [ ! -f /home/vscode/.setupDone ]\n\
+then\n\
+  echo "Waiting to make sure the container is ready..."\n\
+  echo "Press F1, and run "Codespaces: View Creation Log" to check on it. It should take about 5-10 minutes."\n\
+fi\n\
+while [ ! -f /home/vscode/.setupDone ]\n\
+do\n\
+  sleep 2\n\
+done\n\
+\n\
+echo "🎉 The container is ready!"\n\
+echo "To initialize the database, run \"bundle exec rails db:initial_setup\". Then, to run Canvas, run \"bundle exec rails server\"."\n\
+echo "For more information, check out https://github.com/instructure/canvas-lms/wiki/Quick-Start#github-codespaces-setup"\n\
+echo "Have fun!"\n\
+\n\
+export PGHOST=localhost' >> /home/vscode/.bashrc
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.208.0/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
+		// Use hirsute or bionic on local arm64/Apple Silicon.
+		"args": { "VARIANT": "focal" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"rebornix.Ruby"
+	],
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ["bash", "--noprofile", "--norc", "./.devcontainer/postCreate.sh"],
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"node": "lts",
+		"ruby": "2.7"
+	}
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Commands to run to configure the devcontainer after it starts (since they require files in the repo).
+sudo gem install bundle
+sudo gem install bundler -v 2.2.30
+sudo gem install nokogumbo scrypt sanitize
+sudo chown -R vscode:vscode /workspaces/canvas-lms/
+sudo chown -R vscode:vscode /var/lib/gems/2.7.0/
+bundle _2.2.30_ install --without pulsar
+yarn install --pure-lockfile
+for config in amazon_s3 delayed_jobs domain file_store outgoing_mail security external_migration dynamic_settings database; \
+          do cp -v config/$config.yml.example config/$config.yml; done
+sudo chown -R vscode:vscode /var/lib/gems/2.7.0/
+bundle _2.2.30_ update
+bundle exec rails canvas:compile_assets
+sudo chown -R vscode:vscode /var/run/postgresql/
+export PGHOST=localhost
+/usr/lib/postgresql/12/bin/initdb ~/postgresql-data/ -E utf8
+/usr/lib/postgresql/12/bin/pg_ctl -D ~/postgresql-data/ -l ~/postgresql-data/server.log start
+/usr/lib/postgresql/12/bin/createdb canvas_development
+# Set correct domain for port forwarding on Codespaces. npx package was developed by a GitHub employee, since you can't get the URL directly in the codespace yet.
+if [ ! -z ${CODESPACES+x} ]
+then
+    sed -i "s/localhost:3000/$(npx -y codespaces-port 3000 | cut -c 9-)/g" config/domain.yml
+fi
+touch /home/vscode/.setupDone
+# bundle exec rails db:initial_setup


### PR DESCRIPTION
This commit adds a devcontainer.json file and some associated configuration files to automatically configure a Canvas development environment in GitHub Codespaces (or locally, via the VSCode remote containers extension). This way, all you have to do is click "New Codespace" (or open the repo in VSCode locally), wait ten minutes, and be ready to contribute!

Test Plan:
- Create a new Codespace using a branch with these files. (Or open it in VSCode locally, and follow the prompts to build a devcontainer.)
- Make sure it builds successfully.
- Run "bundle exec rails db:initial_setup" and "bundle exec rails server" to make sure Canvas comes up successfully.