### PR TITLE
Update _aac_settings.html.erb

### DIFF
--- a/app/views/authentication_providers/_aac_settings.html.erb
+++ b/app/views/authentication_providers/_aac_settings.html.erb
@@ -121,7 +121,7 @@
                   disable_with: t('deleting...')
                 },
                 class: 'Button Button--danger') do %>
-                <%= t("Delete") %>
+                <%= t("Delete Provider") %>
               <% end %>
           <% end %>
           <%= f.button t('Save'), class: "Button Button--primary" %>


### PR DESCRIPTION
clarify purpose of delete button - when viewing SAML particularly with debugging enabled, it is easy for a user who does not frequently access the authentication section to not realize the delete button will delete the provider, and not the debugging info.