### PR TITLE
fix: correct invalid selector in revert "what-if" scores handler

### DIFF
--- a/ui/features/grade_summary/jquery/index.jsx
+++ b/ui/features/grade_summary/jquery/index.jsx
@@ -759,7 +759,7 @@ function setup() {
       $('#grades_summary .revert_score_link').each(function () {
         $(this).trigger('click', {skipEval: true, refocus: false})
       })
-      $('#.show_guess_grades.exists').show()
+      $('.show_guess_grades.exists').show()
       GradeSummary.updateStudentGrades()
       showAllWhatIfButton.focus()
       $.screenReaderFlashMessageExclusive(I18n.t('Grades are now reverted to original scores'))


### PR DESCRIPTION
You were unable to revert "What-If" scores in the gradebook due to an invalid query selector.

Test Plan:
   - Verify the "Revert to Actual Score" button is functional after setting "What-If" scores