### PR TITLE
Fix documented type for rubric_settings in Assignment object.

### DIFF
--- a/app/controllers/assignments_api_controller.rb
+++ b/app/controllers/assignments_api_controller.rb
@@ -578,8 +578,8 @@
 #         },
 #         "rubric_settings": {
 #           "description": "(Optional) An object describing the basic attributes of the rubric, including the point total. Included if there is an associated rubric.",
-#           "example": "{\"points_possible\"=>12}",
-#           "type": "string"
+#           "example": {"points_possible": "12"},
+#           "type": "object"
 #         },
 #         "rubric": {
 #           "description": "(Optional) A list of scoring criteria and ratings for each rubric criterion. Included if there is an associated rubric.",


### PR DESCRIPTION
Documentation here: https://canvas.instructure.com/doc/api/assignments.html and experiments suggest that `rubric_settings` is returned as an object, not a string.