### PR TITLE
[setup scripts] - Update URL of docker desktop documentation where ir refers to increasing the memory needed to run Canvas.

### DIFF
--- a/script/common/utils/docker_desktop_setup.sh
+++ b/script/common/utils/docker_desktop_setup.sh
@@ -31,7 +31,7 @@ function check_docker_memory {
   if [[ "$docker_memory" -lt '8300000000' ]]; then
     echo_console_and_log "
   Canvas requires at least 8GB of memory dedicated to Docker Desktop. Please refer to
-  https://docs.docker.com/docker-for-mac/#resources for more info on increasing your memory."
+  https://docs.docker.com/desktop/settings/mac/#advanced for more info on increasing your memory."
     exit 1
   fi
 }


### PR DESCRIPTION
When setting up Canvas locally, after my first attempt to run `script/docker_dev_setup.sh` I received the following message:

```sh
  Canvas requires at least 8GB of memory dedicated to Docker Desktop. Please refer to
  https://docs.docker.com/docker-for-mac/#resources for more info on increasing your memory.
```

The referred link above is outdated and lead to nowhere. So This PRs aims to update the given link to the point at Docker desktop documentation where it talks about increasing memory usage.

