### PR TITLE
Adds sanitize to conversation messages

### DIFF
--- a/app/models/conversation_message.rb
+++ b/app/models/conversation_message.rb
@@ -50,6 +50,8 @@ class ConversationMessage < ActiveRecord::Base
   scope :with_media_comments, -> { where("has_media_objects") }
   scope :by_user, ->(user_or_id) { where(author_id: user_or_id) }
 
+  sanitize_field :body, CanvasSanitize::SANITIZE
+
   def self.preload_latest(conversation_participants, author = nil)
     return unless conversation_participants.present?
 


### PR DESCRIPTION
Conversation messages rely on the output-side rendering to escape any malicious HTML.  This adds a sanitize_field call to the body property to clean up the saved data and ensure that API-provided messages are safe as well.

Test plan
  - Open browser developer tools network panel
  - Send a conversation message to someone and verify it's received
  - In Chrome, copy the request out as a cURL command.  Edit the message in the JSON to include some HTML with an onClick event.
  - Invoke the cURL command to send another message
  - Verify that the HTML was stripped