### PR TITLE
Fix margin issue on access code input

### DIFF
--- a/app/views/quizzes/quizzes/access_code.html.erb
+++ b/app/views/quizzes/quizzes/access_code.html.erb
@@ -35,7 +35,7 @@
       <input type="hidden" name="preview" value="1"/>
     <% end %>
     <label for="quiz_access_code" style="font-size: 1.2em;"><%= before_label(:access_code, "Access Code") %></label>
-    <input type="password" name="access_code" style="font-size: 1.2em;" title="<%= before_label(:access_code, "Access Code") %>" id="quiz_access_code"/>
+    <input type="password" name="access_code" style="font-size: 1.2em; margin-bottom:0px;" title="<%= before_label(:access_code, "Access Code") %>" id="quiz_access_code"/>
     <button class="btn" type="submit" class="btn btn-large" disabled><%= t('buttons.submit', "Submit") %></button>
   <% end %>
 </div>


### PR DESCRIPTION
Before:
![image](https://github.com/instructure/canvas-lms/assets/43706372/0b246462-4a7f-4eda-b7bc-61d2c3547527)

After:
![image](https://github.com/instructure/canvas-lms/assets/43706372/f7ecf84b-dac7-4210-aa0a-a101400bfa45)

Fixes margin issue with input not properly aligning with button on the access code input page.

