### PR TITLE
Expose External Tool deployment_id in REST API.

### DIFF
--- a/app/controllers/external_tools_controller.rb
+++ b/app/controllers/external_tools_controller.rb
@@ -111,7 +111,8 @@ class ExternalToolsController < ApplicationController
   #        "selection_width": 500,
   #        "selection_height": 500,
   #        "icon_url": "...",
-  #        "not_selectable": false
+  #        "not_selectable": false,
+  #        "deployment_id": null
   #      },
   #      { ...  }
   #     ]
@@ -310,6 +311,7 @@ class ExternalToolsController < ApplicationController
   # @response_field selection_height The pixel height of the iFrame that the tool will be rendered in
   # @response_field icon_url The url for the tool icon
   # @response_field not_selectable whether the tool is not selectable from assignment and modules
+  # @response_field deployment_id The unique identifier for the deployment of the tool
   #
   # @example_response
   #      {
@@ -372,7 +374,8 @@ class ExternalToolsController < ApplicationController
   #        "selection_width": 500,
   #        "selection_height": 500,
   #        "icon_url": "...",
-  #        "not_selectable": false
+  #        "not_selectable": false,
+  #        "deployment_id": null
   #      }
   def show
     if api_request?

--- a/lib/api/v1/external_tools.rb
+++ b/lib/api/v1/external_tools.rb
@@ -40,6 +40,7 @@ module Api::V1::ExternalTools
     json["not_selectable"] = tool.not_selectable
     json["version"] = tool.use_1_3? ? "1.3" : "1.1"
     json["developer_key_id"] = tool.developer_key_id if tool.developer_key_id
+    json["deployment_id"] = tool.deployment_id if tool.deployment_id
     extension_types.each do |type|
       next unless json[type]
 

--- a/spec/apis/v1/external_tools_api_spec.rb
+++ b/spec/apis/v1/external_tools_api_spec.rb
@@ -789,6 +789,7 @@ describe ExternalToolsController, type: :request do
       "workflow_state" => "public",
       "vendor_help_link" => nil,
       "version" => "1.1",
+      "deployment_id" => et ? et.deployment_id : "",
       "resource_selection" => {
         "enabled" => true,
         "text" => "",


### PR DESCRIPTION
It should be possible to access the deployment_id propery
when creating external tools via the REST API.

Test Plan:
 - Run external tool spec tests.
 - Create an external tool using a developer key and verify
   the deployment_id property is included in the response.