### PR TITLE
bump gem pg

### DIFF
--- a/Gemfile.d/postgres.rb
+++ b/Gemfile.d/postgres.rb
@@ -18,5 +18,5 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
 group :postgres do
-  gem "pg", "1.2.3"
+  gem "pg", "1.4.5"
 end


### PR DESCRIPTION
noted that docker-compose uses postgres 14 image, but:
pg-1.4.5 - Update error codes to PostgreSQL-15
pg 1.3.0 - Update error codes to PostgreSQL-14

so this gem update is required for newer postgres versions.