### PR TITLE
Sort sectionNames var expansion by section id

### DIFF
--- a/lib/lti/variable_expander.rb
+++ b/lib/lti/variable_expander.rb
@@ -290,7 +290,8 @@ module Lti
                        default_name: "com_instructure_user_observees"
 
     # Returns an array of the section names in a JSON-escaped format that the user is enrolled in, if the
-    # context of the tool launch is within a course.
+    # context of the tool launch is within a course. The names are sorted by the course_section_id, so that
+    # they are useful in conjunction with the Canvas.course.sectionIds substitution.
     #
     # @example
     #   ```
@@ -298,7 +299,7 @@ module Lti
     #   ```
     register_expansion "com.instructure.User.sectionNames",
                        [],
-                       -> { @context.enrollments.active.joins(:course_section).where(user_id: @current_user.id).pluck(:name)&.to_json },
+                       -> { @context.enrollments.active.joins(:course_section).where(user_id: @current_user.id).order(:course_section_id).pluck(:name)&.to_json },
                        ENROLLMENT_GUARD,
                        default_name: "com_instructure_user_section_names"
 

--- a/spec/lib/lti/variable_expander_spec.rb
+++ b/spec/lib/lti/variable_expander_spec.rb
@@ -1322,6 +1322,20 @@ module Lti
             variable_expander.expand_variables!(exp_hash)
             expect(JSON.parse(exp_hash[:test])).to match_array ["section one", "section two"]
           end
+
+          it "orders the names by section id" do
+            add_section("section three", { course: })
+            s1 = course.course_sections.find_by(name: "section one")
+            s2 = course.course_sections.find_by(name: "section two")
+            s3 = course.course_sections.find_by(name: "section three")
+            create_enrollment(course, user, { section: s3 }) # Create the enrollment "out of order" based on section id
+            create_enrollment(course, user, { section: s2 })
+            exp_hash = { test: "$com.instructure.User.sectionNames" }
+            variable_expander.expand_variables!(exp_hash)
+            expect(s1.id).to be < s2.id
+            expect(s2.id).to be < s3.id
+            expect(JSON.parse(exp_hash[:test])).to eq ["section one", "section two", "section three"]
+          end
         end
 
         context "when the course has groups" do


### PR DESCRIPTION
Disclaimer: This is my first attempt at a PR against the Canvas repo; I'm a developer at Code.org, which is part of the partner program. I've been told that I should be covered under the partner agreement and don't need to submit a signed contributor agreement. Please let me know if my PR is lacking anything as it's my first try!

**PR context:**
The variable expansion for `com.instructure.User.sectionNames` has no explicit order. While this is fine when the variable is used in isolation, it becomes problematic when an LTI tool needs to construct full knowledge of a course's sections using a combination of `com.instructure.User.sectionNames` and `Canvas.course.sectionIds`. Since the IDs come back in ascending order, it makes sense to sort the names by the same property, guaranteeing that names can be mapped accurately onto IDs, and enabling the tool to accurately reconstruct the sections for a given course using only the NRPS membership response.

For reference, here is the code that returns sorted `sectionIds` in the [substitutions_helper](https://github.com/instructure/canvas-lms/blob/master/lib/lti/substitutions_helper.rb#L232-L234):

```
def section_ids
  course_enrollments.map(&:course_section_id).uniq.sort.join(",")
end
```

This should reliably sort the `sectionIds` in ascending order. However, looking at the [variable expansion code](https://github.com/instructure/canvas-lms/blob/9c8665778cf988a6ea57880982e7faf36c33afe0/lib/lti/variable_expander.rb#L299-L303) for `com.instructure.User.sectionNames`, we see that there is no `order` clause:

```
@context.enrollments.active.joins(:course_section).where(user_id: @current_user.id).pluck(:name)&.to_json
```

This seems to return the `sectionNames` for a user in the order in which the user was enrolled in each section. In practice this makes it possible to know which sections a user is in (since we have the IDs) and the names of the sections (we have all the names), but not _which sections map to which names_, because the order of the names is not guaranteed. This is also coming from the perspective of a third-party tool integrating with Canvas via LTI 1.3, using the NRPS API, but not the more full-featured Canvas REST APIs.

This PR simply orders the names by section id. Since no order was guaranteed or documented before, I'm hoping this wouldn't be considered a breaking change for users, and I think it solves a big use case for LTI tool providers.