### PR TITLE
Observer enrollments need to be touched with latest sis batch id

### DIFF
--- a/lib/sis/enrollment_importer.rb
+++ b/lib/sis/enrollment_importer.rb
@@ -341,6 +341,13 @@ module SIS
             @roll_back_data << data if data
           else
             @enrollments_to_update_sis_batch_ids << enrollment.id
+            # Make sure linked observer enrollments are added to be touched with sis_batch_id
+            linked_enrl = Enrollment.where.not(sis_batch_id: nil)
+                              .where(
+                                associated_user_id: enrollment.user_id,
+                                course_section_id: enrollment.course_section_id)
+                              .shard(Shard.shard_for(enrollment.course_id)).pluck(:id)
+            @enrollments_to_update_sis_batch_ids.push(*linked_enrl)
           end
           @success_count += 1
         end

--- a/spec/models/sis_batch_spec.rb
+++ b/spec/models/sis_batch_spec.rb
@@ -1416,6 +1416,24 @@ test_1,u1,student,active)
       expect(student_enrollment.reload.workflow_state).to eq "active"
       expect(observer_enrollment.reload.workflow_state).to eq "active"
     end
+
+    it "Observer enrollments created by user_observer should remain active when run in batch and not included" do
+      course = @account.courses.create!(name: "one", sis_source_id: "c1", workflow_state: "available")
+      term = @account.enrollment_terms.first
+      student = user_with_managed_pseudonym(account: @account, sis_user_id: "u1")
+      observer = user_with_managed_pseudonym(account: @account, sis_user_id: "u2")
+      UserObservationLink.create_or_restore(observer: observer, student: student, root_account: @account)
+
+      process_csv_data([%(section_id,user_id,role,status,course_id\n,u1,student,active,c1)], batch_mode: true, batch_mode_term: term)
+      student_enrollment = course.enrollments.where(user: student).take
+      observer_enrollment = course.observer_enrollments.where(user: observer).take
+      expect(student_enrollment.workflow_state).to eq "active"
+      expect(observer_enrollment.workflow_state).to eq "active"
+
+      process_csv_data([%(section_id,user_id,role,status,course_id,associated_user_id\n,u1,student,active,c1,u1)], batch_mode: true, batch_mode_term: term)
+      expect(student_enrollment.reload.workflow_state).to eq "active"
+      expect(observer_enrollment.reload.workflow_state).to eq "active"
+    end
   end
 
   describe "remove_previous_imports" do


### PR DESCRIPTION
Observer enrollments not specificied in an enrollments sis import run in batch mode are not updated with the latest sis batch id. As a result, the enrollments are deleted even if the student enrollment remains active

Test plan
  - Set up an observer with an active enrollment tied to a student
  - Run an enrollment sis import in batch mode supplying the student enrollment as active
  >> Expect the observer enrollment to still be active