### PR TITLE
Preserve integration info during course clone

### DIFF
--- a/app/controllers/content_migrations_controller.rb
+++ b/app/controllers/content_migrations_controller.rb
@@ -167,6 +167,7 @@ class ContentMigrationsController < ApplicationController
                OLD_START_DATE: datetime_string(@context.start_at, :verbose),
                OLD_END_DATE: datetime_string(@context.conclude_at, :verbose),
                SHOW_SELECT: should_show_course_copy_dropdown,
+               COPY_COURSE_INTEGRATION_INFO: Account.site_admin.feature_enabled?(:course_copy_allow_copying_integration_info),
                MISSING_POLICY_ENABLED: @context.late_policy&.missing_submission_deduction_enabled || false
              })
       set_tutorial_js_env
@@ -212,6 +213,7 @@ class ContentMigrationsController < ApplicationController
                  BLUEPRINT_ELIGIBLE_IMPORT: MasterCourses::MasterTemplate.blueprint_eligible?(@context),
                  SHOW_BP_SETTINGS_IMPORT_OPTION: MasterCourses::MasterTemplate.blueprint_eligible?(@context) &&
                    @context.account.grants_all_rights?(@current_user, session, :manage_courses_admin, :manage_master_courses),
+                 COPY_COURSE_INTEGRATION_INFO: Account.site_admin.feature_enabled?(:course_copy_allow_copying_integration_info),
                  MISSING_POLICY_ENABLED: @context.late_policy&.missing_submission_deduction_enabled || false
                })
         set_tutorial_js_env
@@ -340,6 +342,10 @@ class ContentMigrationsController < ApplicationController
   #   Import the "use as blueprint course" setting as well as the list of locked items
   #   from the source course or package. The destination course must not be associated
   #   with an existing blueprint course and cannot have any student or observer enrollments.
+  #
+  # @argument settings[copy_integration_info] [Boolean]
+  #   Whether to copy integration_id and integration_data values from
+  #   source assignments to destination assignments during a course copy.
   #
   # @argument date_shift_options[shift_dates] [Boolean]
   #   Whether to shift dates in the copied course

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -2984,7 +2984,8 @@ class CoursesController < ApplicationController
              NEW_QUIZZES_MIGRATION: new_quizzes_migration_enabled?,
              NEW_QUIZZES_MIGRATION_DEFAULT: new_quizzes_migration_default,
              NEW_QUIZZES_MIGRATION_REQUIRED: new_quizzes_require_migration?,
-             NEW_QUIZZES_UNATTACHED_BANK_MIGRATIONS: new_quizzes_unattached_bank_migrations_enabled?
+             NEW_QUIZZES_UNATTACHED_BANK_MIGRATIONS: new_quizzes_unattached_bank_migrations_enabled?,
+             COPY_COURSE_INTEGRATION_INFO: Account.site_admin.feature_enabled?(:course_copy_allow_copying_integration_info)
            })
   end
 
@@ -3045,6 +3046,7 @@ class CoursesController < ApplicationController
       @content_migration.migration_settings[:source_course_id] = @context.id
       @content_migration.migration_settings[:import_quizzes_next] = true if params.dig(:settings, :import_quizzes_next)
       @content_migration.migration_settings[:import_blueprint_settings] = true if params.dig(:settings, :import_blueprint_settings)
+      @content_migration.migration_settings[:copy_integration_info] = true if params.dig(:settings, :copy_integration_info)
       @content_migration.workflow_state = "created"
       if (adjust_dates = params[:adjust_dates]) && Canvas::Plugin.value_to_boolean(adjust_dates[:enabled])
         params[:date_shift_options][adjust_dates[:operation]] = "1"

--- a/app/models/content_migration.rb
+++ b/app/models/content_migration.rb
@@ -713,6 +713,10 @@ class ContentMigration < ApplicationRecord
     Canvas::Plugin.value_to_boolean(migration_settings[:import_quizzes_next])
   end
 
+  def copy_integration_info?
+    Canvas::Plugin.value_to_boolean(migration_settings[:copy_integration_info])
+  end
+
   def quizzes_next_migration?
     context.instance_of?(Course) &&
       context.feature_enabled?(:quizzes_next) &&

--- a/app/models/importers/assignment_importer.rb
+++ b/app/models/importers/assignment_importer.rb
@@ -371,6 +371,11 @@ module Importers
         end
       end
 
+      if migration.copy_integration_info?
+        item.integration_id = hash[:integration_id]
+        item.integration_data = hash[:integration_data]
+      end
+
       [:turnitin_enabled, :vericite_enabled].each do |prop|
         if !hash[prop].nil? && context.send(:"#{prop}?")
           item.send(:"#{prop}=", hash[prop])

--- a/config/feature_flags/00_standard.yml
+++ b/config/feature_flags/00_standard.yml
@@ -34,6 +34,17 @@ autodetect_field_separators_for_gradebook_exports:
     exports based on the number format for your language.
   applies_to: User
   custom_transition_proc: autodetect_field_separators_for_gradebook_exports_custom_transition_hook
+course_copy_allow_copying_integration_info:
+  applies_to: SiteAdmin
+  state: hidden
+  display_name: "Course Copy: allow copying integration_id and integration_data"
+  description: Adds opt-in settings to copy integration_id and integration_data
+    on assignments during course copy.
+  environments:
+    ci:
+      state: allowed_on
+    development:
+      state: allowed_on
 common_cartridge_page_conversion:
   type: setting
   state: hidden

--- a/lib/cc/assignment_resources.rb
+++ b/lib/cc/assignment_resources.rb
@@ -272,10 +272,12 @@ module CC
                 graders_anonymous_to_graders
                 grader_names_visible_to_final_grader
                 anonymous_instructor_annotations
-                allowed_attempts]
+                allowed_attempts
+                integration_id]
       atts.each do |att|
         node.tag!(att, assignment.send(att)) if assignment.send(att) == false || assignment.send(att).present?
       end
+      node.tag!(:integration_data, assignment.integration_data.to_json) if assignment.integration_data.present?
       if assignment.external_tool_tag
         if (content = assignment.external_tool_tag.content) && content.is_a?(ContextExternalTool)
           if content.context == assignment.context

--- a/lib/cc/importer/standard/assignment_converter.rb
+++ b/lib/cc/importer/standard/assignment_converter.rb
@@ -147,9 +147,14 @@ module CC::Importer::Standard
          external_tool_data_json
          external_tool_link_settings_json
          turnitin_settings
-         time_zone_edited].each do |string_type|
+         time_zone_edited
+         integration_id].each do |string_type|
         val = get_node_val(meta_doc, string_type)
         assignment[string_type] = val unless val.nil?
+      end
+      integration_data_val = get_node_val(meta_doc, "integration_data")
+      if integration_data_val.present?
+        assignment["integration_data"] = JSON.parse(integration_data_val)
       end
       %w[turnitin_enabled
          vericite_enabled

--- a/spec/models/content_migration/course_copy_assignments_spec.rb
+++ b/spec/models/content_migration/course_copy_assignments_spec.rb
@@ -1199,5 +1199,50 @@ describe ContentMigration do
         expect(a_to).to be_valid
       end
     end
+
+    context "integration info copying" do
+      it "copies integration_id and integration_data when copy_integration_info is enabled" do
+        assignment_model(course: @copy_from, points_possible: 10, submission_types: "online_text_entry")
+        @assignment.update!(integration_id: "ext-system-42", integration_data: { "sis_source" => "ABC", "vendor_id" => 99 })
+
+        @cm.migration_settings[:copy_integration_info] = true
+        @cm.save!
+
+        run_course_copy
+
+        a_to = @copy_to.assignments.find_by(migration_id: mig_id(@assignment))
+        expect(a_to.integration_id).to eq "ext-system-42"
+        expect(a_to.integration_data).to eq({ "sis_source" => "ABC", "vendor_id" => 99 })
+      end
+
+      it "does not copy integration_id or integration_data when copy_integration_info is not enabled" do
+        assignment_model(course: @copy_from, points_possible: 10, submission_types: "online_text_entry")
+        @assignment.update!(integration_id: "ext-system-42", integration_data: { "sis_source" => "ABC", "vendor_id" => 99 })
+
+        run_course_copy
+
+        a_to = @copy_to.assignments.find_by(migration_id: mig_id(@assignment))
+        expect(a_to.integration_id).to be_nil
+        expect(a_to.integration_data).to be_nil
+      end
+
+      it "copies only populated fields when copy_integration_info is enabled" do
+        a1 = @copy_from.assignments.create!(title: "Only ID", submission_types: "online_text_entry", integration_id: "id-only")
+        a2 = @copy_from.assignments.create!(title: "Only Data", submission_types: "online_text_entry", integration_data: { "data" => "only" })
+
+        @cm.migration_settings[:copy_integration_info] = true
+        @cm.save!
+
+        run_course_copy
+
+        a1_to = @copy_to.assignments.find_by(migration_id: mig_id(a1))
+        expect(a1_to.integration_id).to eq "id-only"
+        expect(a1_to.integration_data).to be_nil
+
+        a2_to = @copy_to.assignments.find_by(migration_id: mig_id(a2))
+        expect(a2_to.integration_id).to be_nil
+        expect(a2_to.integration_data).to eq({ "data" => "only" })
+      end
+    end
   end
 end

--- a/ui/features/content_migrations/react/components/migrator_forms/course_copy.tsx
+++ b/ui/features/content_migrations/react/components/migrator_forms/course_copy.tsx
@@ -419,6 +419,7 @@ export const CourseCopyImporter = ({onSubmit, onCancel, isSubmitting}: CourseCop
         canImportBPSettings={
           selectedCourse && showBpSettingImport ? selectedCourse.blueprint : false
         }
+        canCopyIntegrationInfo={!!ENV.COPY_COURSE_INTEGRATION_INFO}
         oldStartDate={parseDateToISOString(oldStartDate)}
         oldEndDate={parseDateToISOString(oldEndDate)}
         newStartDate={parseDateToISOString(newStartDate)}

--- a/ui/features/copy_course/react/components/form/CopyCourseForm.tsx
+++ b/ui/features/copy_course/react/components/form/CopyCourseForm.tsx
@@ -249,6 +249,7 @@ export const CopyCourseForm = ({
         canAdjustDates={true}
         canSelectContent={true}
         canImportBPSettings={canImportBpSettings}
+        canCopyIntegrationInfo={!!ENV.COPY_COURSE_INTEGRATION_INFO}
         canImportAsNewQuizzes={canImportAsNewQuizzes}
         newStartDate={isoNewCourseStartDate}
         newEndDate={isoNewCourseEndDate}

--- a/ui/shared/content-migrations/react/CommonMigratorControls/CommonMigratorControls.tsx
+++ b/ui/shared/content-migrations/react/CommonMigratorControls/CommonMigratorControls.tsx
@@ -40,6 +40,7 @@ type CommonMigratorControlsProps = {
   canOverwriteAssessmentContent?: boolean
   canAdjustDates?: boolean
   canImportBPSettings?: boolean
+  canCopyIntegrationInfo?: boolean
   onSubmit: onSubmitMigrationFormCallback
   onCancel: () => void
   fileUploadProgress: number | null
@@ -129,6 +130,7 @@ export const CommonMigratorControls = ({
   canOverwriteAssessmentContent = false,
   canAdjustDates = false,
   canImportBPSettings = false,
+  canCopyIntegrationInfo = false,
   onSubmit,
   onCancel,
   isSubmitting,
@@ -149,6 +151,7 @@ export const CommonMigratorControls = ({
     !!ENV.NEW_QUIZZES_MIGRATION_DEFAULT,
   )
   const [overwriteAssessmentContent, setOverwriteAssessmentContent] = useState<boolean>(false)
+  const [copyIntegrationInfo, setCopyIntegrationInfo] = useState<boolean>(false)
   const [showAdjustDates, setShowAdjustDates] = useState<boolean>(false)
   const [dateAdjustmentConfig, setDateAdjustmentConfig] = useState<DateAdjustmentConfig>({
     adjust_dates: {
@@ -199,6 +202,7 @@ export const CommonMigratorControls = ({
     }
     canImportAsNewQuizzes && (data.settings.import_quizzes_next = importAsNewQuizzes)
     canOverwriteAssessmentContent && (data.settings.overwrite_quizzes = overwriteAssessmentContent)
+    canCopyIntegrationInfo && (data.settings.copy_integration_info = copyIntegrationInfo)
     onSubmit(data)
   }, [
     selectiveImport,
@@ -211,6 +215,8 @@ export const CommonMigratorControls = ({
     importAsNewQuizzes,
     canOverwriteAssessmentContent,
     overwriteAssessmentContent,
+    canCopyIntegrationInfo,
+    copyIntegrationInfo,
     onSubmit,
   ])
 
@@ -262,6 +268,20 @@ export const CommonMigratorControls = ({
               tmp.adjust_dates.enabled = target.checked ? 1 : 0
               setDateAdjustmentConfig(tmp)
             }}
+          />,
+        ]
+      : []),
+    ...(canCopyIntegrationInfo
+      ? [
+          <Checkbox
+            key="copy_integration_info"
+            name="copy_integration_info"
+            value="copy_integration_info"
+            disabled={isSubmitting}
+            label={I18n.t('Copy assignment integration IDs and data')}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setCopyIntegrationInfo(e.target.checked)
+            }
           />,
         ]
       : []),

--- a/ui/shared/content-migrations/react/CommonMigratorControls/__tests__/CommonMigratorControls.test.tsx
+++ b/ui/shared/content-migrations/react/CommonMigratorControls/__tests__/CommonMigratorControls.test.tsx
@@ -131,6 +131,20 @@ describe('CommonMigratorControls', () => {
     )
   })
 
+  it('calls onSubmit with copy_integration_info', async () => {
+    renderComponent({canCopyIntegrationInfo: true})
+    await userEvent.click(
+      screen.getByRole('checkbox', {name: 'Copy assignment integration IDs and data'}),
+    )
+    await userEvent.click(screen.getByRole('button', {name: 'Add to Import Queue'}))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({copy_integration_info: true}),
+      }),
+    )
+  })
+
   it('calls onSubmit with all data', async () => {
     renderComponent({
       canSelectContent: true,

--- a/ui/shared/global/env/ContentMigrations.d.ts
+++ b/ui/shared/global/env/ContentMigrations.d.ts
@@ -35,6 +35,7 @@ export interface EnvContentMigrations {
   NEW_QUIZZES_UNATTACHED_BANK_MIGRATIONS?: boolean
   EXPORT_WARNINGS?: string[]
   SHOW_BP_SETTINGS_IMPORT_OPTION?: boolean
+  COPY_COURSE_INTEGRATION_INFO?: boolean
   SHOW_SELECT?: boolean
   OLD_START_DATE?: string
   OLD_END_DATE?: string


### PR DESCRIPTION
Add opt-in settings to copy integration_id and integration_data on assignments during course copy. External systems rely on these fields to correlate Canvas assignments with third-party records and assignments across courses can share the same IDs.

We reuse intergration_ids and integration_data across courses to be able to track assignment data between courses and semesters. I opened a [support ticket](https://adminconsole.canvaslms.com/s/case/500TU00000rMoR3YAK/copy-integration-ids-set-on-assignments-from-one-course-to-another-on-course-clone) and was told integration_data should copy over and that integration_ids were meant to be unique, but since these link to third parties was hopeful people could opt into maintaining over course clone in case the same courses need to link to the same third party data for our case. 

Our data team uses DAP (data access platform) to access Canvas data and it only contains integration_id for assignments not integration_data. If we are able to clone only integration_data on course clone, could this potentially be added to DAP? 

Test Plan:
* Create a course with assignments that have integration_id and integration_data set
* Copy the course with both options enabled
* Verify cloned assignments retain the values
* Copy again with options disabled
* Verify fields are cleared (default behavior)
* Test via API: POST course copy with settings[copy_integration_ids]=true
* Verify same behavior as UI
