### PR TITLE
Update AssignmentCalendar and Rubric docs for cleaner OpenAPI doc generation

### DIFF
--- a/app/controllers/account_calendars_api_controller.rb
+++ b/app/controllers/account_calendars_api_controller.rb
@@ -101,6 +101,28 @@
 #         }
 #       }
 #     }
+#
+# @model AccountCalendarList
+#     {
+#       "id": "AccountCalendarList",
+#       "properties": {
+#         "account_calendars": {
+#           "description": "List of account calendars",
+#           "example": ["AccountCalendar"],
+#           "type": "array",
+#           "items": {
+#             "type": "AccountCalendar"
+#           }
+#         },
+#         "total_results": {
+#           "description": "Total number of account calendars",
+#           "example": "1"
+#           "type": "integer"
+#         }
+#       }
+#     }
+#
+
 class AccountCalendarsApiController < ApplicationController
   include Api::V1::AccountCalendar
 
@@ -119,7 +141,7 @@ class AccountCalendarsApiController < ApplicationController
   #   curl https://<canvas>/api/v1/account_calendars \
   #     -H 'Authorization: Bearer <token>'
   #
-  # @returns { "account_calendars": [AccountCalendar], "total_results": "integer"}
+  # @returns AccountCalendarList
   def index
     GuardRail.activate(:secondary) do
       search_term = params[:search_term]

--- a/app/controllers/outcomes_api_controller.rb
+++ b/app/controllers/outcomes_api_controller.rb
@@ -98,6 +98,7 @@
 #         },
 #         "ratings": {
 #           "description": "possible ratings for this outcome. included only if the outcome embeds a rubric criterion. omitted in the abbreviated form.",
+#           "example": ["RubricRating"],
 #           "type": "array",
 #           "items": { "$ref" : "RubricRating" }
 #         },
@@ -120,6 +121,31 @@
 #           "description": "whether updates to this outcome will propagate to unassessed rubrics that have imported it",
 #           "example": true,
 #           "type": "boolean"
+#         }
+#       }
+#     }
+#
+# @model RubricRating
+#     {
+#       "id": "RubricRating",
+#       "properties": {
+#         "id": {
+#           "example": "name_2",
+#           "type": "string"
+#         },
+#         "criterion_id": {
+#           "example": "_10",
+#           "type": "string"
+#         },
+#         "description": {
+#           "type": "string"
+#         },
+#         "long_description": {
+#           "type": "string"
+#         },
+#         "points": {
+#           "example": "5",
+#           "type": "integer"
 #         }
 #       }
 #     }

--- a/app/controllers/rubrics_api_controller.rb
+++ b/app/controllers/rubrics_api_controller.rb
@@ -324,7 +324,7 @@ class RubricsApiController < ApplicationController
 
   # @API Creates a rubric using a CSV file
   # Returns the rubric import object that was created
-  # @returns RubricImport
+  # @returns Rubric
   def upload
     return unless authorized_action(@context, @current_user, :manage_rubrics)
 


### PR DESCRIPTION
I have an [extensive list](https://github.com/groton-school/canvas-cli/blob/main/packages/api/canvas-api/overrides.json) of places where the Canvas LMS API documentation includes text or values that that don't parse into clean OpenAPI specifications. Not a huge deal, but if the OpenAPI spec were cleaner, it would be easier to automate building a more complete, capable client. So this is my first test pass at tweaking the documentation.

I have tweaked three specific things:

1. [List available account calendars](https://developerdocs.instructure.com/services/canvas/resources/account_calendars#method.account_calendars_api.index) says that it returns an array of AccountCalendars. It does not -- it returns an object containing that list and a total. I created a new model `AccountCalendarList` to describe this result and updated the documentation.
2. [Creates a rubric using a CSV file](https://developerdocs.instructure.com/services/canvas/resources/rubrics#method.rubrics_api.upload) in the JSON spec file incorrectly stated the model name. It is now correct.
3. The [Outcomes model](https://developerdocs.instructure.com/services/canvas/resources/outcomes) references a RubricRating, but does not define it, again creating problems parsing the JSON spec file. RubricRating had already been duplicated once into the Assignments API, so I duplicated it again.

 Test Plan:
   - Build and validate the OpenAPI docs
   - Test that the generated JSON docs that would be hosted at https://example.instructure.com/docs/api/account_calendars.json, https://example.instructure.com/docs/api/outcomes.json, and https://example.instructure.com/docs/api/rubrics.json are valid
   - Test that the developer documentation linked to above generates cleanly