### PR TITLE
fixed TypeError: Unable to resolve type 'size_t' by upgrade ffi to 1.14.0

### DIFF
--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -67,7 +67,7 @@ gem "crocodoc-ruby", "0.0.1", require: false
 gem "ddtrace", "0.42.0", require: false
 gem "encrypted_cookie_store-instructure", "1.2.11", require: "encrypted_cookie_store"
 gem "folio-pagination", "0.0.12", require: "folio/rails"
-gem "ffi", "1.13.1", require: false
+gem "ffi", "1.14.0", require: false
 gem "gepub", "1.0.15"
 gem "apollo-federation", "1.1.5"
 gem "graphql", "1.12.14"


### PR DESCRIPTION
Traceback (most recent call last):
	46: from bin/rails:5:in `<main>'
	45: from bin/rails:5:in `load'
	44: from /Users/feihe/Workspace/canvas-lms/bin/spring:20:in `<top (required)>'
	43: from /Users/feihe/Workspace/canvas-lms/bin/spring:20:in `require'
	42: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/binstub.rb:11:in `<top (required)>'
	41: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/binstub.rb:11:in `load'
	40: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/spring-2.1.1/bin/spring:49:in `<top (required)>'
	39: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/client.rb:30:in `run'
	38: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/client/command.rb:7:in `call'
	37: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/client/rails.rb:28:in `call'
	36: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/client/rails.rb:28:in `load'
	35: from /Users/feihe/Workspace/canvas-lms/bin/rails:16:in `<top (required)>'
	34: from /Users/feihe/Workspace/canvas-lms/bin/rails:16:in `require'
	33: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.0.4.2/lib/rails/commands.rb:18:in `<top (required)>'
	32: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.0.4.2/lib/rails/command.rb:46:in `invoke'
	31: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.0.4.2/lib/rails/command/base.rb:69:in `perform'
	30: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	29: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	28: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	27: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.0.4.2/lib/rails/commands/server/server_command.rb:138:in `perform'
	26: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.0.4.2/lib/rails/commands/server/server_command.rb:138:in `tap'
	25: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.0.4.2/lib/rails/commands/server/server_command.rb:141:in `block in perform'
	24: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:324:in `require'
	23: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:291:in `load_dependency'
	22: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:324:in `block in require'
	21: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:324:in `require'
	20: from /Users/feihe/Workspace/canvas-lms/config/application.rb:28:in `<top (required)>'
	19: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.30/lib/bundler.rb:175:in `require'
	18: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.30/lib/bundler/runtime.rb:44:in `require'
	17: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.30/lib/bundler/runtime.rb:44:in `each'
	16: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.30/lib/bundler/runtime.rb:55:in `block in require'
	15: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.30/lib/bundler/runtime.rb:55:in `each'
	14: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.30/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
	13: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/bundler-2.2.30/lib/bundler/runtime.rb:60:in `require'
	12: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/scrypt-3.0.7/lib/scrypt.rb:9:in `<top (required)>'
	11: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:324:in `require'
	10: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:291:in `load_dependency'
	 9: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:324:in `block in require'
	 8: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/activesupport-6.0.4.2/lib/active_support/dependencies.rb:324:in `require'
	 7: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/scrypt-3.0.7/lib/scrypt/engine.rb:6:in `<top (required)>'
	 6: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/scrypt-3.0.7/lib/scrypt/engine.rb:7:in `<module:SCrypt>'
	 5: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/scrypt-3.0.7/lib/scrypt/engine.rb:10:in `<module:Ext>'
	 4: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/ffi-1.13.1/lib/ffi/library.rb:239:in `attach_function'
	 3: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/ffi-1.13.1/lib/ffi/library.rb:239:in `map'
	 2: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/ffi-1.13.1/lib/ffi/library.rb:239:in `block in attach_function'
	 1: from /Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/ffi-1.13.1/lib/ffi/library.rb:589:in `find_type'
/Users/feihe/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/ffi-1.13.1/lib/ffi/types.rb:69:in `find_type': unable to resolve type 'size_t' (TypeError)