### PR TITLE
fix(quizzes): center marked questions flag

### DIFF
--- a/app/stylesheets/pages/quizzes/_quizzes.scss
+++ b/app/stylesheets/pages/quizzes/_quizzes.scss
@@ -1159,7 +1159,7 @@ ul#question_list {
     &.marked {
       font-weight: bold;
       background-image: url("/images/flagged_question#{direction-rtl('-rtl', '')}.png");
-      background-position: direction('left') 3px top 7px;
+      background-position: direction(left) 3px top 7px;
       background-repeat: no-repeat;
       @if $use_high_contrast {
         @include bg-image(flagged_question_hc, png, no-repeat, 3px, 7px, transparent, 10px, 8px);


### PR DESCRIPTION
Just a typo fix.

before:

![image](https://github.com/user-attachments/assets/e011edbf-50f1-4ce0-962b-6b52ed35c207)

after:

![image](https://github.com/user-attachments/assets/60a297d3-0924-444b-8243-9f3e77bfbeaf)

(ignore the recolor, i'm using a custom userstyle)