### PR TITLE
Use a more polite fallback message in comments

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2233,7 +2233,7 @@ class Submission < ActiveRecord::Base
       if opts[:media_comment_id]
         opts[:comment] = ""
       elsif opts[:attachments].try(:length)
-        opts[:comment] = t("attached_files_comment", "See attached files.")
+        opts[:comment] = t("attached_files_comment", "Please see attached files.")
       end
     end
     if opts[:provisional]

--- a/ui/features/submissions/jquery/index.js
+++ b/ui/features/submissions/jquery/index.js
@@ -279,7 +279,7 @@ export function setup() {
           !formData['submission[comment]'] &&
           $("#add_comment_form input[type='file']").length > 0
         ) {
-          formData['submission[comment]'] = I18n.t('see_attached_files', 'See attached files')
+          formData['submission[comment]'] = I18n.t('see_attached_files', 'Please see attached files')
         }
       }
       if (!formData['submission[comment]'] && !formData['submission[media_comment_id]']) {


### PR DESCRIPTION
This PR tweaks the automatic comment that is made when you upload a file during grading. The user is not prewarned that this message will be sent on their behalf, so it would be good to use a more polite message. 

I don't see English listed [in Transifex](https://explore.transifex.com/instructure/canvas-crowdsource) so I assume nothing needs to be changed in the i18n system?