### PR TITLE
Update updated_at on sis batch when progress is updated

### DIFF
--- a/app/models/sis_batch.rb
+++ b/app/models/sis_batch.rb
@@ -278,7 +278,7 @@ class SisBatch < ActiveRecord::Base
 
     self.progress = val
     state = SisBatch.connection.select_value(<<~SQL.squish)
-      UPDATE #{SisBatch.quoted_table_name} SET progress=#{val} WHERE id=#{id} RETURNING workflow_state
+      UPDATE #{SisBatch.quoted_table_name} SET progress=#{val}, updated_at = NOW() WHERE id=#{id} RETURNING workflow_state
     SQL
     raise SisBatch::Aborted if state == "aborted"
   end


### PR DESCRIPTION
When the progress is updated on an sis batch via fast_updated_progress the updated_at field should also be updated.

The updated_at field is useful when monitoring when an import might be hung. For example, progress hasn't incremented since x time. Currently, as far as i've observed the updated_at value never progresses during the cleanup batch phase.

Test plan
  - Run an enrollment batch import and validate the updated_at field is changing as the progress changes.