### PR TITLE
add configuration for GitHub Codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "initializeCommand": "./script/codespace_setup.sh",
+  "postStartCommand": "./script/codespace_start.sh"
+}

--- a/script/codespace_setup.sh
+++ b/script/codespace_setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# https://github.com/instructure/canvas-lms/wiki/Quick-Start#github-codespaces-setup
+
+sudo apt-get update
+sudo apt-get -y install ruby ruby-dev postgresql-12 zlib1g-dev libxml2-dev libsqlite3-dev libpq-dev libxmlsec1-dev curl build-essential
+
+sudo gem install bundle
+sudo gem install bundler:2.2.30
+sudo gem install nokogumbo scrypt sanitize
+sudo chown -R codespace:codespace /workspaces/canvas-lms
+sudo chown -R codespace:codespace /var/lib/gems/2.7.0/
+bundle _2.2.30_ install
+yarn install --pure-lockfile
+
+for config in amazon_s3 delayed_jobs domain file_store outgoing_mail security external_migration dynamic_settings database; \
+          do cp -v config/$config.yml.example config/$config.yml; done
+
+sudo chown -R codespace:codespace /var/lib/gems/2.7.0/
+bundle _2.2.30_ update
+
+sudo chown -R codespace:codespace /var/run/postgresql/
+export PGHOST=localhost
+/usr/lib/postgresql/12/bin/initdb ~/postgresql-data/ -E utf8
+/usr/lib/postgresql/12/bin/pg_ctl -D ~/postgresql-data/ -l ~/postgresql-data/server.log start
+/usr/lib/postgresql/12/bin/createdb canvas_development
+
+bundle exec rails canvas:compile_assets
+bundle exec rails db:initial_setup

--- a/script/codespace_start.sh
+++ b/script/codespace_start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+# https://github.com/instructure/canvas-lms/wiki/Quick-Start#starting-it-again
+
+export PGHOST=localhost
+/usr/lib/postgresql/12/bin/pg_ctl start -D ~/postgresql-data/
+bundle exec rails server


### PR DESCRIPTION
This takes the [CodeSpace setup instructions from the wiki](https://github.com/instructure/canvas-lms/wiki/Quick-Start#github-codespaces-setup) and moves them into the repository, with some small fixes. It also adds a devcontainer configuration file so that the setup commands get run automatically.

There wasn't a way that was obvious (to me) to gracefully shut down PostgreSQL when the container is being stopped — happy to add if anyone has ideas.

## Test plan

1. Go to this branch on github.com
1. [Create a codespace](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace)
1. Continue with the post-installation Quick Start instructions

## Follow-up TODOs

- [ ] Modify the Quick Start to reflect the new setup