### PR TITLE
Fix calendar event recurrence UI in non-English locales

### DIFF
--- a/ui/features/edit_calendar_event/backbone/views/EditEventView.jsx
+++ b/ui/features/edit_calendar_event/backbone/views/EditEventView.jsx
@@ -129,10 +129,7 @@ export default class EditCalendarEventView extends Backbone.View {
         attrs.start_at.equals(attrs.start_at.clearTime())
       this.model.set(attrs)
       this.frequency = attrs.rrule
-        ? RRULEToFrequencyOptionValue(
-            moment.tz(attrs.start_date, 'MMM D, YYYY', ENV.TIMEZONE),
-            attrs.rrule,
-          )
+        ? RRULEToFrequencyOptionValue(this.parseEventStartDate(attrs.start_date), attrs.rrule)
         : 'not-repeat'
       this.render()
 
@@ -291,11 +288,18 @@ export default class EditCalendarEventView extends Backbone.View {
     )
   }
 
+  // The start date is written into the field with the active locale, so it has to be
+  // read back with the locale aware parser rather than a fixed English pattern.
+  parseEventStartDate(value) {
+    const parsed = value ? tz.parse(value) : null
+
+    return parsed ? moment.tz(parsed, ENV.TIMEZONE) : moment.invalid()
+  }
+
   renderRecurringEventFrequencyPicker() {
     if (!this.model.get('use_section_dates')) {
       const pickerNode = document.getElementById('recurring_event_frequency_picker')
-      const start = this.$el.find('[name="start_date"]').val()
-      const eventStart = start ? moment.tz(start, 'MMM D, YYYY', ENV.TIMEZONE) : moment('invalid')
+      const eventStart = this.parseEventStartDate(this.$el.find('[name="start_date"]').val())
 
       const rrule = this.model.get('rrule')
       const date = eventStart.isValid() ? eventStart.toISOString(true) : undefined
@@ -308,19 +312,25 @@ export default class EditCalendarEventView extends Backbone.View {
           : this.course.get('term')?.end_at
       }
 
+      // FrequencyPicker throws when it gets no date along with a frequency. Clearing the
+      // start date hits that same condition, so while the date is unknown the picker is
+      // rendered disabled and non repeating, and its changes are ignored so the stored
+      // rrule is not reset to not-repeat behind the user's back.
+      const hasDate = date !== undefined
+
       legacyRender(
         <div id="recurring_event_frequency_picker" style={{margin: '.5rem 0 1rem'}}>
           <FrequencyPickerErrorBoundary>
             <FrequencyPicker
               key={date || 'not-repeat'}
               date={date}
-              interaction={eventStart.isValid() ? 'enabled' : 'disabled'}
+              interaction={hasDate ? 'enabled' : 'disabled'}
               locale={ENV.LOCALE || 'en'}
               timezone={ENV.TIMEZONE}
-              initialFrequency={this.frequency}
-              rrule={rrule}
+              initialFrequency={hasDate ? this.frequency : 'not-repeat'}
+              rrule={hasDate ? rrule : undefined}
               width="fit"
-              onChange={this.handleFrequencyChange}
+              onChange={hasDate ? this.handleFrequencyChange : () => {}}
               courseEndAt={courseEndAt || undefined}
             />
           </FrequencyPickerErrorBoundary>
@@ -337,8 +347,7 @@ export default class EditCalendarEventView extends Backbone.View {
     this.showDuplicates(this.model.get('use_section_dates'))
 
     this.$el.find('[name="start_date"]').on('change', () => {
-      const start = this.$el.find('[name="start_date"]').val()
-      const eventStart = start ? moment.tz(start, 'MMM D, YYYY', ENV.TIMEZONE) : moment('invalid')
+      const eventStart = this.parseEventStartDate(this.$el.find('[name="start_date"]').val())
       if (eventStart.isValid() && this.model.get('rrule') && this.frequency !== 'saved-custom') {
         this.model.set('rrule', updateRRuleForNewDate(eventStart, this.model.get('rrule')))
       }

--- a/ui/shared/calendar/react/RecurringEvents/RecurrenceEndPicker/RecurrenceEndPicker.tsx
+++ b/ui/shared/calendar/react/RecurringEvents/RecurrenceEndPicker/RecurrenceEndPicker.tsx
@@ -324,7 +324,11 @@ export default function RecurrenceEndPicker({
 
   const gridStyle = {
     display: 'grid',
-    gridTemplateColumns: 'min-content min-content',
+    // The label column is max-content: min-content shrinks to the narrowest wrappable
+    // width, and in languages that allow breaks between characters that is a single
+    // character, which stacks the labels vertically. The label element itself resets
+    // inherited styles, so capping the break from the outside does not work.
+    gridTemplateColumns: 'max-content min-content',
     gridTemplateRows: 'auto auto',
     rowGap: '0.5rem',
     columnGap: '0.75rem',


### PR DESCRIPTION
Two defects in the calendar event recurrence UI only reproduce when the user
locale is not English, which is why they have gone unnoticed. Both are still
present on master as of today.

### 1. The frequency picker fails to render for recurring events

Opening the "More Options" page for an event that has a recurrence renders an
error block where the frequency picker should be:

    There was an error rendering.
    FrequencyPicker: date is required when initialFrequency is not not-repeat

The page never recovers, because the error boundary has no reset path. The event
is still editable, but the recurrence can no longer be seen or changed.

`EditEventView` writes the start date into the date field with the active
locale, and then reads it back with a hard coded English pattern:

```js
// written with the active locale
picked_params.start_date = new Intl.DateTimeFormat(ENV.LOCALE, {
  month: 'short',
  day: 'numeric',
  year: 'numeric',
  timeZone: ENV.TIMEZONE,
}).format(new Date(picked_params.start_at))

// read back as English only
const eventStart = start ? moment.tz(start, 'MMM D, YYYY', ENV.TIMEZONE) : moment('invalid')
```

In English the two formats happen to agree, so the round trip works. In `ko`
the field holds `2026년 3월 6일`, the English pattern fails to parse it, and
`date` becomes `undefined`. `FrequencyPicker` deliberately throws when it has no
date and a frequency other than `not-repeat`, so the error surfaces only for
events that repeat. Events without a recurrence never meet that throw
condition, which is why the page looks fine for them.

The same round trip is done in three places in `EditEventView.jsx`: computing
the initial frequency, rendering the frequency picker, and handling start date
changes.

**Approach.** Parse with the locale aware parser instead of a fixed pattern.
`tz.parse` from `@instructure/moment-utils` already resolves both the Moment
locale formats and the Canvas i18n date formats, and it is what the date field
itself (`DatetimeField#parseValue`) uses. Routing all three call sites through
one helper makes the view agree with the field it reads from, and removes the
locale assumption rather than adding another format to the list.

A second, related case is fixed as well. Clearing the start date on an event
that repeats produces the identical error in every locale, because `date`
becomes `undefined` while `initialFrequency` is still a repeating value. While
the start date is unknown the picker is now rendered disabled and non
repeating, and its change notifications are ignored so the stored `rrule` is
not silently reset to `not-repeat` and lost on save.

### 2. The "Ends:" labels stack one character per line

In the custom recurrence modal, the `On` and `After` radio labels are laid out
in a grid whose columns are sized `min-content`:

```js
gridTemplateColumns: 'min-content min-content',
```

`min-content` resolves to the narrowest wrappable width. English words do not
break mid-word, so the whole word becomes that minimum and the label stays on
one line. CJK text allows breaks between characters, so the minimum is a single
character and the column collapses to that width, stacking the label
vertically. In Korean the labels read as one character per row.

**Approach.** Size the label column `max-content` so it is as wide as the label
needs. Capping the break from the outside with `white-space: nowrap` does not
work here, because the InstUI radio label element resets inherited properties
with `all: initial`. Only the two labels live in that column, so widening it
does not affect the rest of the modal.

I am happy to reshape this however the review prefers. If you take the fixes, I would
appreciate having this commit merged rather than reimplemented, and if it has to land
through your internal review instead, please consider keeping attribution with:

    Co-authored-by: Taehyun Kim <81336710+qiyana-ratchet@users.noreply.github.com>

Test Plan:
  - Set your user language to a non-English locale whose date format differs
    from English. Korean is a good case because `2026년 3월 6일` shares no
    tokens with `MMM D, YYYY`, and its labels are short enough to make the
    stacking obvious.
  - Go to the calendar, click a day, and fill in a title and a date.
  - Set Frequency to a repeating value, for example Weekly.
  - Click "More Options".
  - Verify the frequency picker renders with the frequency you selected, and
    that no "There was an error rendering." block is present.
  - Change the start date and verify the frequency picker labels update to the
    new date, for example the weekday named in the weekly option.
  - Clear the start date entirely. Verify the picker becomes disabled and shows
    "Does not repeat", and that no error block appears.
  - Re-enter a start date. Verify the picker becomes selectable again.
  - Open the frequency picker and choose "Custom" to open the recurrence modal.
    Verify the "Ends:" radio labels each render on a single line.
  - Save the event and verify the recurring events are created on the expected
    dates.
  - Repeat the whole flow with the user language set to English and verify
    nothing changed from current behavior, including the modal layout.
  - Also verify an event without any recurrence still opens "More Options"
    normally in both locales.

<img width="1301" height="853" alt="image" src="https://github.com/user-attachments/assets/363ca967-9412-4786-8ab2-060aff40cc76" />
