### PR TITLE
Fix minor issues with locales.yml

### DIFF
--- a/config/locales/locales.yml
+++ b/config/locales/locales.yml
@@ -139,7 +139,7 @@ da:
       weekday: "%A"
   dow_offset: 1
   locales:
-    da: Dansk
+    da: Dansk (Danmark)
   time:
     event: "%{date} kl. %{time}"
     formats:
@@ -189,7 +189,7 @@ da-x-k12:
   dow_offset: 1
   fullcalendar_locale: da
   locales:
-    da-x-k12: Dansk GR/GY
+    da-x-k12: Dansk (GR/GY)
   moment_locale: da
   time:
     event: "%{date} kl. %{time}"
@@ -307,7 +307,7 @@ el:
 en:
   bigeasy_locale: en_US
   locales:
-    en: English (US)
+    en: English (United States)
 en-AU:
   date:
     abbr_month_names:
@@ -458,7 +458,7 @@ es:
       weekday: "%A"
   dow_offset: 1
   locales:
-    es: Español
+    es: Español (Latinoamérica)
   time:
     event: "%{date} en %{time}"
     formats:
@@ -638,7 +638,7 @@ fr:
       weekday: "%A"
   dow_offset: 1
   locales:
-    fr: Français
+    fr: Français (France)
   time:
     event: "%{date} à %{time}"
     formats:
@@ -1066,7 +1066,7 @@ ko:
       full: "%Y.%-m.%-d. %P %l:%M"
       full_with_weekday: "%Y.%-m.%-d. %a %P %l:%M"
   locales:
-    ko: 한국말
+    ko: 한국어
   time:
     event: "%{date} %{time}"
     formats:
@@ -1107,7 +1107,7 @@ mi:
       weekday: "%A"
   fullcalendar_locale: mi_NZ
   locales:
-    mi: Reo Māori (Aotearoa)
+    mi: Te reo Māori
   moment_locale: mi-nz
   time:
     event: "%{date} i %{time} "
@@ -1149,7 +1149,7 @@ nb:
       weekday: "%A"
   dow_offset: 1
   locales:
-    nb: Norsk (Bokmål)
+    nb: Norsk bokmål (Norge)
   time:
     event: "%{date} i %{time}"
     formats:
@@ -1199,7 +1199,7 @@ nb-x-k12:
   dow_offset: 1
   fullcalendar_locale: nb
   locales:
-    nb-x-k12: Norsk (Bokmål) GS/VGS
+    nb-x-k12: Norsk bokmål (GS/VGS)
   moment_locale: nb
   time:
     event: "%{date} i %{time}"
@@ -1301,7 +1301,7 @@ nn:
   dow_offset: 1
   fullcalendar_locale: nb
   locales:
-    nn: Norsk (Nynorsk)
+    nn: Norsk nynorsk
   time:
     event: "%{date} %{time}"
     formats:
@@ -1399,7 +1399,7 @@ pt:
       weekday: "%A"
   dow_offset: 1
   locales:
-    pt: Português
+    pt: Português (Portugal)
   time:
     event: "%{date} em %{time}"
     formats:
@@ -1446,7 +1446,7 @@ pt-BR:
       short_with_weekday: "%a, %-d %b"
       weekday: "%A"
   locales:
-    pt-BR: Português do Brasil
+    pt-BR: Português (Brasil)
   time:
     event: "%{date} em %{time}"
     formats:
@@ -1495,7 +1495,7 @@ ru:
       weekday: "%A"
   dow_offset: 1
   locales:
-    ru: pу́сский
+    ru: Русский
   time:
     event: "%{date} в %{time}"
     formats:
@@ -1584,7 +1584,7 @@ sv:
       weekday: "%A"
   dow_offset: 1
   locales:
-    sv: Svenska
+    sv: Svenska (Sverige)
   time:
     event: "%{date} kl %{time}"
     formats:
@@ -1634,7 +1634,7 @@ sv-x-k12:
   dow_offset: 1
   fullcalendar_locale: sv
   locales:
-    sv-x-k12: Svenska GR/GY
+    sv-x-k12: Svenska (GR/GY)
   moment_locale: sv
   time:
     event: "%{date} kl %{time}"
@@ -1781,7 +1781,7 @@ uk:
       weekday: "%A"
   dow_offset: 1
   locales:
-    uk: український
+    uk: Українська
   time:
     event: "%{date} о %{time}"
     formats:


### PR DESCRIPTION
Here are the fixes that I am proposing. Note that these are only minor changes so that we don’t want to break any critical functionality in Canvas.
1. es_ES exists twice. Because of this, I looked up some strings on the Internet to determine which one is Castilian Spanish and which one is Latin American Spanish. The phrase “a las” is used for time phrases in Castilian Spanish (commonly known as Spanish (Spain)), so we left Español (España) untouched and changed the other from Español to Español (Latinoamérica).
(The bigeasy_locale is unchanged to avoid breaking critical functionality.)
2. English (United Kingdom) and English (US) do not appear to be in line. I chose English (US) to be replaced with English (United States).
3. Some languages are misspelled or not capitalized. We fixed them just as they appeared in the language menu of smartphones and tablets (placed in the following order: Latin, Cyrillic, right-to-left, languages, Indian, and East Asian). The variant is shown in parentheses only if a language has two or more regions/variants, just like in many mobile operating systems.