### PR TITLE
Bumped ruby-debug-ide version to .3

### DIFF
--- a/Gemfile.d/development.rb
+++ b/Gemfile.d/development.rb
@@ -27,5 +27,5 @@ group :development do
 
   gem "byebug", "11.1.3", platform: :mri
   gem "debase", "0.2.5.beta2", require: false
-  gem "ruby-debug-ide", "0.7.2", require: false
+  gem "ruby-debug-ide", "0.7.3", require: false
 end


### PR DESCRIPTION
Following the Quick Start guide, I got "Could not find ruby-debug-ide-0.7.2 in any of the sources". I had to bump the version to .3 for the project to finish running setup scripts.