### PR TITLE
started_at live events for course copy and blueprint sync.

### DIFF
--- a/doc/api/data_services/json/canvas/event-types/content_migration_started.json
+++ b/doc/api/data_services/json/canvas/event-types/content_migration_started.json
@@ -1,0 +1,49 @@
+{
+  "name": "content_migration_started",
+  "definition": "The event is emitted anytime a content migration begins importing content.",
+  "trigger": "Triggered when a content migration transitions into the importing state, before the resulting content changes are applied. Useful as an early signal that a bulk copy/import into a course is starting.",
+  "schema": {
+    "content_migration_id": "The Canvas id of the content migration.",
+    "context_id": "The Canvas id of the context associated with the content migration.",
+    "context_type": "The type of context associated with the content migration.",
+    "context_uuid": "The uuid of the context associated with the content migration.",
+    "import_quizzes_next": "Indicates whether the user requested that the quizzes in the content migration be created in Quizzes.Next (true) or in native Canvas (false).",
+    "lti_context_id": "The lti context id of the context associated with the content migration.",
+    "source_course_lti_id": "The lti context id of the the source course, if applicable.",
+    "source_course_uuid": "The uuid of the source course, if applicable.",
+    "destination_course_lti_id": "Alias for lti_context_id.",
+    "migration_type": "The migration type. Examples include: academic_benchmark_importer, angel_exporter, blackboard_exporter, canvas_cartridge_importer, common_cartridge_importer, course_copy_importer, d2l_exporter, master_course_import, moodle_converter, qti_converter, webct_scraper, zip_file_importer, context_external_tool_1234.",
+    "domain": "The default hostname for the Canvas root account."
+  },
+  "examples": [
+    {
+      "payload": {
+        "metadata": {
+          "context_id": "21070000000008972",
+          "context_type": "Course",
+          "event_name": "content_migration_started",
+          "event_time": "2019-11-01T19:11:01.024Z",
+          "job_id": "1020020528469291",
+          "job_tag": "ContentMigration#import_content",
+          "producer": "canvas",
+          "root_account_id": "21070000000000001",
+          "root_account_lti_guid": "VicYj3cu5BIFpoZhDVU4DZumnlBrWi1grgJEzADs.oxana.instructure.com",
+          "root_account_uuid": "VicYj3cu5BIFpoZhDVU4DZumnlBrWi1grgJEzADs"
+        },
+        "body": {
+          "content_migration_id": "21070000000000072",
+          "context_id": "21070000000008972",
+          "context_type": "Course",
+          "context_uuid": "Uc69p8GCYLMYWQJqkyzQGqg1kNMXbmnRl8qdCJge",
+          "import_quizzes_next": false,
+          "lti_context_id": "694d2e30346f6a94ad20cea11ce78d19bd849c9c",
+          "source_course_lti_id": "38ab9de0f0bc8e8e0889432275420de08f0d8380",
+          "source_course_uuid": "Wd58q9HDZMNZXRKrlzaRHrh2lONYcnoSm9rePDkh",
+          "destination_course_lti_id": "694d2e30346f6a94ad20cea11ce78d19bd849c9c",
+          "migration_type": "course_copy_importer",
+          "domain": "oxana.instructure.com"
+        }
+      }
+    }
+  ]
+}

--- a/doc/api/data_services/json/canvas/event-types/master_migration_started.json
+++ b/doc/api/data_services/json/canvas/event-types/master_migration_started.json
@@ -1,0 +1,37 @@
+{
+  "name": "master_migration_started",
+  "definition": "The event is emitted anytime a blueprint (master course) migration begins.",
+  "trigger": "Triggered when a MasterCourses::MasterMigration transitions into the exporting state, before content is pushed to associated (child) courses. Useful as an early signal that a blueprint sync is starting.",
+  "schema": {
+    "master_migration_id": "The Canvas id of the master migration.",
+    "master_template_id": "The Canvas id of the master template (blueprint) associated with the migration.",
+    "account_id": "The Canvas id of the account that owns the blueprint course.",
+    "account_uuid": "The uuid of the account that owns the blueprint course.",
+    "blueprint_course_id": "The Canvas id of the blueprint (master) course.",
+    "blueprint_course_uuid": "The uuid of the blueprint (master) course."
+  },
+  "examples": [
+    {
+      "payload": {
+        "metadata": {
+          "event_name": "master_migration_started",
+          "event_time": "2019-11-01T19:11:01.024Z",
+          "job_id": "1020020528469291",
+          "job_tag": "MasterCourses::MasterMigration#perform_exports",
+          "producer": "canvas",
+          "root_account_id": "21070000000000001",
+          "root_account_lti_guid": "VicYj3cu5BIFpoZhDVU4DZumnlBrWi1grgJEzADs.oxana.instructure.com",
+          "root_account_uuid": "VicYj3cu5BIFpoZhDVU4DZumnlBrWi1grgJEzADs"
+        },
+        "body": {
+          "master_migration_id": "21070000000000072",
+          "master_template_id": "21070000000000021",
+          "account_id": "21070000000000001",
+          "account_uuid": "VicYj3cu5BIFpoZhDVU4DZumnlBrWi1grgJEzADs",
+          "blueprint_course_id": "21070000000008972",
+          "blueprint_course_uuid": "Uc69p8GCYLMYWQJqkyzQGqg1kNMXbmnRl8qdCJge"
+        }
+      }
+    }
+  ]
+}

--- a/lib/canvas/live_events.rb
+++ b/lib/canvas/live_events.rb
@@ -798,6 +798,40 @@ module Canvas::LiveEvents
     payload
   end
 
+  def self.content_migration_started(content_migration)
+    post_event_stringified(
+      "content_migration_started",
+      content_migration_started_data(content_migration),
+      amended_context(content_migration.context)
+    )
+  end
+
+  def self.content_migration_started_data(content_migration)
+    context = content_migration.context
+
+    # NOTE: intentionally omits resource_map_url. At the "importing" state importing? is true, so
+    # asset_map_url(generate_if_needed:) would generate and persist an asset map attachment before
+    # the import has run. The resource map is a completion artifact and belongs on _completed only.
+    payload = {
+      content_migration_id: content_migration.global_id,
+      context_id: context.global_id,
+      context_type: context.class.to_s,
+      lti_context_id: context.lti_context_id,
+      context_uuid: context.uuid,
+      import_quizzes_next: content_migration.migration_settings&.[](:import_quizzes_next) == true,
+      source_course_lti_id: content_migration.source_course&.lti_context_id,
+      source_course_uuid: content_migration.source_course&.uuid,
+      destination_course_lti_id: context.lti_context_id,
+      migration_type: content_migration.migration_type
+    }
+
+    if context.respond_to?(:root_account)
+      payload[:domain] = context.root_account&.domain(ApplicationController.test_cluster_name)
+    end
+
+    payload
+  end
+
   def self.course_section_created(section)
     post_event_stringified("course_section_created", get_course_section_data(section))
   end
@@ -1289,11 +1323,15 @@ module Canvas::LiveEvents
     }
   end
 
-  def self.master_migration_completed(master_migration)
-    post_event_stringified("master_migration_completed", master_migration_completed_data(master_migration))
+  def self.master_migration_started(master_migration)
+    post_event_stringified("master_migration_started", master_migration_data(master_migration))
   end
 
-  def self.master_migration_completed_data(master_migration)
+  def self.master_migration_completed(master_migration)
+    post_event_stringified("master_migration_completed", master_migration_data(master_migration))
+  end
+
+  def self.master_migration_data(master_migration)
     {
       master_migration_id: master_migration.id,
       master_template_id: master_migration.master_template.id,

--- a/lib/canvas/live_events_callbacks.rb
+++ b/lib/canvas/live_events_callbacks.rb
@@ -111,6 +111,8 @@ module Canvas::LiveEventsCallbacks
     when ContentMigration
       if changes["workflow_state"] && obj.workflow_state == "imported"
         Canvas::LiveEvents.content_migration_completed(obj)
+      elsif changes["workflow_state"] && obj.workflow_state == "importing"
+        Canvas::LiveEvents.content_migration_started(obj)
       end
     when Course
       if changes["syllabus_body"]
@@ -214,6 +216,8 @@ module Canvas::LiveEventsCallbacks
     when MasterCourses::MasterMigration
       if changes["workflow_state"] && obj.workflow_state == "completed"
         Canvas::LiveEvents.master_migration_completed(obj)
+      elsif changes["workflow_state"] && obj.workflow_state == "exporting"
+        Canvas::LiveEvents.master_migration_started(obj)
       end
     when MasterCourses::MasterTemplate
       if %w[default_restrictions use_default_restrictions_by_type default_restrictions_by_type].any? { |field| changes[field] }

--- a/spec/lib/canvas/live_events_spec.rb
+++ b/spec/lib/canvas/live_events_spec.rb
@@ -1661,6 +1661,62 @@ describe Canvas::LiveEvents do
     end
   end
 
+  describe ".content_migration_started" do
+    let(:course) { course_factory }
+    let(:source_course) { course_factory }
+    let(:migration) do
+      ContentMigration.create(context: course,
+                              source_course:,
+                              migration_type: "course_copy_importer",
+                              workflow_state: "importing",
+                              user: @user)
+    end
+
+    before do
+      migration.migration_settings[:import_quizzes_next] = true
+      course.lti_context_id = "abc"
+      source_course.lti_context_id = "def"
+    end
+
+    it "sends events with expected payload" do
+      expect_event(
+        "content_migration_started",
+        hash_including(
+          content_migration_id: migration.global_id.to_s,
+          context_id: course.global_id.to_s,
+          context_type: course.class.to_s,
+          context_uuid: course.uuid,
+          import_quizzes_next: true,
+          domain: course.root_account.domain,
+          source_course_lti_id: source_course.lti_context_id,
+          source_course_uuid: source_course&.uuid,
+          destination_course_lti_id: course.lti_context_id,
+          migration_type: migration.migration_type
+        ),
+        hash_including(
+          context_type: course.class.to_s,
+          context_id: course.global_id.to_s,
+          root_account_id: course.root_account.global_id.to_s,
+          root_account_uuid: course.root_account.uuid,
+          root_account_lti_guid: course.root_account.lti_guid.to_s
+        )
+      ).once
+
+      Canvas::LiveEvents.content_migration_started(migration)
+    end
+
+    it "never includes a resource map (a completion artifact)" do
+      expect(migration).not_to receive(:asset_map_url)
+      expect_event(
+        "content_migration_started",
+        hash_not_including(:resource_map_url),
+        hash_including(context_id: course.global_id.to_s)
+      ).once
+
+      Canvas::LiveEvents.content_migration_started(migration)
+    end
+  end
+
   describe ".course_section_created" do
     it "triggers a course section creation live event" do
       course_with_student_submissions
@@ -3169,6 +3225,20 @@ describe Canvas::LiveEvents do
       @course = course_model
       @master_template = MasterCourses::MasterTemplate.create!(course: @course)
       @master_migration = MasterCourses::MasterMigration.create!(master_template: @master_template)
+    end
+
+    context "started" do
+      it "triggers a master_migration_started live event" do
+        expect_event("master_migration_started", {
+                       master_migration_id: @master_migration.id.to_s,
+                       master_template_id: @master_template.id.to_s,
+                       account_id: @master_migration.master_template.course.account.global_id.to_s,
+                       account_uuid: @master_migration.master_template.course.account.uuid.to_s,
+                       blueprint_course_uuid: @master_migration.master_template.course.uuid.to_s,
+                       blueprint_course_id: @master_migration.master_template.course.global_id.to_s
+                     }).once
+        Canvas::LiveEvents.master_migration_started(@master_migration)
+      end
     end
 
     context "completed" do

--- a/spec/observers/live_events_observer_spec.rb
+++ b/spec/observers/live_events_observer_spec.rb
@@ -530,6 +530,29 @@ describe LiveEventsObserver do
     end
   end
 
+  describe "content_migration_started" do
+    before do
+      user_model
+      account_model
+      course_model(name: "CS101", account: @account)
+      @cm = ContentMigration.create!(
+        context: @course,
+        user: @teacher,
+        workflow_state: "exported"
+      )
+    end
+
+    it "posts a started event when the migration begins importing" do
+      expect(Canvas::LiveEvents).to receive(:content_migration_started).once
+      @cm.update!(workflow_state: "importing")
+    end
+
+    it "does not post a started event for unrelated workflow_state transitions" do
+      expect(Canvas::LiveEvents).not_to receive(:content_migration_started)
+      @cm.update!(workflow_state: "imported")
+    end
+  end
+
   describe "modules" do
     it "posts create events" do
       expect(Canvas::LiveEvents).to receive(:module_created).with(anything)
@@ -771,6 +794,22 @@ describe LiveEventsObserver do
       master_migration = MasterCourses::MasterMigration.create!(master_template:)
       expect(Canvas::LiveEvents).not_to receive(:master_migration_completed)
       master_migration.update(workflow_state: "exports_failed")
+    end
+
+    it "posts a started event when the migration begins exporting" do
+      course_model
+      master_template = MasterCourses::MasterTemplate.create!(course: @course)
+      master_migration = MasterCourses::MasterMigration.create!(master_template:)
+      expect(Canvas::LiveEvents).to receive(:master_migration_started).once
+      master_migration.update(workflow_state: "exporting")
+    end
+
+    it "does not post a started event when the migration completes" do
+      course_model
+      master_template = MasterCourses::MasterTemplate.create!(course: @course)
+      master_migration = MasterCourses::MasterMigration.create!(master_template:)
+      expect(Canvas::LiveEvents).not_to receive(:master_migration_started)
+      master_migration.update(workflow_state: "completed")
     end
   end
 


### PR DESCRIPTION
This allows live event consumers to be notified when a blueprint sync or course copy (including zip imports, common cartridge, etc.) is started. 

The motivation for this is so that if the consumer is trying to keep an index of content with minimal API calls, a started_at event will keep them from making calls for the flood of events caused by a course copy. 

This is a bit more involved than our previous live event PRs, but I believe it is correct and useful. 