### PR TITLE
Fix docker_dev_setup script on Linux: status check

### DIFF
--- a/script/common/os/linux/impl.sh
+++ b/script/common/os/linux/impl.sh
@@ -15,7 +15,7 @@ function set_service_util {
 }
 
 function start_docker_daemon {
-  eval "$service_manager docker status &> /dev/null" && return 0
+  eval "docker info &> /dev/null" && return 0
   prompt 'The docker daemon is not running. Start it? [y/n]' confirm
   [[ ${confirm:-n} == 'y' ]] || return 1
   eval "$start_docker"


### PR DESCRIPTION
On systemd machines without the `service` command available, docker will always appear to not be running.

The file `script/common/os/linux/impl.sh` will attempt to run the following command to check the status of docker:
```bash
sudo systemctl docker status # this returns an error, always--the arguments are in the wrong order
```

I suggest we use `docker info` instead. This command will return an error code if docker is inactive and success if docker is active. Alternatively, the arguments should be properly arranged for `service` vs `systemctl`. 