### PR TITLE
`canvas_init`: Set shell (-s) - suppport limited system user

### DIFF
--- a/script/canvas_init
+++ b/script/canvas_init
@@ -13,7 +13,7 @@ set -e
 
 # drop privs if necessary
 if [ "$(id -u)" == "0" ]; then
-  exec su $(stat -c %U $(dirname $(readlink -f $0))/../config/environment.rb) -c "/bin/bash $0 $@"
+  exec su $(stat -c %U $(dirname $(readlink -f $0))/../config/environment.rb) -s /bin/bash -c "/bin/bash $0 $@"
   exit -1;
 fi
 


### PR DESCRIPTION
Minor change to `canvas_init` so that it can also run under a limited system user account (that does not have a shell by default, or uses `/bin/nologin` or `/bin/false`).

Currently the service will fail to start if the user does not have a shell set.

As an aside, I would like to see a native systemd service. Even though systemd is ubiquitous these days, it wouldn't be unreasonable to keep this init.d script (e.g. for those few that might wish to use OpenRC - or something else). But a native `canvas_init.service` file would be preferable. I have personally noticed some weirdness (e.g. the system losing track of it's workers) with the init.d script unless used via systemd (i.e. if you `/etc/init.d/canvas_init start`, I found on most occasions if I follow that with `systemctl status canvas_init` it reports "failed" - but it's actually running).