### PR TITLE
LtiDeepLinkingResponse can indicate that link open in new tab

### DIFF
--- a/app/controllers/lti/ims/concerns/deep_linking_modules.rb
+++ b/app/controllers/lti/ims/concerns/deep_linking_modules.rb
@@ -67,11 +67,19 @@ module Lti::IMS::Concerns
       }
     end
 
+    # the window property in a deep linking response can contain
+    # link-specific options. If a targetName is present, it can
+    # be used to determine whether the link should default to
+    # being opened in a new tab or not
+    def open_in_new_tab?(content_item)
+      content_item.dig(:window, :targetName) == '_blank'
+    end
+
     def build_module_item(content_item)
       {
         type: "context_external_tool",
         id: tool.id,
-        new_tab: 0,
+        new_tab: open_in_new_tab?(content_item) ? 1 : 0,
         indent: 0,
         url: content_item[:url],
         title: content_item[:title],
@@ -111,7 +119,7 @@ module Lti::IMS::Concerns
             external_tool_tag_attributes: {
               content_type: "ContextExternalTool",
               content_id: tool.id,
-              new_tab: 0,
+              new_tab: open_in_new_tab?(content_item) ? 1 : 0,
               url: content_item[:url]
             }
           }


### PR DESCRIPTION
Canvas defaults to using an iframe (new_tab: 0) for ltiResourceLink content items. This requires that a tool provider use the Canvas HTTP API to update each module item or assignment to specify that it open the LTI link in a new tab.

Since Canvas doesn't currently take the `window.targetName` into account when handling ltiResourceLink content items, it seemed OK to handle a value of "_blank" as a special case for indicating that the content should open in a new tab.

This would not affect any existing content and it's unlikely (?) to surprise any users who have set a targetName of "_blank". In fact, it may now do what they've intended it to do.

Test Plan:
  - Configure a course to launch an LTI Advantage Deep-Linking workflow
  - The tool should return a Deep-Linking response with at least one ltiResourceLink content item whose window.targetName value is set to "_blank"
  - Once the item populates (module item or assignment), ensure it opens in a new tab