### PR TITLE
Document the skip_message parameter.

### DIFF
--- a/app/controllers/account_reports_controller.rb
+++ b/app/controllers/account_reports_controller.rb
@@ -269,6 +269,9 @@ class AccountReportsController < ApplicationController
   #   A few example parameters have been provided below. Note that the example
   #   parameters provided below may not be valid for every report.
   #
+  # @argument parameters[skip_message] [Boolean] If true, no message will be sent
+  #   to the user upon completion of the report.
+  #
   # @argument parameters[course_id] [Integer] The id of the course to report on.
   #   Note: this parameter has been listed to serve as an example and may not be
   #   valid for every report.


### PR DESCRIPTION
All reports support the `skip_message` parameter which when set prevents Canvas from sending the user a notification about the completion of the report, this should be in the account report documentation.