### PR TITLE
fix: preserve decimal points in rubric CSV imports

### DIFF
--- a/lib/rubric_csv_importer.rb
+++ b/lib/rubric_csv_importer.rb
@@ -67,7 +67,7 @@ class RubricCSVImporter
       {
         description: rating_description,
         long_description: row[rating_indices[:long_description_indices][index]],
-        points: row[rating_indices[:points_indices][index]].to_i
+        points: row[rating_indices[:points_indices][index]].to_f
       }
     end.compact
 


### PR DESCRIPTION
When importing rubrics via CSV, rating points should be preserved as floating point numbers rather than being truncated to integers. This prevents the rating points from being incorrectly imported and maintains consistency with how points are handled elsewhere in Canvas LMS.

Closes https://community.canvaslms.com/t5/Known-Issues/OPEN-Rubric-imports-cannot-process-decimal-values-for-rating/ta-p/631147

Test plan:
- Import a CSV rubric containing a decimal point in the rating. E.g.
`Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points`
`Test Rubric,Criterion 1,Example description,true,High Distinction,Example description,9.9`