### PR TITLE
Raise error when QTI Migration Tool is missing

### DIFF
--- a/gems/plugins/qti_exporter/lib/qti.rb
+++ b/gems/plugins/qti_exporter/lib/qti.rb
@@ -117,7 +117,11 @@ module Qti
   end
 
   def self.get_conversion_command(out_dir, manifest_file, file_path_prepend = nil)
-    prepend = file_path_prepend ? "--pathprepend=\"#{file_path_prepend}\" " : ""
-    "\"#{@migration_executable}\" #{prepend}--ucvars --nogui --overwrite --cpout=#{Shellwords.escape(out_dir)} #{Shellwords.escape(manifest_file)} 2>&1"
+    if @migration_executable.nil?
+      raise "Couldn't find QTI Migration Tool. See https://github.com/instructure/QTIMigrationTool/wiki for installation instructions."
+    else
+      prepend = file_path_prepend ? "--pathprepend=\"#{file_path_prepend}\" " : ""
+      "\"#{@migration_executable}\" #{prepend}--ucvars --nogui --overwrite --cpout=#{Shellwords.escape(out_dir)} #{Shellwords.escape(manifest_file)} 2>&1"
+    end
   end
 end


### PR DESCRIPTION
On a system where the QTI Migration Tool is not installed, Canvas still
tries to run it.

In this situation `@migration_executable` is `nil`, so
`Qti.get_conversion_command` returns a bogus command string. This leads to
unhelpful error messages in `run_qti_converter`. The error cases in said
function assume that a *valid* command failed (and therefore look to the
command's standard output for information about the failure).

When `@migration_executable` is `nil`, raising the error in
`Qti.get_conversion_command` tells user that they haven't installed the tool.

This might make it easier to troubleshoot issues like #1436.