### PR TITLE
The function of "Reset Course Content" is unclear at first glance. Changed to more descriptive button name.

### DIFF
--- a/app/views/courses/_settings_sidebar.html.erb
+++ b/app/views/courses/_settings_sidebar.html.erb
@@ -96,11 +96,11 @@
 
   <% if can_do(@context, @current_user, :reset_content) && !MasterCourses::MasterTemplate.is_master_course?(@context) %>
     <%= link_to context_url(@context, :course_reset_url), :class => ' Button Button--link Button--link--has-divider Button--course-settings reset_course_content_button' do %>
-      <i class="icon-reset"></i><%= t('links.reset', 'Reset Course Content') %>
+      <i class="icon-reset"></i><%= t('links.reset', 'Delete Course Content') %>
     <% end %>
 
     <div <%= hidden(true) %> id="reset_course_content_dialog">
-      <p><%= mt('help.reset_course_content', 'Resetting course content will permanently delete all associated assignments, discussions, quizzes, modules, rubrics, pages, files, learning outcomes, question banks, collaborations, conferences, or any other content. This action is irreversible, and the data *cannot* be recovered. Are you sure you wish to continue?') %></p>
+      <p><%= mt('help.reset_course_content', 'Deleting course content will permanently delete all associated assignments, discussions, quizzes, modules, rubrics, pages, files, learning outcomes, question banks, collaborations, conferences, or any other content. This action is irreversible, and the data *cannot* be recovered. Are you sure you wish to continue?') %></p>
 
       <%= form_for @context, :url => context_url(@context, :course_reset_url), :html => { :method => :post } do %>
         <div class="button-container">
@@ -108,7 +108,7 @@
             <%= t('#buttons.cancel', 'Cancel') %>
           </button>
           <button type="submit" class="btn btn-danger submit_button">
-            <%= t('buttons.reset', 'Reset Course Content') %>
+            <%= t('buttons.reset', 'Delete Course Content') %>
           </button>
         </div>
       <% end %>


### PR DESCRIPTION
I am ashamed to admit that I made a mistake in a production Canvas environment and deleted my course by accident. Luckily I think our administrators have a backup. I misconstrued "Reset Course Content" to mean resetting course progression for students. I think its much clearer to just call it "Delete Course Content" since that is what the button is actually doing. Based on my quick Google searches it seems I am not the only person who has made this mistake. 

Also I know there's a lightbox dialog that somewhat clarifies the functionality but I still misread it and thought it would just reset course progression. 

I don't think this warrants changing the naming convention for the functionality in code (since "reset" can help differentiate from "delete course" functionality) but I am happy to go through and update this as well if its deemed necessary. 