### PR TITLE
Fix typo in rubric_associations_controller.rb

### DIFF
--- a/app/controllers/rubric_associations_controller.rb
+++ b/app/controllers/rubric_associations_controller.rb
@@ -91,7 +91,7 @@ class RubricAssociationsController < ApplicationController
     rubric_id = association_params.delete(:rubric_id)
     @rubric = @association ? @association.rubric : Rubric.find(rubric_id)
     # raise "User doesn't have access to this rubric" unless @rubric.grants_right?(@current_user, session, :read)
-    return unless can_manage_rubrics_or_association_object?(@assocation, @association_object)
+    return unless can_manage_rubrics_or_association_object?(@association, @association_object)
     return unless can_update_association?(@association)
 
     # create a new rubric if associating in a different course


### PR DESCRIPTION
Fix typo for `@assocation` to `@association`. Causes `return true if association ||` to fail the first condition inside method `can_manage_rubrics_or_association_object?` in `app/controllers/rubric_associations_controller.rb`.