### PR TITLE
Fix for S3 Environment Error in Canvas-LMS Submission Reupload

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -1140,7 +1140,7 @@ class FilesController < ApplicationController
     return unless quota_exempt? || check_quota_after_attachment
 
     if Attachment.s3_storage?
-      return head(:bad_request) unless @attachment.state == :unattached
+      return head(:bad_request) unless [:attached, :attached_temporary].include?(@attachment.state)
 
       details = @attachment.s3object.data
       @attachment.process_s3_details!(details)

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -1140,7 +1140,7 @@ class FilesController < ApplicationController
     return unless quota_exempt? || check_quota_after_attachment
 
     if Attachment.s3_storage?
-      return head(:bad_request) unless [:attached, :attached_temporary].include?(@attachment.state)
+      return head(:bad_request) unless [:unattached, :unattached_temporary].include?(@attachment.state)
 
       details = @attachment.s3object.data
       @attachment.process_s3_details!(details)


### PR DESCRIPTION
I recently encountered an issue (referenced [here](https://github.com/instructure/canvas-lms/issues/2278)) related to the state "attached_temporary" in Canvas-LMS when reuploading submission zip files. The problem arises from the if statement `unless @attachment.state == :unattached`, causing errors during the reupload process in an S3 environment.

To address this, I've added `attached_temporary` state into the if statement.
With this adjustment, the code will no longer impede the reuploading of submission zip files in S3 environments, preventing errors specifically when "create_success" is encountered after uploading.