### PR TITLE
Fix observer enrollment impacting section privileges of teacher

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -492,6 +492,7 @@ class Enrollment < ActiveRecord::Base
     self.root_account_id = other.root_account_id
     self.sis_batch_id = other.sis_batch_id unless sis_batch_id.nil?
     self.skip_touch_user = other.skip_touch_user
+    self.limit_privileges_to_course_section = other.limit_privileges_to_course_section
     if skip_broadcasts
       save_without_broadcasting!
     else

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1851,6 +1851,17 @@ describe Course do
       expect(@course.course_section_visibility(limited_teacher)).to eq [@section2.id]
     end
 
+    it "correctly limits visibilities for a limited teacher observing a student in different section" do
+      limited_teacher = user_with_pseudonym(name: "Limited Teacher")
+      @course.enroll_teacher(limited_teacher,
+                             limit_privileges_to_course_section: true,
+                             section: @section2)
+      student = user_with_pseudonym
+      @course.enroll_student(student, enrollment_state: "active", section: @section1, limit_privileges_to_course_section: true)
+      add_linked_observer(student, limited_teacher)
+      expect(@course.course_section_visibility(limited_teacher)).to eq [@section1.id, @section2.id]
+    end
+
     it "unlimited teachers can see everything" do
       unlimited_teacher = User.create(name: "Unlimited Teacher")
       @course.enroll_teacher(unlimited_teacher, section: @section2)


### PR DESCRIPTION
visibility_limited_to_course_sections? should return true if all of the enrollments have limited_section_privileges ignoring observer enrollments

 closes gh-2245

 Test Plan:
   - Enroll a teacher in a section of course with limit section privileges set to true
   - Enroll a student in a different section of the same course with limit section privileges set to true
   - Set up the teacher as an observer of the student (for example the teacher teaches a section of a course but has a son or daughter taking a different section of the same course) Confirm the teacher cannot view all sections and can only see the two sections.