### PR TITLE
User Observer process should restore inactive observer enrollments an…

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -434,7 +434,7 @@ class Enrollment < ActiveRecord::Base
     # we don't want to create a new observer enrollment if one exists
     self.class.unique_constraint_retry do
       enrollment = linked_enrollment_for(observer)
-      return true if enrollment && !enrollment.deleted?
+      return true if enrollment && !enrollment.deleted? && !enrollment.inactive?
       return false unless observer.can_be_enrolled_in_course?(course)
 
       enrollment ||= observer.observer_enrollments.build

--- a/spec/models/user_observer_spec.rb
+++ b/spec/models/user_observer_spec.rb
@@ -56,6 +56,23 @@ describe UserObservationLink do
     expect(observer_enroll.reload).to_not be_deleted
   end
 
+  it 'restores inactive observer enrollments on "restore" (even if nothing about the observee changed)' do
+    # i'm like 66% sure someone will complain about this
+    stu_enroll = student_in_course(user: student)
+    stu_enroll.workflow_state = "active"
+    stu_enroll.save!
+
+    observer = user_with_pseudonym
+    UserObservationLink.create_or_restore(observer: observer, student: student, root_account: Account.default)
+    observer_enroll = observer.observer_enrollments.first
+    observer_enroll.workflow_state = "inactive"
+    observer_enroll.save!
+
+    UserObservationLink.create_or_restore(observer: observer, student: student, root_account: Account.default)
+    observer_enroll.reload
+    expect(observer_enroll.workflow_state).to eq "active"
+  end
+
   it "creates an observees when one does not exist" do
     observer = user_with_pseudonym
     re_observee = UserObservationLink.create_or_restore(observer: observer, student: student, root_account: Account.default)


### PR DESCRIPTION
User Observer process should restore inactive observer enrollments

It is common for schools to run sis imports in batch mode using the batch_mode_enrollment_drop_status parameter set to inactive. This changes the default behavior of marking data previously imported via sis that is not represented in the latest sis import as deleted to inactive. The User Observer process is currently unable to handle restoring observer enrollments that have been marked inactive.

 Test Plan:
   - Add a user as an observer of a student with active enrollments
   - Mark one or more of the observer enrollments associated to the student as inactive
   - Process a user_observer sis import tying the observer to the student
   - Confirm the observer enrollments marked as inactive are restored