### PR TITLE
Include score in `submission posted` messages

### DIFF
--- a/app/messages/submission_posted.email.erb
+++ b/app/messages/submission_posted.email.erb
@@ -8,10 +8,6 @@
   <%= t "Submission Posted: %{title}, %{course}", title: assignment.title, course: assignment.context.name %>
 <% end %>
 
-<%= t <<-BODY, title: assignment.title, course: assignment.context.name, url: content(:link)
-Your instructor has released grade changes and new comments for %{title}. These changes are now viewable.
+<%= t :body, "Your instructor has released grade changes and new comments for %{title}. These changes are now viewable.", title: assignment.title %>
 
-Your can view it here:
-%{url}
-BODY
-%>
+<%= t :link_message, "You can view it here: %{link}.", link: content(:link) %>

--- a/app/messages/submission_posted.email.erb
+++ b/app/messages/submission_posted.email.erb
@@ -10,4 +10,14 @@
 
 <%= t :body, "Your instructor has released grade changes and new comments for %{title}. These changes are now viewable.", title: assignment.title %>
 
+<%= t :graded_date, "graded: %{date}", :date => (datetime_string(force_zone(asset.graded_at)) rescue t(:no_date_set, "No Date Set")) %>
+<% if user.try(:send_scores_in_emails?, assignment.context) %>
+  <% if asset.excused? %>
+    <%= t :excused, "This assignment has been excused." %>
+  <% elsif asset.score %>
+    <%= t :score, "score:  %{score} out of %{total}", :score => asset.score, :total => (assignment.points_possible || t(:not_applicable, "N/A")) %>
+  <% end %>
+<% end %>
+<%= t(:score_pending_review, "score pending review by the teacher") if asset.pending_review? %>
+
 <%= t :link_message, "You can view it here: %{link}.", link: content(:link) %>

--- a/app/messages/submission_posted.email.html.erb
+++ b/app/messages/submission_posted.email.html.erb
@@ -15,3 +15,15 @@
 <% end %>
 
 <p><%= t :body, "Your instructor has released grade changes and new comments for %{title}. These changes are now viewable.", :title => assignment.title %></p>
+
+<p><%= t :graded_date, "graded: %{date}", :date => (datetime_string(force_zone(asset.graded_at)) rescue t(:no_date_set, "No Date Set")) %></p>
+
+<% if user.try(:send_scores_in_emails?, assignment.context) %>
+  <% if asset.excused? %>
+    <p><%= t :excused, "This assignment has been excused." %>
+  <% elsif asset.score %>
+    <p><%= t :score, "score:  %{score} out of %{total}", :score => asset.score, :total => (assignment.points_possible || t(:not_applicable, "N/A")) %>
+  <% end %>
+<% end %>
+
+<p><%= t(:score_pending_review, "score pending review by the teacher") if asset.pending_review? %></p>

--- a/app/messages/submission_posted.sms.erb
+++ b/app/messages/submission_posted.sms.erb
@@ -7,4 +7,8 @@
 <%= t :body, "Your instructor has released grade changes and new comments for %{title}, %{course}.",
       title: assignment.title, course: assignment.context.name %>
 
+<% if asset.score && user.try(:send_scores_in_emails?, assignment.context) %>
+  <%= t :score, "score:  %{score} out of %{total}", :score => asset.score, :total => (assignment.points_possible || t(:not_applicable, "N/A")) %>
+<% end %>
+
 <%= t :link_message, "More info at %{link}.", link: content(:link) %>

--- a/app/messages/submission_posted.sms.erb
+++ b/app/messages/submission_posted.sms.erb
@@ -1,8 +1,10 @@
 <% assignment = asset.assignment %>
 
-<%= t <<-BODY, title: assignment.title, course: assignment.context.name, url: polymorphic_url([assignment.context, assignment, asset])
-Your instructor has released grade changes and new comments for %{title}, %{course}.
+<% define_content :link do %>
+  <%= polymorphic_url([assignment.context, assignment, asset]) %>
+<% end %>
 
-More info at %{url}
-BODY
-%>
+<%= t :body, "Your instructor has released grade changes and new comments for %{title}, %{course}.",
+      title: assignment.title, course: assignment.context.name %>
+
+<%= t :link_message, "More info at %{link}.", link: content(:link) %>

--- a/app/messages/submission_posted.summary.erb
+++ b/app/messages/submission_posted.summary.erb
@@ -7,3 +7,9 @@
 <% define_content :subject do %>
   <%= t "Grade changes and new comments released for: %{title}, %{course}", title: assignment.title, course: assignment.context.name %>
 <% end %>
+
+<%= t :graded_date, "graded: %{date}", :date => (datetime_string(force_zone(asset.graded_at)) rescue t(:no_date_set, "No Date Set")) %>
+<% if asset.score && user.try(:send_scores_in_emails?, assignment.context) %>
+  <%= t :score, "score:  %{score} out of %{total}", :score => asset.score, :total => (assignment.points_possible || t(:not_applicable, "N/A")) %>
+<% end %>
+<%= t(:score_pending_review, "score pending review by the teacher") if asset.pending_review? %>


### PR DESCRIPTION
When an assignment submission's grades are manually posted, the student does not receive a message (email, SMS, etc.) with their score.

This PR takes inspiration from the `submission graded` messages by including the following in the `submission posted` messages:

- date graded
- score (or if the assignment's been excused)
- if the score is pending review by the teacher

<br/>

**Test Plan:**
- Send `submission posted` messages via email (check both text and HTML), SMS, and summary. (there is no Twitter template for `submission posted`)
- Try various cases:
    - submission excused
    - submission pending review
    - submission with `graded_at` nil
    - user with "send score in emails" disabled

FYI, this code was largely copied from the `submission graded` messages!