### PR TITLE
Clear out the section name input box after creating a new section

### DIFF
--- a/ui/features/course_settings/jquery/index.js
+++ b/ui/features/course_settings/jquery/index.js
@@ -231,7 +231,7 @@ $(document).ready(function () {
         .addClass('option_for_section_' + section.id)
       $('#sections .section_blank').before($section)
       $section.slideDown()
-      $('#course_section_name').val()
+      $('#course_section_name').val('')
       $('#add_section_form button[type="submit"]').focus()
     },
     error(data) {


### PR DESCRIPTION
In the Course Settings -> Section tab, when you added a new
section, the input box would remain with the newly created
section name. The code was apparently attempting to clear it
but needed an empty string to actually succeed.

Test Plan:
 - In a Course Settings -> Section tab, add a new Section
 - Behold that the input box is cleared after adding