### PR TITLE
feat: allow custom module naming through LTI deep-linking

### DIFF
--- a/app/controllers/lti/ims/concerns/deep_linking_services.rb
+++ b/app/controllers/lti/ims/concerns/deep_linking_services.rb
@@ -70,6 +70,10 @@ module Lti::IMS::Concerns
       @replace_editor_contents ||= tool_has_scope && (deep_linking_jwt["https://canvas.instructure.com/lti/replace_editor_contents"] || false)
     end
 
+    def module_name
+      deep_linking_jwt["https://canvas.instructure.com/lti/module_name"]&.to_s&.presence
+    end
+
     def lti_resource_links
       content_items.filter { |item| item[:type] == "ltiResourceLink" }
     end

--- a/app/controllers/lti/ims/deep_linking_controller.rb
+++ b/app/controllers/lti/ims/deep_linking_controller.rb
@@ -146,7 +146,7 @@ module Lti
           # * if a module was created, alert it and then navigate to modules page
           # * reload the page
           context_module = if create_new_module?
-                             @context.context_modules.create!(name: I18n.t("New Content From App"), workflow_state: "unpublished")
+                             @context.context_modules.create!(name: module_name || I18n.t("New Content From App"), workflow_state: "unpublished")
                            else
                              @context.context_modules.not_deleted.find(return_url_parameters[:context_module_id])
                            end

--- a/doc/lti/12_deep_linking.md
+++ b/doc/lti/12_deep_linking.md
@@ -89,6 +89,26 @@ When this process is complete, Canvas now knows about and is displaying the sele
 
 5. If needed, add the backend work to create database objects to the deep linking controller. This is already done for module items and all resource links (links to tool content), and possibly could be helpful for the placement and records you are adding.
 
+### Canvas Extensions to the Deep Linking Response
+
+Canvas supports the following non-standard claims in the `LtiDeepLinkingResponse` JWT, which tools may optionally include to influence Canvas-specific behavior.
+
+#### `https://canvas.instructure.com/lti/module_name`
+
+**Type:** string | absent
+
+**Applicable placements:** `module_index_menu_modal`, `course_assignments_menu`
+
+When Canvas creates a new module as part of processing a deep linking response (i.e. the placement triggers automatic module creation), this claim sets the name of that module. If omitted or blank, Canvas defaults to _"New Content From App"_.
+
+**Example:**
+
+```json
+{
+  "https://canvas.instructure.com/lti/module_name": "Week 3 Activities"
+}
+```
+
 ### Relevant Code
 
 [`Lti::Messages::DeepLinkingRequest`](/lib/lti/messages/deep_linking_request.rb) builds the LTI message that gets sent during a deep linking request, and also houses the per-placement configuration for allowing deep linking.

--- a/spec/controllers/lti/ims/concerns/deep_linking_spec_helper.rb
+++ b/spec/controllers/lti/ims/concerns/deep_linking_spec_helper.rb
@@ -49,7 +49,8 @@ RSpec.shared_context "deep_linking_spec_helper" do
       "https://purl.imsglobal.org/spec/lti-dl/claim/errormsg" => errormsg,
       "https://purl.imsglobal.org/spec/lti-dl/claim/log" => log,
       "https://purl.imsglobal.org/spec/lti-dl/claim/errorlog" => errorlog,
-      "https://canvas.instructure.com/lti/replace_editor_contents" => replace_editor_contents
+      "https://canvas.instructure.com/lti/replace_editor_contents" => replace_editor_contents,
+      "https://canvas.instructure.com/lti/module_name" => module_name
     }.compact
   end
   let(:deep_linking_jwt) do
@@ -69,4 +70,5 @@ RSpec.shared_context "deep_linking_spec_helper" do
   let(:public_jwk) { JSON::JWK.new(developer_key.public_jwk) }
   let(:private_jwk) { JSON::JWK.new(developer_key.private_jwk) }
   let(:replace_editor_contents) { nil }
+  let(:module_name) { nil }
 end

--- a/spec/controllers/lti/ims/deep_linking_controller_spec.rb
+++ b/spec/controllers/lti/ims/deep_linking_controller_spec.rb
@@ -769,6 +769,20 @@ module Lti
                   subject
                   expect(assigns.dig(:js_env, :deep_link_response, :moduleCreated)).to be true
                 end
+
+                it "names the module with the default name when no module_name claim is given" do
+                  subject
+                  expect(course.context_modules.last.name).to eq("New Content From App")
+                end
+
+                context "when module_name claim is provided" do
+                  let(:module_name) { "My Custom Module" }
+
+                  it "creates a module with the provided name" do
+                    subject
+                    expect(course.context_modules.last.name).to eq("My Custom Module")
+                  end
+                end
               end
 
               context "multiple items" do


### PR DESCRIPTION
This PR adds a new claim to allow a custom module name when creating a module through LTI.

The objective of this was to ease up the LTI deep-linking, allowing some sort of customization when creating new modules through that venue. As of now, it is not possible to customize the name of the newly created module, as it is always shows an i18n version of "New Content From App". While by default it will still do as it did before, with the right claim, shown in the documentation is added, the module will have a custom name!

 Test Plan:
   - Have an external tool that can deep-link content via LTI integrated in a Canvas course. The placement that I used for this test was "**module_index_menu_modal**".
   - Go to the Modules page of the course, and make use of the menu to set up a deeplink process.
   - The external tool will have, among the rest of the options, have the new property. An example shown here:

``` js
    const jwtBody = {
      iss: obtainedPlatform.platformClientId(),
      aud: idtoken.iss,
      nonce: createRandomString(),
      'https://purl.imsglobal.org/spec/lti/claim/deployment_id':
        idtoken.deploymentId,
      'https://purl.imsglobal.org/spec/lti/claim/message_type':
        'LtiDeepLinkingResponse',
      'https://purl.imsglobal.org/spec/lti/claim/version': '1.3.0',
      'https://canvas.instructure.com/lti/module_name': 'New Custom Name' // The new property
    };
```

- Now, when the deep-link process is done, the created module with have "New Custom Name" rather than the default naming!