### PR TITLE
Correct mangled try/catch block

### DIFF
--- a/app/views/shared/_embedded_chat.html.erb
+++ b/app/views/shared/_embedded_chat.html.erb
@@ -57,7 +57,7 @@
       iframe.style.width = data.width+'px';
       iframe.style.height = data.height+'px';
       iframe.style.bottom = data.bottom+'px';
-    } catch () {
+    } catch (e) {
       // fail gracefully
     }
   }, false);


### PR DESCRIPTION
This mangled try/catch block (no exception object specified to catch) causes the embedded chat to fail to load (as well as cause a number of issues for those of us who jump on the coat-tails of its iframe-resizing code in instutional learning content!). The simplest of fixes is proposed. Also see issue 2131.