### PR TITLE
fix temp uploaded files path

### DIFF
--- a/gems/attachment_fu/lib/attachment_fu/railtie.rb
+++ b/gems/attachment_fu/lib/attachment_fu/railtie.rb
@@ -25,7 +25,7 @@ module AttachmentFu
     end
 
     def self.setup_tempfile_path
-      AttachmentFu.tempfile_path = "/tmp/attachment_fu"
+      AttachmentFu.tempfile_path = "tmp/attachment_fu"
       AttachmentFu.tempfile_path = ATTACHMENT_FU_TEMPFILE_PATH if Object.const_defined?(:ATTACHMENT_FU_TEMPFILE_PATH)
 
       begin


### PR DESCRIPTION
fix temp uploaded files path
By default it uploads files to /tmp/attachment_fu

in case of several canvas instances issue with file upload due to permissions issue
changing folder to RWX for all users does not fix issue

we change to tmp/attachment_fu 
in this case tmp uploaded files are in project's folder tmp and no issues
