### PR TITLE
docker_dev_setup.sh permission fix for issues in https://github.com/instructure/canvas-lms/issues/2199

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ WORKDIR $APP_HOME
 
 USER root
 
+# This is required in order to change the permissions and 
+# ownership of the directory that causes permission issues
+# via bundle_config_and_install() in install_assets.sh
+RUN useradd -ms /bin/bash docker || usermod -aG sudo docker
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 ARG USER_ID
 # This step allows docker to write files to a host-mounted volume with the correct user permissions.
 # Without it, some linux distributions are unable to write at all to the host mounted volume.

--- a/script/install_assets.sh
+++ b/script/install_assets.sh
@@ -9,6 +9,7 @@ function bundle_config_and_install() {
   bundle config --global build.nokogiri --use-system-libraries &&
   bundle config --global build.ffi --enable-system-libffi &&
   mkdir -p /home/docker/.bundle &&
+  sudo chown -R docker:docker /usr/src/app &&
   bundle install --jobs $(nproc)
 }
 


### PR DESCRIPTION
This pull request fixes the issues in: 
- `https://github.com/instructure/canvas-lms/issues/2199`

When trying to install Canvas via `docker_dev_setup.sh` the user is unable to complete the installation script due to permissions of files and directories in the application root being changed resulting in other programs being unable to install packages and dependencies in those locations.