### PR TITLE
Make 'new_window' a valid display type

### DIFF
--- a/lib/schemas/internal_lti_configuration.rb
+++ b/lib/schemas/internal_lti_configuration.rb
@@ -22,7 +22,7 @@ module Schemas
   # Represents the "internal" JSON schema used to configure an LTI 1.3 tool,
   # as stored in Lti::ToolConfiguration and used in Lti::Registration.
   class InternalLtiConfiguration < Base
-    VALID_DISPLAY_TYPES = %w[default full_width full_width_in_context in_nav_context borderless].freeze
+    VALID_DISPLAY_TYPES = %w[default full_width full_width_in_context in_nav_context borderless new_window].freeze
 
     # Transforms a hash conforming to the LtiConfiguration schema into
     # a hash conforming to the InternalLtiConfiguration schema.


### PR DESCRIPTION
LTI tools registered using Dynamic Registration have no way of configuring navigation placements to open in a new tab instead of in frame. Adding 'new_window' to enum of VALID_DISPLAY_TYPES in InternalLtiConfiguration schema allows for this.

Test Plan:
- Configure an LTI 1.3 tool with the Course Navigation placement using Dynamic Registration
- Enable the tool in a course
- Select the course navigation link added by the tool. The tool should open in a new tab instead of in frame.