### PR TITLE
Fix touch_context leaking a per-instance skip flag into a process-wide class variable

### DIFF
--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -251,6 +251,9 @@ class ActiveRecord::Base
     end
   end
 
+  # Process-wide switch. Only self.skip_touch_context may write to it.
+  @@skip_touch_context = false
+
   def self.skip_touch_context
     @@skip_touch_context = true
     yield
@@ -266,7 +269,7 @@ class ActiveRecord::Base
   end
 
   def touch_context
-    return if @@skip_touch_context ||= @skip_touch_context ||= false
+    return if @@skip_touch_context || @skip_touch_context
 
     self.class.connection.after_transaction_commit do
       if respond_to?(:context_type) && respond_to?(:context_id) && context_type && context_id


### PR DESCRIPTION
### Summary

`ActiveRecord::Base#touch_context` reads its two skip flags with a chained `||=`, which
turns the read into an assignment. A per-instance skip set by
`save_without_touching_context` leaks into the process-wide class variable and is never
cleared, so the worker silently stops touching contexts for every subsequent request it
handles.

### The bug

`config/initializers/active_record.rb`

```ruby
def touch_context
  return if @@skip_touch_context ||= @skip_touch_context ||= false
```

Ruby parses this as:

```ruby
@@skip_touch_context ||= (@skip_touch_context ||= false)
```

`@@skip_touch_context` is `false`, which is falsy, so the right-hand side is evaluated on
every call. When an object with `@skip_touch_context == true` passes through, `true` is
assigned to the class variable.

`save_without_touching_context` restores the instance flag in `ensure`, but nothing
restores the class variable. It stays `true` for the lifetime of the process.

### Reproduction

Standalone script using the exact code from master:

```ruby
class Base
  @@skip_touch_context = false

  def self.skip_touch_context
    @@skip_touch_context = true
    yield
  ensure
    @@skip_touch_context = false
  end

  def save_without_touching_context
    @skip_touch_context = true
    save
  ensure
    @skip_touch_context = false
  end

  def save
    touch_context
  end

  def touch_context
    return 'SKIPPED' if @@skip_touch_context ||= @skip_touch_context ||= false
    'TOUCHED'
  end

  def self.flag
    @@skip_touch_context
  end
end

puts Base.new.save                        # => "TOUCHED"
Base.new.save_without_touching_context
puts Base.flag                            # => true      <-- leaked
puts Base.new.save                        # => "SKIPPED" <-- unrelated object
```

### Impact in a running app

`save_without_touching_context` is reached from module position handling:

- `ContextModulesApiController#set_position`, on module create and update whenever
  `module[position]` is present
- `ContextModulesController#reorder`
- `ContextModule#update_downstreams`, on module delete, which runs in a job

Any request that positions or reorders modules flips the switch for the worker that
served it. From then on that worker never bumps `updated_at` on any context, for any
user, in any course. The process keeps serving requests normally and no error or log
entry is produced, so the condition is invisible from the outside.

One consequence is user visible. `Context#active_record_types` caches its answer in
Redis with no expiry, keyed on the context's `updated_at`. When `updated_at` stops
moving, the cached "nothing here" verdict sticks, so a course navigation tab stays
marked `hidden_unused` after content is added and remains invisible to students. The
mirror case also happens: after all content is removed, the tab never returns to the
hidden state.

### Verified on a running instance

We exposed the class variable through a temporary middleware on a deployed Canvas
instance and read it per worker:

| after | `@@skip_touch_context` |
| --- | --- |
| app restart | undefined |
| creating 12 assignments | `false` |
| creating 12 modules with `module[position]` | `true` |

With the switch on, `courses.updated_at` stopped moving while assignments were still
being created successfully.

Because Passenger routes to the least busy process and picks the first one on a tie,
sequential requests concentrate on a single worker, so only one or two flip. Under
concurrent load the requests spread and every worker flips. We reproduced a full sweep
of all 12 workers with 36 concurrent module creations, after which every assignment
created through the web left `updated_at` untouched.

### The fix

Declare the class variable up front and make the guard read-only.

```ruby
+ # Process-wide switch. Only self.skip_touch_context may write to it.
+ @@skip_touch_context = false
+
  def self.skip_touch_context
    ...
  end

  def touch_context
-   return if @@skip_touch_context ||= @skip_touch_context ||= false
+   return if @@skip_touch_context || @skip_touch_context
```

The declaration is needed because the `||=` was also serving as lazy initialization.

Intentional skipping still works exactly as before. `skip_touch_context` still sets the
class variable inside its block, and `save_without_touching_context` still sets the
instance variable for the duration of the save. Only the leak is removed.

I am happy to reshape this however the review prefers. If you take the fix, I would
appreciate having this commit merged rather than reimplemented, and if it has to land
through your internal review instead, please consider keeping attribution with:

    Co-authored-by: Taehyun Kim <81336710+qiyana-ratchet@users.noreply.github.com>

### Test Plan

  - Start Canvas and open a course as a teacher. Confirm the Assignments tab shows the
    "No content" indicator while the course has no assignments.
  - In any course, create a module while sending `module[position]`, or drag a module to
    reorder it. On master this flips `@@skip_touch_context` on the worker that served
    the request.
  - In a different course that still has no assignments, view the Assignments page so
    the empty verdict is cached, then create and publish an assignment.
  - On master, reload and observe the "No content" indicator is still present and the
    tab remains hidden from students, while `courses.updated_at` has not advanced past
    the assignment's `created_at`.
  - With this patch, the same sequence bumps `updated_at` and the indicator clears.
  - Confirm intentional skipping is unchanged: reorder modules and verify the module
    list order updates, and verify a course content import still completes with the
    context touched once at the end.
  - Optionally run the standalone script above before and after the change and compare
    the value of the class variable.
