### PR TITLE
Cast number to boolean before using as condition

### DIFF
--- a/ui/shared/files/react/components/FilePreview.js
+++ b/ui/shared/files/react/components/FilePreview.js
@@ -306,11 +306,11 @@ export default class FilePreview extends React.PureComponent {
             </div>
             <div className="ef-file-preview-stretch">
               {this.state.otherItems &&
-                this.state.otherItems.length &&
+                !!this.state.otherItems.length &&
                 this.renderArrowLink('left')}
               {this.renderPreview()}
               {this.state.otherItems &&
-                this.state.otherItems.length &&
+                !!this.state.otherItems.length &&
                 this.renderArrowLink('right')}
               {this.state.showInfoPanel && (
                 <FilePreviewInfoPanel


### PR DESCRIPTION
Possible fix for issue #2019

Test plan
- `document.querySelector("#.ef-file-preview-stretch").textContent === ""`