### PR TITLE
Update ui_listview.scss

### DIFF
--- a/app/stylesheets/bundles/ui_listview.scss
+++ b/app/stylesheets/bundles/ui_listview.scss
@@ -18,10 +18,11 @@
  @import "base/environment";
 
 .ui-listview {
-  box-shadow: 0px 1px 4px rgba(0,0,0,.3);
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
   padding: 0;
   list-style: none;
   min-width: 300px;
+  overflow: hidden; // crop the iframe outside the border-radius
 
   border-radius: 0.6em;
   li:first-child {
@@ -31,13 +32,6 @@
   li:last-child  {
     border-bottom-#{direction(right)}-radius: 0.6em;
     border-bottom-#{direction(left)}-radius: 0.6em;
-  }
-
-  &.ui-listview-no-rounded-bottom {
-    &, li:last-child {
-      border-bottom-#{direction(right)}-radius: 0;
-      border-bottom-#{direction(left)}-radius: 0;
-    }
   }
 
 /*  &, li:first-child, li:last-child {
@@ -61,6 +55,11 @@
       font-size: 1em; /*this is to override the .file, .pdf, .doc etc 10px size*/
       background-position: 15px center; /*overrides background-position left of attachment_links*/
     }
+    .ui-listview-text > iframe {
+      border: none; // remove big iframe border
+      border-radius: 0 0 .6em .6em;
+      border-bottom: 1px solid #ccc;
+    }
     &:hover {
       border-color: #bbb;
       background:       #dadada;
@@ -71,13 +70,11 @@
       a{ text-decoration: none;}
     }
     &:active, &.active {
-      border-color: #999;
-      background:       #999;
       font-weight: bold;
-      color:          #fff;
+      color: #fff;
       cursor: pointer;
       text-decoration: none;
-      @include vertical-gradient(#ccc, #aaa);
+      background: #f9fbfd; // make background white instead of an ugly gradient
       outline: none;
       a {
         color: #444;


### PR DESCRIPTION
I made the integrated google docs/slides/sheets look nicer by removing the border on the iframe, giving it a more spread out a less harsh shadow and adding border radius to the bottom of the window.

Normal:
<img width="1099" alt="Screenshot 2024-04-14 at 9 25 55 PM" src="https://github.com/instructure/canvas-lms/assets/89492541/a3eb00bd-31ee-47a7-abed-e34e7d8384e0">

With edits:
<img width="1107" alt="Screenshot 2024-04-14 at 9 24 47 PM" src="https://github.com/instructure/canvas-lms/assets/89492541/bdd4c9c6-652f-4771-9846-f4c93c4f5630">