### PR TITLE
Change list format to match rest of docs

### DIFF
--- a/doc/api/data_services/json/canvas/event-types/submission_updated.json
+++ b/doc/api/data_services/json/canvas/event-types/submission_updated.json
@@ -15,7 +15,7 @@
     "missing": "Whether the submission is missing, which generally means past-due and not yet submitted.",
     "score": "The raw score",
     "submission_id": "The Canvas id of the new submission.",
-    "submission_type": "The types of submission ex: ('online_text_entry'|'online_url'|'online_upload'|'media_recording')",
+    "submission_type": "The types of submission (online_text_entry, online_url, online_upload, media_recording)",
     "submitted_at": "The timestamp when the assignment was submitted.",
     "workflow_state": "The state of the submission, such as 'submitted' or 'graded'.",
     "updated_at": "The time at which this assignment was last modified in any way",

--- a/doc/api/data_services/md/dynamic/data_service_canvas_submission.md
+++ b/doc/api/data_services/md/dynamic/data_service_canvas_submission.md
@@ -231,7 +231,7 @@ Submission
 | **missing** | Whether the submission is missing, which generally means past-due and not yet submitted. |
 | **score** | The raw score |
 | **submission_id** | The Canvas id of the new submission. |
-| **submission_type** | The types of submission ex: ('online_text_entry'|'online_url'|'online_upload'|'media_recording') |
+| **submission_type** | The types of submission (online_text_entry, online_url, online_upload, media_recording) |
 | **submitted_at** | The timestamp when the assignment was submitted. |
 | **workflow_state** | The state of the submission, such as 'submitted' or 'graded'. |
 | **updated_at** | The time at which this assignment was last modified in any way |


### PR DESCRIPTION
Most lists like this in the docs use commas. This pull request changes the vertical pipes to commas and removes the single quotes around each list item. Using vertical bars causes the text to not render properly, as explained in https://github.com/instructure/canvas-lms/pull/1943.
Closes https://github.com/instructure/canvas-lms/pull/1943