### PR TITLE
Fix syntax error for script/common/utils/common.sh check_dependencies function

### DIFF
--- a/script/common/utils/common.sh
+++ b/script/common/utils/common.sh
@@ -155,7 +155,7 @@ function check_dependencies {
       continue
     fi
     if [[ ${#dep[@]} -gt 1 ]]; then
-      version=$(eval "${dep[0]}" version |grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+")
+      version=$(eval "${dep[0]}" version |grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+") | head -1
       if (( $(echo "$version ${dep[1]}" | awk '{print ($1 < $2)}') )); then
         wrong_version+=("$dependency or higher. Found: ${dep[0]} $version.")
       fi


### PR DESCRIPTION
Evaluation of docker-compose version outputs multiple lines with multiple matches to the regex pattern

We only want the docker-compose version which is first so pipe it to head. This fixes the following syntax error
```
Checking Dependencies...
script/common/utils/common.sh: line 159: ((: 0
0
0
1 : syntax error in expression (error token is "0
0
1 ")
```

```
echo "$(eval "docker-compose" version |grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+")"
1.29.2
5.0.3
3.10.6
3.0.2
```

```
echo "$(eval "docker-compose" version |grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+")" | head -1
1.29.2
```

Closes #2169

 Test Plan:
  - On linux and mac, run the script with and without the change. Confirm funtionality still works and syntax error is removed.

