### PR TITLE
fix: rm config/locales/generated in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 !/config/crystalball.yml
 !/config/graphql_persisted_queries.yml
 /config/environments/*-local.rb
-/config/locales/generated/
 /config/saml/*
 /config/RAILS_VERSION
 /coverage/


### PR DESCRIPTION
since config/locales/generated/ is removed, so we can update .gitignore correspondingly