### PR TITLE
fix use of Dory for Mac setup

### DIFF
--- a/script/common/os/mac/dev_setup.sh
+++ b/script/common/os/mac/dev_setup.sh
@@ -30,14 +30,12 @@ message "It looks like you're using a Mac. Let's set that up."
 if is_mutagen; then
   print_mutagen_intro
   dependencies='docker,mutagen 0.13.0,mutagen-compose'
-  check_dependencies
-  check_for_docker_desktop
-  docker_running &> /dev/null || attempt_start_docker
-  check_docker_memory
-  dory_or_dinghy
 else
-  dependencies='docker,docker-machine,docker-compose 1.20.0,dinghy'
-  check_dependencies
-  create_dinghy_vm
-  start_dinghy_vm
+  dependencies='docker,docker-compose 1.20.0'
 fi
+
+check_dependencies
+check_for_docker_desktop
+docker_running &> /dev/null || attempt_start_docker
+check_docker_memory
+dory_or_dinghy

--- a/script/common/utils/dinghy_setup.sh
+++ b/script/common/utils/dinghy_setup.sh
@@ -1,63 +1,6 @@
 #!/bin/bash
 source script/common/utils/common.sh
 
-# Defaults
-DINGHY_MEMORY='8192'
-DINGHY_CPUS='4'
-DINGHY_DISK='150'
-DINGHY_DEPRECATION_MESSAGE="WARNING: Dinghy is currently deprecated, we suggest to use mutagen instead.
-For further information check the confluence page: https://instructure.atlassian.net/wiki/spaces/CE/pages/4334256157/Canvas+LMS+docker+dev+Installation+Update"
-
-function create_dinghy_vm {
-  warning_message $DINGHY_DEPRECATION_MESSAGE
-  if ! dinghy status | grep -q 'not created'; then
-    # make sure DOCKER_MACHINE_NAME is set
-    eval "$(dinghy env)"
-    existing_memory="$(docker-machine inspect --format "{{.Driver.Memory}}" "${DOCKER_MACHINE_NAME}")"
-    if [[ "$existing_memory" -lt "$DINGHY_MEMORY" ]]; then
-      echo "
-  Canvas requires at least 8GB of memory dedicated to the VM. Please recreate
-  your VM with a memory value of at least ${DINGHY_MEMORY}. For Example:
-
-      $ dinghy create --memory ${DINGHY_MEMORY}"
-      exit 1
-    else
-      message "Using existing dinghy VM..."
-      return 0
-    fi
-  fi
-
-  prompt 'OK to create a dinghy VM? [y/n]' confirm
-  [[ ${confirm:-n} == 'y' ]] || return 1
-
-  if ! installed VBoxManage; then
-    message 'Please install VirtualBox first!'
-    return 1
-  fi
-
-  prompt "How much memory should I allocate to the VM (in MB)? [$DINGHY_MEMORY]" memory
-  prompt "How many CPUs should I allocate to the VM? [$DINGHY_CPUS]" cpus
-  prompt "How big should the VM's disk be (in GB)? [$DINGHY_DISK]" disk
-
-  message "OK let's do this."
-  message "Creating dinghy machine..."
-  _canvas_lms_track_with_log dinghy create \
-    --provider=virtualbox \
-    --memory "${memory:-$DINGHY_MEMORY}" \
-    --cpus "${cpus:-$DINGHY_CPUS}" \
-    --disk "${disk:-$DINGHY_DISK}000"
-}
-
-function start_dinghy_vm {
-  if dinghy status | grep -q 'stopped'; then
-    message "Starting dinghy VM..."
-    _canvas_lms_track_with_log dinghy up
-  else
-    message 'Looks like the dinghy VM is already running. Moving on...'
-  fi
-  eval "$(dinghy env)"
-}
-
 function setup_dinghy_proxy {
   if [[ "$(docker ps -aq --filter ancestor=codekitchen/dinghy-http-proxy)" == "" ]]; then
     docker run -d --restart=always \


### PR DESCRIPTION
This fixes a couple issues:

- The Mac setup script referenced docker-machine, which hasn't been supported since 2019.
- If not using Mutagen, the setup script required Dinghy instead of allowing for Dory.

Since Dinghy also hasn't been maintained since 2019, I'd personally recommend dropping all references to that, but I figured that would be more controversial so didn't bother.

Fixes https://github.com/instructure/canvas-lms/issues/1997.

## Test plan

- Follow the [automated setup
  instructions](https://github.com/instructure/canvas-lms/wiki/Quick-Start#automated-setup)