### PR TITLE
Add syllabus body field to course graphql schema

### DIFF
--- a/app/graphql/types/course_type.rb
+++ b/app/graphql/types/course_type.rb
@@ -85,6 +85,7 @@ module Types
 
     field :name, String, null: false
     field :course_code, String, "course short name", null: true
+    field :syllabus_body, String, null: true
     field :state, CourseWorkflowState, method: :workflow_state, null: false
 
     field :assignment_groups_connection, AssignmentGroupType.connection_type,


### PR DESCRIPTION
Adds the additional `syllabus_body` field to the graphql endpoint for courses.

I'm working on an external frontend client for canvas, and hoping to switch to graphql for some of the backend calls, but there are some fields missing from the REST alternative. Apologies if this PR is malformed, I'm not very familiar with this stack.

Test Plan:
* Create a new course
* Add a syllabus to the course
* Navigate to `https://<canvas_host>/graphiql` and enter the following query:

    ```
    query MyQuery {
        course(id:COURSE_ID_HERE) {
            syllabusBody
        }
    }
    ```
* Ensure that the result returns the syllabus body HTML.
