### PR TITLE
Add "sent" as a valid scope argument

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -171,7 +171,7 @@ class ConversationsController < ApplicationController
   # Returns the paginated list of conversations for the current user, most
   # recent ones first.
   #
-  # @argument scope [String, "unread"|"starred"|"archived"]
+  # @argument scope [String, "unread"|"starred"|"archived"|"sent"]
   #   When set, only return conversations of the specified type. For example,
   #   set to "unread" to return only conversations that haven't been read.
   #   The default behavior is to return all non-archived conversations (i.e.


### PR DESCRIPTION
After looking at some of the GraphQL queries in the conversation page, 'sent' is a valid filter in the API for conversation list queries. This PR is to update the documentation to reflect the actual available functionality.