### PR TITLE
Handle Rails 7.1 Content Type deprecation in Grade Passback

### DIFF
--- a/app/controllers/lti_api_controller.rb
+++ b/app/controllers/lti_api_controller.rb
@@ -34,7 +34,7 @@ class LtiApiController < ApplicationController
   def grade_passback
     verify_oauth
 
-    if request.content_type != "application/xml"
+    if request.media_type != "application/xml"
       raise BasicLTI::BasicOutcomes::InvalidRequest, "Content-Type must be 'application/xml'"
     end
 

--- a/spec/controllers/lti_api_controllers_spec.rb
+++ b/spec/controllers/lti_api_controllers_spec.rb
@@ -301,6 +301,14 @@ describe LtiApiController, type: :request do
       expect(xml.at_css("imsx_POXBody *:first").name).to eq "replaceResultResponse"
     end
 
+    it "works with a content-type of application/xml with a charset present" do
+      make_call(
+        "content-type" => "application/xml; charset=utf-8",
+        "body" => replace_result(score: "0.6")
+      )
+      check_success
+    end
+
     it "allows updating the submission score" do
       expect(@assignment.submissions.not_placeholder.where(user_id: @student)).not_to be_exists
       make_call("body" => replace_result(score: "0.6"))


### PR DESCRIPTION
Rails 7.1 deprecates using `#content_type` for checking media types. https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-request-content-type-now-returns-content-type-header-as-it-is

Because Canvas currently has an exact check against content type, many clients are failing with 415 errors because they POST with a content type header of `application/xml; charset=utf-8`.

Changing to `#media_type` fixes this.

Test plan:
 - Change the Dockerfile to use Rails 7.1
 - Make API request to .../grade_passback with a request Content-Type header of "application/xml; charset=utf-8"
 > Expect request to be successful and set the grade