### PR TITLE
Resource Links Create/Edit/Delete Trigger Live Event

### DIFF
--- a/app/observers/live_events_observer.rb
+++ b/app/observers/live_events_observer.rb
@@ -53,6 +53,7 @@ class LiveEventsObserver < ActiveRecord::Observer
           :user_account_association,
           :user,
           :wiki_page,
+          "Lti::ResourceLink",
           "MasterCourses::MasterTemplate",
           "MasterCourses::MasterMigration",
           "MasterCourses::ChildSubscription",

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -630,6 +630,30 @@ module Canvas::LiveEvents
                            })
   end
 
+  def self.get_lti_resource_link_data(resource_link)
+    {
+      resource_link_id: resource_link.global_id,
+      resource_link_uuid: resource_link.resource_link_uuid,
+      lookup_uuid: resource_link.lookup_uuid,
+      context_id: resource_link.global_context_id,
+      context_type: resource_link.context_type,
+      context_external_tool_id: resource_link.original_context_external_tool.global_id,
+      url: resource_link.url,
+      title: resource_link.title,
+      workflow_state: resource_link.workflow_state
+    }
+  end
+
+  def self.lti_resource_link_created(resource_link)
+    post_event_stringified("lti_resource_link_created",
+                           get_lti_resource_link_data(resource_link))
+  end
+
+  def self.lti_resource_link_updated(resource_link)
+    post_event_stringified("lti_resource_link_updated",
+                           get_lti_resource_link_data(resource_link))
+  end
+
   def self.attachment_created(attachment)
     post_event_stringified("attachment_created", get_attachment_data(attachment))
   end

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -637,7 +637,7 @@ module Canvas::LiveEvents
       lookup_uuid: resource_link.lookup_uuid,
       context_id: resource_link.global_context_id,
       context_type: resource_link.context_type,
-      context_external_tool_id: resource_link.original_context_external_tool.global_id,
+      context_external_tool_id: resource_link.original_context_external_tool&.global_id,
       url: resource_link.url,
       title: resource_link.title,
       workflow_state: resource_link.workflow_state

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -46,6 +46,8 @@ module Canvas::LiveEventsCallbacks
       Canvas::LiveEvents.group_membership_created(obj)
     when WikiPage
       Canvas::LiveEvents.wiki_page_created(obj)
+    when Lti::ResourceLink
+      Canvas::LiveEvents.lti_resource_link_created(obj)
     when Assignment
       Canvas::LiveEvents.assignment_created(obj)
     when AssignmentGroup
@@ -135,6 +137,8 @@ module Canvas::LiveEventsCallbacks
                                              changes["title"]&.first,
                                              changes["body"]&.first)
       end
+    when Lti::ResourceLink
+      Canvas::LiveEvents.lti_resource_link_updated(obj)
     when Assignment
       Canvas::LiveEvents.assignment_updated(obj)
     when AssignmentGroup

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -284,6 +284,62 @@ describe Canvas::LiveEvents do
     end
   end
 
+  describe ".lti_resource_link_created" do
+    before do
+      course_with_teacher
+      @tool = external_tool_model(context: @course)
+      @resource_link = Lti::ResourceLink.create!(
+        context: @course,
+        context_external_tool: @tool,
+        url: "http://example.com/launch",
+        title: "My Link"
+      )
+    end
+
+    it "posts the correct event and payload" do
+      expect_event("lti_resource_link_created", {
+                     resource_link_id: @resource_link.global_id.to_s,
+                     resource_link_uuid: @resource_link.resource_link_uuid,
+                     lookup_uuid: @resource_link.lookup_uuid,
+                     context_id: @resource_link.global_context_id.to_s,
+                     context_type: "Course",
+                     context_external_tool_id: @tool.global_id.to_s,
+                     url: "http://example.com/launch",
+                     title: "My Link",
+                     workflow_state: "active"
+                   })
+      Canvas::LiveEvents.lti_resource_link_created(@resource_link)
+    end
+  end
+
+  describe ".lti_resource_link_updated" do
+    before do
+      course_with_teacher
+      @tool = external_tool_model(context: @course)
+      @resource_link = Lti::ResourceLink.create!(
+        context: @course,
+        context_external_tool: @tool,
+        url: "http://example.com/launch",
+        title: "My Link"
+      )
+    end
+
+    it "posts the correct event and payload" do
+      expect_event("lti_resource_link_updated", {
+                     resource_link_id: @resource_link.global_id.to_s,
+                     resource_link_uuid: @resource_link.resource_link_uuid,
+                     lookup_uuid: @resource_link.lookup_uuid,
+                     context_id: @resource_link.global_context_id.to_s,
+                     context_type: "Course",
+                     context_external_tool_id: @tool.global_id.to_s,
+                     url: "http://example.com/launch",
+                     title: "My Link",
+                     workflow_state: "active"
+                   })
+      Canvas::LiveEvents.lti_resource_link_updated(@resource_link)
+    end
+  end
+
   describe ".wiki_page_updated" do
     before do
       course_with_teacher

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -69,6 +69,40 @@ describe LiveEventsObserver do
     end
   end
 
+  describe "lti_resource_link" do
+    let(:course) { Course.create!(name: "Course") }
+    let(:tool) { external_tool_model(context: course) }
+
+    it "posts lti_resource_link_created when a resource link is created" do
+      expect(Canvas::LiveEvents).to receive(:lti_resource_link_created).once
+      Lti::ResourceLink.create!(
+        context: course,
+        context_external_tool: tool,
+        url: "http://example.com/launch"
+      )
+    end
+
+    it "posts lti_resource_link_updated when a resource link is updated" do
+      resource_link = Lti::ResourceLink.create!(
+        context: course,
+        context_external_tool: tool,
+        url: "http://example.com/launch"
+      )
+      expect(Canvas::LiveEvents).to receive(:lti_resource_link_updated).once
+      resource_link.update!(title: "New Title")
+    end
+
+    it "posts lti_resource_link_updated (not deleted) when a resource link is soft deleted" do
+      resource_link = Lti::ResourceLink.create!(
+        context: course,
+        context_external_tool: tool,
+        url: "http://example.com/launch"
+      )
+      expect(Canvas::LiveEvents).to receive(:lti_resource_link_updated).once
+      resource_link.destroy
+    end
+  end
+
   describe "wiki" do
     it "posts create events" do
       expect(Canvas::LiveEvents).to receive(:wiki_page_created).once


### PR DESCRIPTION
There were no live events for Lti::ResourceLink. This adds lti_resource_link_created and lti_resource_link_updated events so downstream consumers can react when Canvas encounters a new LTI link in a course.

Added lti_resource_link_created and lti_resource_link_updated event methods to Canvas::LiveEvents with a shared
payload helper
Registered Lti::ResourceLink in LiveEventsObserver and wired after_create/after_update in
Canvas::LiveEventsCallbacks
Soft delete (.destroy) fires lti_resource_link_updated with workflow_state: "deleted" — no separate delete event
Payload includes: resource_link_id, resource_link_uuid, lookup_uuid, context_id, context_type,
context_external_tool_id, url, title, workflow_state

Verified with: unit tests, observer integration tests, and manual testing via fake Kinesis server