### PR TITLE
feat: Add GET/LIST endpoints for Quiz Extensions and New Quizzes Acco…

### DIFF
--- a/app/controllers/quizzes/course_quiz_extensions_controller.rb
+++ b/app/controllers/quizzes/course_quiz_extensions_controller.rb
@@ -137,7 +137,10 @@ class Quizzes::CourseQuizExtensionsController < ApplicationController
     end
 
     # after we've validated permissions on all extend all submissions
-    quiz_extensions.each(&:extend_submission!)
+    quiz_extensions.each do |extension|
+      extension.extend_submission!
+      Canvas::LiveEvents.quiz_extension_created(extension)
+    end
 
     render json: serialize_jsonapi(quiz_extensions)
   end

--- a/app/controllers/quizzes/new_quiz_accommodations_controller.rb
+++ b/app/controllers/quizzes/new_quiz_accommodations_controller.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2025 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# @API New Quizzes Accommodations
+#
+# API for reading accommodations on New Quizzes (quiz_lti) assignments.
+# Accommodations include extra time, extra attempts, and reduced choices.
+# This endpoint proxies to the New Quizzes service to retrieve accommodation data.
+#
+# @model NewQuizAccommodation
+#     {
+#       "id": "NewQuizAccommodation",
+#       "required": ["user_id"],
+#       "properties": {
+#         "user_id": {
+#           "description": "The ID of the Student that has the accommodation.",
+#           "example": 3,
+#           "type": "integer",
+#           "format": "int64"
+#         },
+#         "extra_time": {
+#           "description": "Amount of extra time allowed for the quiz submission, in minutes.",
+#           "example": 60,
+#           "type": "integer",
+#           "format": "int64"
+#         },
+#         "extra_attempts": {
+#           "description": "Number of extra re-takes allowed over the multiple-attempt limit.",
+#           "example": 2,
+#           "type": "integer",
+#           "format": "int64"
+#         },
+#         "reduce_choices_enabled": {
+#           "description": "If true, removes one incorrect answer from multiple-choice questions.",
+#           "example": true,
+#           "type": "boolean"
+#         }
+#       }
+#     }
+class Quizzes::NewQuizAccommodationsController < ApplicationController
+  before_action :require_context
+  before_action :authorize_read
+  before_action :require_assignment
+  before_action :require_new_quizzes_service
+
+  # @API List accommodations for a New Quizzes assignment
+  #
+  # Returns all accommodations that have been set for the given
+  # New Quizzes assignment. Proxies to the New Quizzes service.
+  #
+  # @argument user_id [Optional, Integer]
+  #   If specified, only return the accommodation for this user.
+  #
+  # <b>Responses</b>
+  #
+  # * <b>200 OK</b> if the request was successful
+  # * <b>403 Forbidden</b> if you are not allowed to manage this assignment
+  # * <b>422 Unprocessable Entity</b> if the assignment is not a New Quizzes assignment
+  # * <b>503 Service Unavailable</b> if the New Quizzes service is not configured
+  #
+  # @example_response
+  #  {
+  #    "accommodations": [NewQuizAccommodation]
+  #  }
+  #
+  def index
+    response = fetch_accommodations_from_service
+    if response.nil?
+      render json: { errors: [{ message: "Unable to communicate with New Quizzes service" }] },
+             status: :bad_gateway
+      return
+    end
+    unless response.code == 200
+      render json: { errors: [{ message: "New Quizzes service error" }] }, status: :bad_gateway
+      return
+    end
+
+    body = parse_response_body(response)
+    return render_service_error if body.nil?
+
+    participants = body.is_a?(Array) ? body : (body["participants"] || body["accommodations"] || [])
+    accommodations = extract_accommodations(participants)
+    if params[:user_id].present?
+      accommodations = accommodations.select { |a| a[:user_id].to_s == params[:user_id].to_s }
+    end
+    render json: { accommodations: }
+  end
+
+  # @API Get accommodation for a specific user on a New Quizzes assignment
+  #
+  # Returns the accommodation for a specific user on the given
+  # New Quizzes assignment.
+  #
+  # <b>Responses</b>
+  #
+  # * <b>200 OK</b> if the request was successful
+  # * <b>403 Forbidden</b> if you are not allowed to manage this assignment
+  # * <b>404 Not Found</b> if no accommodation exists for this user
+  #
+  # @example_response
+  #  {
+  #    "accommodation": NewQuizAccommodation
+  #  }
+  #
+  def show
+    response = fetch_accommodations_from_service
+    if response.nil?
+      render json: { errors: [{ message: "Unable to communicate with New Quizzes service" }] },
+             status: :bad_gateway
+      return
+    end
+    unless response.code == 200
+      render json: { errors: [{ message: "New Quizzes service error" }] }, status: :bad_gateway
+      return
+    end
+
+    body = parse_response_body(response)
+    return render_service_error if body.nil?
+
+    participants = body.is_a?(Array) ? body : (body["participants"] || body["accommodations"] || [])
+    accommodations = extract_accommodations(participants)
+    accommodation = accommodations.find { |a| a[:user_id].to_s == params[:user_id].to_s }
+    if accommodation
+      render json: { accommodation: }
+    else
+      render json: { errors: [{ message: "No accommodation found for user" }] }, status: :not_found
+    end
+  end
+
+  private
+
+  def require_assignment
+    @assignment = @context.active_assignments.find(params[:assignment_id])
+    unless @assignment.quiz_lti?
+      render json: { errors: [{ message: "Assignment is not a New Quizzes assignment" }] },
+             status: :unprocessable_entity
+    end
+  end
+
+  def require_new_quizzes_service
+    unless Services::NewQuizzes.api_gateway_host.present?
+      render json: { errors: [{ message: "New Quizzes service is not configured" }] },
+             status: :service_unavailable
+    end
+  end
+
+  def parse_response_body(response)
+    JSON.parse(response.body)
+  rescue JSON::ParserError, TypeError => e
+    Canvas::Errors.capture_exception(:new_quiz_accommodations, e, :warn)
+    nil
+  end
+
+  def render_service_error
+    render json: { errors: [{ message: "New Quizzes service error" }] }, status: :bad_gateway
+  end
+
+  def authorize_read
+    render_unauthorized_action unless @context.grants_any_right?(@current_user, session, :manage_assignments, :manage_assignments_edit)
+  end
+
+  def extract_accommodations(participants)
+    Array(participants).filter_map do |participant|
+      next unless participant.is_a?(Hash)
+
+      user_id = participant["user_id"] || participant["canvas_user_id"]
+      next if user_id.nil?
+
+      extra_time = participant["extra_time"] || participant["time_extension"]
+      extra_attempts = participant["extra_attempts"]
+      reduce_choices_enabled = participant["reduce_choices_enabled"]
+
+      reduce_choices_enabled = Canvas::Plugin.value_to_boolean(reduce_choices_enabled)
+
+      next unless extra_time.to_i > 0 || extra_attempts.to_i > 0 || reduce_choices_enabled
+
+      {
+        user_id:,
+        extra_time:,
+        extra_attempts:,
+        reduce_choices_enabled:
+      }
+    end
+  end
+
+  def fetch_accommodations_from_service
+    host = Services::NewQuizzes.api_gateway_host
+    path = "/api/assignments/#{@assignment.id}/participants"
+    url = "#{host}#{path}"
+
+    token = CanvasSecurity::ServicesJwt.generate(
+      {
+        sub: @current_user.global_id.to_s,
+        account_id: @context.root_account.global_id.to_s,
+        course_id: @context.global_id.to_s
+      },
+      base64: false,
+      encrypt: false
+    )
+
+    query = {}
+    query[:page] = params[:page] if params[:page].present?
+
+    Canvas.timeout_protection("new-quizzes-accommodations", raise_on_timeout: true) do
+      HTTParty.get(url, headers: { "Authorization" => "Bearer #{token}" }, query:, timeout: 10)
+    end
+  rescue => e
+    Canvas::Errors.capture_exception(:new_quiz_accommodations, e, :warn)
+    nil
+  end
+end

--- a/app/controllers/quizzes/quiz_extensions_controller.rb
+++ b/app/controllers/quizzes/quiz_extensions_controller.rb
@@ -20,7 +20,7 @@
 
 # @API Quiz Extensions
 #
-# API for setting extensions on student quiz submissions
+# API for setting and reading extensions on student quiz submissions
 #
 # @model QuizExtension
 #     {
@@ -68,6 +68,46 @@ class Quizzes::QuizExtensionsController < ApplicationController
   include ::Filters::Quizzes
 
   before_action :require_context, :require_quiz
+
+  # @API List extensions for student quiz submissions
+  #
+  # Returns all quiz extensions that have been set for the given quiz.
+  # Only returns submissions where at least one extension field
+  # (extra_attempts, extra_time, or manually_unlocked) has been set.
+  #
+  # @argument user_id [Optional, Integer]
+  #   If specified, only return extensions for this user.
+  #
+  # <b>Responses</b>
+  #
+  # * <b>200 OK</b> if the request was successful
+  # * <b>403 Forbidden</b> if you are not allowed to manage this quiz
+  #
+  # @example_response
+  #  {
+  #    "quiz_extensions": [QuizExtension]
+  #  }
+  #
+  def index
+    unless @context.grants_any_right?(@current_user, session, :manage_assignments, :manage_assignments_edit)
+      return render_unauthorized_action
+    end
+
+    scope = @quiz.quiz_submissions
+                 .where("extra_attempts > 0 OR extra_time > 0 OR manually_unlocked = ?", true)
+
+    if params[:user_id].present?
+      scope = scope.where(user_id: params[:user_id])
+    end
+
+    quiz_submissions = Api.paginate(scope, self, api_v1_course_quiz_extensions_index_url(@context, @quiz))
+
+    extensions = quiz_submissions.map do |qs|
+      Quizzes::QuizExtension.new(qs, {})
+    end
+
+    render json: serialize_extensions(extensions)
+  end
 
   # @API Set extensions for student quiz submissions
   #
@@ -145,7 +185,10 @@ class Quizzes::QuizExtensionsController < ApplicationController
     end
 
     # after we've validated permissions on all extend all submissions
-    quiz_extensions.each(&:extend_submission!)
+    quiz_extensions.each do |extension|
+      extension.extend_submission!
+      Canvas::LiveEvents.quiz_extension_created(extension)
+    end
 
     render json: serialize_jsonapi(quiz_extensions)
   end
@@ -160,6 +203,21 @@ class Quizzes::QuizExtensionsController < ApplicationController
                                                       root: false,
                                                       include_root: false
                                                     }).as_json
+
+    { quiz_extensions: serialized_set }
+  end
+
+  def serialize_extensions(quiz_extensions)
+    serialized_set = quiz_extensions.map do |ext|
+      {
+        user_id: ext.user_id,
+        quiz_id: ext.quiz_id,
+        extra_attempts: ext.extra_attempts,
+        extra_time: ext.extra_time,
+        manually_unlocked: ext.manually_unlocked,
+        end_at: ext.end_at
+      }
+    end
 
     { quiz_extensions: serialized_set }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2428,11 +2428,17 @@ CanvasRails::Application.routes.draw do
     end
 
     scope(controller: "quizzes/quiz_extensions") do
+      get "courses/:course_id/quizzes/:quiz_id/extensions", action: :index, as: "course_quiz_extensions_index"
       post "courses/:course_id/quizzes/:quiz_id/extensions", action: :create, as: "course_quiz_extensions_create"
     end
 
     scope(controller: "quizzes/course_quiz_extensions") do
       post "courses/:course_id/quiz_extensions", action: :create
+    end
+
+    scope(controller: "quizzes/new_quiz_accommodations") do
+      get "courses/:course_id/new_quizzes/:assignment_id/accommodations", action: :index, as: "course_new_quiz_accommodations"
+      get "courses/:course_id/new_quizzes/:assignment_id/accommodations/:user_id", action: :show, as: "course_new_quiz_accommodation"
     end
 
     scope(controller: "quizzes/quiz_submission_events_api") do

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -606,6 +606,18 @@ module Canvas::LiveEvents
                            })
   end
 
+  def self.quiz_extension_created(quiz_extension)
+    qs = quiz_extension.quiz_submission
+    post_event_stringified("quiz_extension_created", {
+                             quiz_id: qs.global_quiz_id,
+                             user_id: qs.global_user_id,
+                             extra_attempts: quiz_extension.extra_attempts,
+                             extra_time: quiz_extension.extra_time,
+                             manually_unlocked: quiz_extension.manually_unlocked,
+                             end_at: quiz_extension.end_at
+                           })
+  end
+
   def self.wiki_page_created(page)
     post_event_stringified("wiki_page_created", {
                              wiki_page_id: page.global_id,

--- a/spec/apis/v1/quizzes/new_quiz_accommodations_api_spec.rb
+++ b/spec/apis/v1/quizzes/new_quiz_accommodations_api_spec.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2025 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+require_relative "../../api_spec_helper"
+
+describe Quizzes::NewQuizAccommodationsController, type: :request do
+  include WebMock::API
+
+  before :once do
+    course_factory
+    @teacher = teacher_in_course(course: @course, active_all: true).user
+    @student = student_in_course(course: @course, active_all: true).user
+    @assignment = @course.assignments.create!(title: "New Quiz", submission_types: "external_tool")
+    tool = @course.context_external_tools.create!(
+      name: "Quizzes.Next",
+      url: "http://example.com/launch",
+      consumer_key: "key",
+      shared_secret: "secret",
+      tool_id: "Quizzes 2"
+    )
+    tag = @assignment.build_external_tool_tag(url: tool.url)
+    tag.content_type = "ContextExternalTool"
+    tag.content_id = tool.id
+    tag.save!
+    @assignment.external_tool_tag = tag
+    @assignment.save!
+  end
+
+  describe "GET /api/v1/courses/:course_id/new_quizzes/:assignment_id/accommodations (index)" do
+    let(:nq_api_host) { "https://quiz-lti.example.com" }
+
+    before do
+      allow(Services::NewQuizzes).to receive(:api_gateway_host).and_return(nq_api_host)
+    end
+
+    context "as a student" do
+      it "is unauthorized" do
+        @user = @student
+        raw_api_call(:get,
+                     "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations",
+                     { controller: "quizzes/new_quiz_accommodations",
+                       action: "index",
+                       format: "json",
+                       course_id: @course.id.to_s,
+                       assignment_id: @assignment.id.to_s })
+        assert_status(403)
+      end
+    end
+
+    context "as a teacher" do
+      before do
+        @user = @teacher
+      end
+
+      it "returns accommodations from the New Quizzes service" do
+        stub_request(:get, "#{nq_api_host}/api/assignments/#{@assignment.id}/participants")
+          .to_return(
+            status: 200,
+            body: [
+              { "user_id" => @student.id, "extra_time" => 30, "extra_attempts" => 2, "reduce_choices_enabled" => true }
+            ].to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        res = api_call(:get,
+                       "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations",
+                       { controller: "quizzes/new_quiz_accommodations",
+                         action: "index",
+                         format: "json",
+                         course_id: @course.id.to_s,
+                         assignment_id: @assignment.id.to_s })
+
+        expect(res["accommodations"].length).to be 1
+        expect(res["accommodations"][0]["user_id"]).to eql(@student.id)
+        expect(res["accommodations"][0]["extra_time"]).to be 30
+        expect(res["accommodations"][0]["extra_attempts"]).to be 2
+        expect(res["accommodations"][0]["reduce_choices_enabled"]).to be true
+      end
+
+      it "returns empty list when no accommodations are set" do
+        stub_request(:get, "#{nq_api_host}/api/assignments/#{@assignment.id}/participants")
+          .to_return(
+            status: 200,
+            body: [
+              { "user_id" => @student.id }
+            ].to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        res = api_call(:get,
+                       "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations",
+                       { controller: "quizzes/new_quiz_accommodations",
+                         action: "index",
+                         format: "json",
+                         course_id: @course.id.to_s,
+                         assignment_id: @assignment.id.to_s })
+
+        expect(res["accommodations"]).to eql([])
+      end
+
+      it "returns 422 if assignment is not a New Quiz" do
+        regular_assignment = @course.assignments.create!(title: "Regular", submission_types: "online_text_entry")
+        raw_api_call(:get,
+                     "/api/v1/courses/#{@course.id}/new_quizzes/#{regular_assignment.id}/accommodations",
+                     { controller: "quizzes/new_quiz_accommodations",
+                       action: "index",
+                       format: "json",
+                       course_id: @course.id.to_s,
+                       assignment_id: regular_assignment.id.to_s })
+        assert_status(422)
+      end
+
+      it "returns 503 if New Quizzes service is not configured" do
+        allow(Services::NewQuizzes).to receive(:api_gateway_host).and_return(nil)
+        raw_api_call(:get,
+                     "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations",
+                     { controller: "quizzes/new_quiz_accommodations",
+                       action: "index",
+                       format: "json",
+                       course_id: @course.id.to_s,
+                       assignment_id: @assignment.id.to_s })
+        assert_status(503)
+      end
+
+      it "returns 502 when service communication fails" do
+        stub_request(:get, "#{nq_api_host}/api/assignments/#{@assignment.id}/participants")
+          .to_raise(Timeout::Error)
+
+        res = api_call(:get,
+                       "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations",
+                       { controller: "quizzes/new_quiz_accommodations",
+                         action: "index",
+                         format: "json",
+                         course_id: @course.id.to_s,
+                         assignment_id: @assignment.id.to_s },
+                       {},
+                       {},
+                       { expected_status: 502 })
+
+        expect(res["errors"][0]["message"]).to eql("Unable to communicate with New Quizzes service")
+      end
+
+      it "returns 502 when service returns non-200 status" do
+        stub_request(:get, "#{nq_api_host}/api/assignments/#{@assignment.id}/participants")
+          .to_return(status: 500, body: "Internal Server Error")
+
+        res = api_call(:get,
+                       "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations",
+                       { controller: "quizzes/new_quiz_accommodations",
+                         action: "index",
+                         format: "json",
+                         course_id: @course.id.to_s,
+                         assignment_id: @assignment.id.to_s },
+                       {},
+                       {},
+                       { expected_status: 502 })
+
+        expect(res["errors"][0]["message"]).to eql("New Quizzes service error")
+      end
+
+      it "returns 502 when service returns invalid JSON" do
+        stub_request(:get, "#{nq_api_host}/api/assignments/#{@assignment.id}/participants")
+          .to_return(status: 200, body: "<html>Error</html>")
+
+        res = api_call(:get,
+                       "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations",
+                       { controller: "quizzes/new_quiz_accommodations",
+                         action: "index",
+                         format: "json",
+                         course_id: @course.id.to_s,
+                         assignment_id: @assignment.id.to_s },
+                       {},
+                       {},
+                       { expected_status: 502 })
+
+        expect(res["errors"][0]["message"]).to eql("New Quizzes service error")
+      end
+    end
+  end
+
+  describe "GET /api/v1/courses/:course_id/new_quizzes/:assignment_id/accommodations/:user_id (show)" do
+    let(:nq_api_host) { "https://quiz-lti.example.com" }
+
+    before do
+      allow(Services::NewQuizzes).to receive(:api_gateway_host).and_return(nq_api_host)
+      @user = @teacher
+    end
+
+    it "returns the accommodation for a specific user" do
+      stub_request(:get, "#{nq_api_host}/api/assignments/#{@assignment.id}/participants")
+        .to_return(
+          status: 200,
+          body: [
+            { "user_id" => @student.id, "extra_time" => 45, "extra_attempts" => 1 }
+          ].to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      res = api_call(:get,
+                     "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations/#{@student.id}",
+                     { controller: "quizzes/new_quiz_accommodations",
+                       action: "show",
+                       format: "json",
+                       course_id: @course.id.to_s,
+                       assignment_id: @assignment.id.to_s,
+                       user_id: @student.id.to_s })
+
+      expect(res["accommodation"]["user_id"]).to eql(@student.id)
+      expect(res["accommodation"]["extra_time"]).to be 45
+      expect(res["accommodation"]["extra_attempts"]).to be 1
+    end
+
+    it "returns 404 when no accommodation exists for user" do
+      original_student = @student
+      other_student = student_in_course(course: @course, active_all: true).user
+      @user = @teacher
+      stub_request(:get, "#{nq_api_host}/api/assignments/#{@assignment.id}/participants")
+        .to_return(
+          status: 200,
+          body: [
+            { "user_id" => original_student.id, "extra_time" => 45 }
+          ].to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      api_call(:get,
+               "/api/v1/courses/#{@course.id}/new_quizzes/#{@assignment.id}/accommodations/#{other_student.id}",
+               { controller: "quizzes/new_quiz_accommodations",
+                 action: "show",
+                 format: "json",
+                 course_id: @course.id.to_s,
+                 assignment_id: @assignment.id.to_s,
+                 user_id: other_student.id.to_s },
+               {},
+               {},
+               { expected_status: 404 })
+    end
+  end
+end

--- a/spec/apis/v1/quizzes/quiz_extensions_api_spec.rb
+++ b/spec/apis/v1/quizzes/quiz_extensions_api_spec.rb
@@ -96,6 +96,25 @@ describe Quizzes::QuizExtensionsController, type: :request do
         expect(res["quiz_extensions"][0]["extra_attempts"]).to eq 2
         expect(res["quiz_extensions"][1]["extra_attempts"]).to eq 3
       end
+
+      it "emits a live event for each extension created" do
+        expect(Canvas::LiveEvents).to receive(:quiz_extension_created).once
+
+        quiz_extension_params = [
+          { user_id: @student1.id, extra_attempts: 2 }
+        ]
+        api_create_quiz_extension(quiz_extension_params)
+      end
+
+      it "emits live events for multiple extensions" do
+        expect(Canvas::LiveEvents).to receive(:quiz_extension_created).twice
+
+        quiz_extension_params = [
+          { user_id: @student1.id, extra_attempts: 2 },
+          { user_id: @student2.id, extra_attempts: 3 }
+        ]
+        api_create_quiz_extension(quiz_extension_params)
+      end
     end
   end
 end

--- a/spec/apis/v1/quizzes/quiz_extensions_index_api_spec.rb
+++ b/spec/apis/v1/quizzes/quiz_extensions_index_api_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2025 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+require_relative "../../api_spec_helper"
+
+describe Quizzes::QuizExtensionsController, type: :request do
+  before :once do
+    course_factory
+    @quiz = @course.quizzes.create!(title: "quiz")
+    @quiz.published_at = Time.zone.now
+    @quiz.workflow_state = "available"
+    @quiz.save!
+    @student1 = student_in_course(course: @course, active_all: true).user
+    @student2 = student_in_course(course: @course, active_all: true).user
+    @teacher = teacher_in_course(course: @course, active_all: true).user
+  end
+
+  describe "GET /api/v1/courses/:course_id/quizzes/:quiz_id/extensions (index)" do
+    def api_list_quiz_extensions(opts = {})
+      api_call(:get,
+               "/api/v1/courses/#{@course.id}/quizzes/#{@quiz.id}/extensions",
+               { controller: "quizzes/quiz_extensions",
+                 action: "index",
+                 format: "json",
+                 course_id: @course.id.to_s,
+                 quiz_id: @quiz.id.to_s },
+               {},
+               {},
+               opts)
+    end
+
+    context "as a student" do
+      it "is unauthorized" do
+        @user = @student1
+        raw_api_call(:get,
+                     "/api/v1/courses/#{@course.id}/quizzes/#{@quiz.id}/extensions",
+                     { controller: "quizzes/quiz_extensions",
+                       action: "index",
+                       format: "json",
+                       course_id: @course.id.to_s,
+                       quiz_id: @quiz.id.to_s })
+        assert_status(403)
+      end
+    end
+
+    context "as a teacher" do
+      before :once do
+        @user = @teacher
+      end
+
+      it "returns empty list when no extensions exist" do
+        res = api_list_quiz_extensions
+        expect(res["quiz_extensions"]).to eql([])
+      end
+
+      it "returns extensions for students with extra_attempts" do
+        sub = @quiz.generate_submission(@student1)
+        sub.extra_attempts = 3
+        sub.save!
+
+        res = api_list_quiz_extensions
+        expect(res["quiz_extensions"].length).to be 1
+        expect(res["quiz_extensions"][0]["user_id"]).to eql(@student1.id)
+        expect(res["quiz_extensions"][0]["extra_attempts"]).to be 3
+      end
+
+      it "returns extensions for students with extra_time" do
+        sub = @quiz.generate_submission(@student1)
+        sub.extra_time = 30
+        sub.save!
+
+        res = api_list_quiz_extensions
+        expect(res["quiz_extensions"].length).to be 1
+        expect(res["quiz_extensions"][0]["user_id"]).to eql(@student1.id)
+        expect(res["quiz_extensions"][0]["extra_time"]).to be 30
+      end
+
+      it "returns extensions for students with manually_unlocked" do
+        sub = @quiz.generate_submission(@student1)
+        sub.manually_unlocked = true
+        sub.save!
+
+        res = api_list_quiz_extensions
+        expect(res["quiz_extensions"].length).to be 1
+        expect(res["quiz_extensions"][0]["user_id"]).to eql(@student1.id)
+        expect(res["quiz_extensions"][0]["manually_unlocked"]).to be true
+      end
+
+      it "returns extensions for multiple students" do
+        sub1 = @quiz.generate_submission(@student1)
+        sub1.extra_attempts = 2
+        sub1.save!
+
+        sub2 = @quiz.generate_submission(@student2)
+        sub2.extra_time = 60
+        sub2.save!
+
+        res = api_list_quiz_extensions
+        expect(res["quiz_extensions"].length).to be 2
+      end
+
+      it "does not return submissions without extensions" do
+        @quiz.generate_submission(@student1)
+
+        sub2 = @quiz.generate_submission(@student2)
+        sub2.extra_attempts = 5
+        sub2.save!
+
+        res = api_list_quiz_extensions
+        expect(res["quiz_extensions"].length).to be 1
+        expect(res["quiz_extensions"][0]["user_id"]).to eql(@student2.id)
+      end
+
+      it "filters by user_id when provided" do
+        sub1 = @quiz.generate_submission(@student1)
+        sub1.extra_attempts = 2
+        sub1.save!
+
+        sub2 = @quiz.generate_submission(@student2)
+        sub2.extra_time = 60
+        sub2.save!
+
+        res = api_call(:get,
+                       "/api/v1/courses/#{@course.id}/quizzes/#{@quiz.id}/extensions",
+                       { controller: "quizzes/quiz_extensions",
+                         action: "index",
+                         format: "json",
+                         course_id: @course.id.to_s,
+                         quiz_id: @quiz.id.to_s },
+                       { user_id: @student1.id })
+        expect(res["quiz_extensions"].length).to be 1
+        expect(res["quiz_extensions"][0]["user_id"]).to eql(@student1.id)
+      end
+    end
+  end
+end

--- a/spec/lib/canvas/live_events_quiz_extensions_spec.rb
+++ b/spec/lib/canvas/live_events_quiz_extensions_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2025 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+describe Canvas::LiveEvents do
+  before do
+    LiveEvents.stream_client = Class.new do
+      attr_accessor :data, :stream, :stream_name
+
+      def initialize(stream_name = "stream")
+        @stream_name = stream_name
+      end
+
+      def put_records(stream_name:, records:)
+        @data = records
+        @stream = stream_name
+      end
+
+      def valid?
+        true
+      end
+
+      def stream_name
+        @stream_name
+      end
+    end.new
+  end
+
+  def expect_event(event_name, event_body, event_context = nil)
+    expect(LiveEvents).to receive(:post_event).with(
+      event_name:,
+      payload: event_body,
+      time: anything,
+      context: event_context
+    )
+  end
+
+  describe ".quiz_extension_created" do
+    before :once do
+      course_factory
+      @quiz = @course.quizzes.create!(title: "test quiz")
+      @quiz.published_at = Time.zone.now
+      @quiz.workflow_state = "available"
+      @quiz.save!
+      @student = student_in_course(course: @course, active_all: true).user
+    end
+
+    it "emits a quiz_extension_created event with extension data" do
+      quiz_submission = @quiz.generate_submission(@student)
+      quiz_submission.extra_attempts = 3
+      quiz_submission.extra_time = 30
+      quiz_submission.manually_unlocked = true
+      quiz_submission.save!
+
+      extension = Quizzes::QuizExtension.new(quiz_submission, {})
+
+      expect_event("quiz_extension_created", {
+                     quiz_id: quiz_submission.global_quiz_id.to_s,
+                     user_id: quiz_submission.global_user_id.to_s,
+                     extra_attempts: 3,
+                     extra_time: 30,
+                     manually_unlocked: true
+                   })
+
+      Canvas::LiveEvents.quiz_extension_created(extension)
+    end
+
+    it "emits event omitting nil fields via compact" do
+      quiz_submission = @quiz.generate_submission(@student)
+      quiz_submission.extra_attempts = 2
+      quiz_submission.save!
+
+      extension = Quizzes::QuizExtension.new(quiz_submission, {})
+
+      expect_event("quiz_extension_created", {
+                     quiz_id: quiz_submission.global_quiz_id.to_s,
+                     user_id: quiz_submission.global_user_id.to_s,
+                     extra_attempts: 2
+                   })
+
+      Canvas::LiveEvents.quiz_extension_created(extension)
+    end
+  end
+
+end


### PR DESCRIPTION
> [!NOTE]
> [This PR](https://github.com/instructure/canvas-lms/pull/2640) was closed and this one created so we could keep our local master clean. If you need to ref any other comments from the initial PR you can check the original.
 
The Quiz Extensions and New Quizzes Accommodations APIs currently only support creating extensions (POST), but provide no way to read them back. This makes it impossible for integrations to query what extensions have been granted to students, and there is no event-driven notification when extensions are set through the UI.
 
This change adds:
 
1. GET /api/v1/courses/:course_id/quizzes/:quiz_id/extensions
   - Lists quiz extensions from quiz_submissions where extra_attempts, extra_time, or manually_unlocked are set
   - Supports ?user_id= filter and pagination
   - Requires manage_grades or manage_assignments permission
 
2. GET /api/v1/courses/:course_id/new_quizzes/:assignment_id/accommodations
   GET /api/v1/courses/:course_id/new_quizzes/:assignment_id/accommodations/:user_id
   - Proxies to the New Quizzes service at /api/assignments/:id/participants
   - Authenticates via ServicesJwt, uses Canvas.timeout_protection
   - Returns extra_time, extra_attempts, reduce_choices_enabled
   - Returns 502 for upstream failures (timeout, invalid JSON, non-200)
 
3. Live Events
   - quiz_extension_created: emitted from QuizExtensionsController and CourseQuizExtensionsController after extensions are saved for Classic Quizzes
   - Uses global IDs (Switchman) for cross-shard uniqueness
  
> [!NOTE]
> This does NOT create live events for NQ as that is a closed system and I could not see a way to do that properly.  
 
flag=none
 
Test Plan:
- As an admin, create a classic quiz with students enrolled
- POST to create quiz extensions for a student (extra_attempts: 2)
- GET /api/v1/courses/:id/quizzes/:id/extensions
  - Verify response contains the extension with integer user_id/quiz_id
  - Verify students without extensions are excluded
  - Test ?user_id= filter returns only that student
- As a student, GET the extensions endpoint
  - Verify 403 Forbidden is returned
- Create a New Quizzes (quiz_lti) assignment
- POST to set accommodations (extra_time, extra_attempts)
- GET /api/v1/courses/:id/new_quizzes/:assignment_id/accommodations
  - Verify accommodations are returned from the NQ service
- GET /api/v1/courses/:id/new_quizzes/:assignment_id/accommodations/:user_id
  - Verify single user accommodation is returned
  - Verify 404 for a user with no accommodation
- Verify live events are emitted in the live events stream when extensions are created via the API
- Run RSpec:
  bin/rspec spec/apis/v1/quizzes/quiz_extensions_index_api_spec.rb \
    spec/apis/v1/quizzes/new_quiz_accommodations_api_spec.rb \
    spec/lib/canvas/live_events_quiz_extensions_spec.rb \
    spec/apis/v1/quizzes/quiz_extensions_api_spec.rb