### PR TITLE
Assignments copied between courses now default to unpublished

### DIFF
--- a/app/models/importers/assignment_importer.rb
+++ b/app/models/importers/assignment_importer.rb
@@ -126,7 +126,7 @@ module Importers
       if new_record || item.deleted? || master_migration
         restore_lti_models(item) if item.deleted?
         item.workflow_state = if item.can_unpublish?
-                                hash[:workflow_state] || "published"
+                                hash[:workflow_state] || "unpublished"
                               else
                                 "published"
                               end

--- a/spec/models/content_migration/course_copy_assignments_spec.rb
+++ b/spec/models/content_migration/course_copy_assignments_spec.rb
@@ -83,6 +83,17 @@ describe ContentMigration do
       end
     end
 
+    it "copies assignments as unpublished" do
+      from_assign = @copy_from.assignments.create!(title: "published assignment")
+      from_assign.publish!
+      expect(from_assign).to be_published
+
+      run_course_copy
+
+      to_assign = @copy_to.assignments.where(migration_id: mig_id(from_assign)).first!
+      expect(to_assign).to be_unpublished
+    end
+
     it "links assignments to account rubrics and outcomes" do
       account = @copy_from.account
       lo = create_outcome(account)


### PR DESCRIPTION
When copying an assignment from one course to another, the copied assignment was automatically published in the new course. This change makes copied assignments default to an unpublished state instead, giving instructors a chance to review the assignment before it becomes available to students. If an assignment's workflow state is explicitly set in the source course, that state is preserved during the copy.

Test Plan:
  - Create a published assignment in a source course
  - Copy the course to a new course
  - Verify the copied assignment is unpublished in the new course
  - Verify that if an unpublished assignment is copied, it remains unpublished