### PR TITLE
Fix: Add space between words in User Provisioning page

### DIFF
--- a/doc/api/provisioning.md
+++ b/doc/api/provisioning.md
@@ -39,7 +39,7 @@ Once an access token is obtained, tools may begin to <a href="names_and_role.htm
 ### Workflow
 - Step 1: Configure a tool that support NRPS in Canvas
 - Step 2: Launch the tool
-- Step 3: Tool consumes the Names and Role service claim as described in the<a href="https://www.imsglobal.org/spec/lti-nrps/v2p0#lti-1-3-integration" target="_blank">NRPS specification</a>, or by substituting the desired course_id/group_id in the <a href="names_and_role.html" target="_blank">Names and Role API</a>.
+- Step 3: Tool consumes the Names and Role service claim as described in the <a href="https://www.imsglobal.org/spec/lti-nrps/v2p0#lti-1-3-integration" target="_blank">NRPS specification</a>, or by substituting the desired course_id/group_id in the <a href="names_and_role.html" target="_blank">Names and Role API</a>.
 - Step 4: Tool obtains <a href="file.oauth.html#accessing-lti-advantage-services" target="_blank">a client_credentials access token</a> (this can actually happen any time before the next step)
 - Step 5: Tool runs requests against the <a href="names_and_role.html" target="_blank">Names and Role API</a>.
 


### PR DESCRIPTION
Summary: This PR adds a missing space in the phrase "the NRPS specification" in the [User Provisioning webpage](https://canvas.instructure.com/doc/api/file.provisioning.html).

Steps to reproduce: Open the provided website and note the missing space in the "Workflow" section.

Expected behavior: Should be a space between "the" and "NRPS"

Additional notes: 
I attach a picture of the issue below:
![image](https://github.com/user-attachments/assets/e1ecba2e-d4e1-4819-801d-a0b698e7056c)
