### PR TITLE
fix docker_dev_setup db:drop failure

### DIFF
--- a/script/common/canvas/build_helpers.sh
+++ b/script/common/canvas/build_helpers.sh
@@ -74,9 +74,24 @@ This script will destroy ALL EXISTING DATA if it continues
 If you want to migrate the existing database, cancel now
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
       message 'About to run "bundle exec rake db:drop"'
-      start_spinner "Deleting db....."
-      _canvas_lms_track_with_log run_command bundle exec rake db:drop
+      start_spinner "Stopping app containers to release db connections..."
+      stop_running_canvas_app_services
       stop_spinner
+      start_spinner "Deleting db....."
+      drop_failed=0
+      if ! _canvas_lms_track_with_log run_command_once bundle exec rake db:drop; then
+        drop_failed=1
+      fi
+      stop_spinner
+      start_spinner "Restarting web..."
+      _canvas_lms_track_with_log $DOCKER_COMMAND up -d web
+      stop_spinner
+      if [[ $drop_failed -ne 0 ]]; then
+        start_spinner "Restarting app containers..."
+        restart_stopped_canvas_app_services
+        stop_spinner
+        return 1
+      fi
     fi
   fi
   stop_spinner
@@ -94,6 +109,11 @@ If you want to migrate the existing database, cancel now
   _canvas_lms_track_with_log run_command bundle exec rake db:migrate RAILS_ENV=test
   stop_spinner
   [[ ${dropped:-DROP} == 'migrate' ]] || _canvas_lms_track run_command_tty bundle exec rake db:initial_setup
+  if [[ ${dropped:-DROP} == 'DROP' ]]; then
+    start_spinner "Restarting app containers..."
+    restart_stopped_canvas_app_services
+    stop_spinner
+  fi
 }
 
 function bundle_install {

--- a/script/common/utils/common.sh
+++ b/script/common/utils/common.sh
@@ -51,6 +51,17 @@ function run_command {
     "$@"
   fi
 }
+
+function run_command_once {
+  if is_running_on_jenkins; then
+    docker compose run --rm -T web "$@"
+  elif is_docker; then
+    $DOCKER_COMMAND run --rm -T -e TELEMETRY_OPT_IN web "$@"
+  else
+    "$@"
+  fi
+}
+
 # remove once https://github.com/docker/compose/issues/9104 is fixed
 function run_command_tty {
   if is_running_on_jenkins; then
@@ -202,6 +213,50 @@ function docker_running {
   echo "Docker is not running! Start docker daemon and try again."
   return 1
 fi
+}
+
+function check_for_running_containers {
+  running_containers=$($DOCKER_COMMAND ps -q 2>/dev/null)
+  if [[ -n "$running_containers" ]]; then
+    echo ""
+    echo "Warning: Canvas Docker containers are currently running."
+    echo "This may cause issues (e.g., database connections preventing db:drop)."
+    echo ""
+    $DOCKER_COMMAND ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null
+    echo ""
+    if ! is_running_on_jenkins; then
+      prompt "Stop running containers before continuing? [y/n]" stop_containers
+      if [[ ${stop_containers:-n} == 'y' ]]; then
+        start_spinner "Stopping running containers..."
+        _canvas_lms_track_with_log $DOCKER_COMMAND down
+        stop_spinner
+        message "Containers stopped."
+      else
+        echo "Continuing with containers running. This may cause errors."
+      fi
+    fi
+  fi
+}
+
+function running_canvas_app_services {
+  $DOCKER_COMMAND ps --services --status running 2>/dev/null | grep -vE '^(postgres|redis)$' || true
+}
+
+function stop_running_canvas_app_services {
+  STOPPED_CANVAS_APP_SERVICES=$(running_canvas_app_services)
+
+  if [[ -n "$STOPPED_CANVAS_APP_SERVICES" ]]; then
+    # shellcheck disable=SC2086
+    _canvas_lms_track_with_log $DOCKER_COMMAND stop $STOPPED_CANVAS_APP_SERVICES
+  fi
+}
+
+function restart_stopped_canvas_app_services {
+  if [[ -n "${STOPPED_CANVAS_APP_SERVICES:-}" ]]; then
+    # shellcheck disable=SC2086
+    _canvas_lms_track_with_log $DOCKER_COMMAND up -d $STOPPED_CANVAS_APP_SERVICES
+    STOPPED_CANVAS_APP_SERVICES=
+  fi
 }
 
 function os_setup {

--- a/script/docker_dev_setup.sh
+++ b/script/docker_dev_setup.sh
@@ -32,6 +32,7 @@ init_log_file "Docker Dev Setup"
 detect_local_canvas
 os_setup
 message 'Now we can set up Canvas!'
+check_for_running_containers
 copy_docker_config
 setup_docker_compose_override
 build_images


### PR DESCRIPTION
## Summary

`docker_dev_setup.sh` fails with `PG::ObjectInUse` when
choosing DROP because app containers hold open database
connections that prevent `db:drop` from completing.

This fix:
- Stops all app containers (web, jobs, etc.) before
  dropping, keeping only postgres and redis running
- Uses `rake db:drop` via a one-shot container so Rails
  hooks (e.g. Redis flush) still execute
- Reads database names from database.yml instead of
  hardcoding them
- Adds an early prompt warning users about running
  containers at the start of setup

## Test Plan
- Start Canvas containers (`docker compose up -d`)
- Run `bash script/docker_dev_setup.sh`
- Verify prompt shows running containers
- Choose "y" to stop, confirm they stop
- Run setup again with containers running
- Choose "n" at early prompt to skip
- When prompted, choose DROP for the database
- Verify db:drop succeeds without ObjectInUse
- Verify Redis state is flushed after drop
- Verify setup completes successfully
- Run with no containers, confirm no prompt