### PR TITLE
OIDC login hint

### DIFF
--- a/app/controllers/login/oauth2_controller.rb
+++ b/app/controllers/login/oauth2_controller.rb
@@ -28,7 +28,7 @@ class Login::OAuth2Controller < Login::OAuthBaseController
     super
     nonce = session[:oauth2_nonce] = SecureRandom.hex(24)
     jwt = Canvas::Security.create_jwt({ aac_id: @aac.global_id, nonce:, host: request.host_with_port }, 10.minutes.from_now)
-    authorize_url = @aac.generate_authorize_url(oauth2_login_callback_url, jwt)
+    authorize_url = @aac.generate_authorize_url(oauth2_login_callback_url, jwt, params[:login_hint])
 
     if @aac.debugging? && @aac.debug_set(:nonce, nonce, overwrite: false)
       @aac.debug_set(:debugging, t("Redirected to identity provider"))

--- a/app/models/authentication_provider/oauth2.rb
+++ b/app/models/authentication_provider/oauth2.rb
@@ -38,8 +38,10 @@ class AuthenticationProvider::OAuth2 < AuthenticationProvider::Delegated
     @client ||= ::OAuth2::Client.new(client_id, client_secret, client_options)
   end
 
-  def generate_authorize_url(redirect_uri, state)
-    client.auth_code.authorize_url({ redirect_uri:, state: }.merge(authorize_options))
+  def generate_authorize_url(redirect_uri, state, login_hint = nil)
+    options = { redirect_uri: redirect_uri, state: state }
+    options[:login_hint] = login_hint if login_hint
+    client.auth_code.authorize_url(options.merge(authorize_options))
   end
 
   def get_token(code, redirect_uri, _params)


### PR DESCRIPTION
This adds some support for the `login_hint` parameter, defined by the [OIDC Core 1.0 spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) and mentioned in [Google's documentation](https://developers.google.com/identity/openid-connect/openid-connect#login-hint) of the same.

With this change, if users are directed to "/login/google?login_hint=user@foo.com", assuming canvas has the "google" authentication option set up, it will add `&login_hint` to the authorization request URL. The effect on the user is to skip the account choice screen if the user has multiple active sessions with the IdP and the email provided in `login_hint` matches one of them.