### PR TITLE
Fix cookie samesite issue for LTI 1.3 deep linking

### DIFF
--- a/gems/canvas_breach_mitigation/lib/canvas_breach_mitigation/masking_secrets.rb
+++ b/gems/canvas_breach_mitigation/lib/canvas_breach_mitigation/masking_secrets.rb
@@ -32,7 +32,7 @@ module CanvasBreachMitigation
         encoded_masked_token = masked_token(unmasked_token(cookies["_csrf_token"]))
 
         cookie = { value: encoded_masked_token }
-        %i[domain httponly secure].each do |key|
+        %i[domain httponly secure same_site].each do |key|
           next unless options.key?(key)
 
           cookie[key] = options[key]

--- a/gems/request_context/lib/request_context/session.rb
+++ b/gems/request_context/lib/request_context/session.rb
@@ -32,7 +32,8 @@ module RequestContext
         ActionDispatch::Request.new(env).cookie_jar[:log_session_id] = {
           value: session_id,
           secure: Rails.application.config.session_options[:secure],
-          httponly: true
+          httponly: true,
+          same_site: Rails.application.config.session_options[:same_site]
         }
       end
 

--- a/lib/canvas/request_forgery_protection.rb
+++ b/lib/canvas/request_forgery_protection.rb
@@ -40,7 +40,7 @@ module Canvas
 
     def authenticity_token_options
       session_options = CanvasRails::Application.config.session_options
-      options = session_options.slice(:domain, :secure)
+      options = session_options.slice(:domain, :secure, :same_site)
       options[:httponly] = HostUrl.is_file_host?(request.host_with_port)
       options
     end


### PR DESCRIPTION
LTI 1.3 deep linking don't seem to be working in latest Chrome. Seemingly this is due to because SameSite property of session and CSRF token cookies are not set to None to allow cross-site. Even though the deep link selection iframe ends up at same domain (Canvas) it's navigated to through the tool domain which effectively makes it cross-site.

Closes gh-1900

Test plan:
- Test LTI 1.3 deep linking with an external tool
- Test compatibility with different browsers (new browsers supporting SameSite: None and browsers not supporting)
- Investigate any undesired security implications this change might have