### PR TITLE
Fix local docker setup (for Linux/Ubuntu)

### DIFF
--- a/script/common/canvas/build_helpers.sh
+++ b/script/common/canvas/build_helpers.sh
@@ -75,7 +75,15 @@ If you want to migrate the existing database, cancel now
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
       message 'About to run "bundle exec rake db:drop"'
       start_spinner "Deleting db....."
-      _canvas_lms_track_with_log run_command bundle exec rake db:drop
+      # The 'up -d web' above (plus any jobs/webpack) holds a Postgres session,
+      # and db:drop fails with PG::ObjectInUse while any other session is
+      # connected. Stop those containers, drop from a transient container
+      # (db:drop needs no running web), then bring web back so the exec-based
+      # create/migrate below work -- same as the no-existing-db path, which
+      # also runs web before a database is present.
+      _canvas_lms_track_with_log $DOCKER_COMMAND stop web jobs webpack
+      _canvas_lms_track_with_log $DOCKER_COMMAND run --rm web bundle exec rake db:drop
+      _canvas_lms_track_with_log $DOCKER_COMMAND up -d web
       stop_spinner
     fi
   fi

--- a/script/docker_dev_setup.sh
+++ b/script/docker_dev_setup.sh
@@ -10,7 +10,14 @@ LOG="$(pwd)/log/docker_dev_setup.log"
 SCRIPT_NAME="$0 $@"
 OS="$(uname)"
 DOCKER='true'
-CANVAS_SKIP_DOCKER_USERMOD='true'
+# On Linux, skipping usermod leaves the container's docker user at uid 9999,
+# which cannot write bind-mounted files owned by the host user (uid 1000).
+# Skip only where Docker maps uids automatically: macOS (Darwin) and
+# native Windows (MINGW/MSYS via Docker Desktop). WSL2 reports 'Linux' and
+# uses the ext4 filesystem, so it correctly runs usermod like native Linux.
+if [[ $OS != 'Linux' ]]; then
+  CANVAS_SKIP_DOCKER_USERMOD='true'
+fi
 
 _canvas_lms_opt_in_telemetry "$SCRIPT_NAME" "$LOG"
 


### PR DESCRIPTION
This PR addresses two issues which were found on Ubuntu during the fresh setup using docker.

1) Permissions issue (wrong UID)
2) DROP failed because of the error message `ERROR:  database "canvas_development" is being accessed by other users `

NOTE: the second issue has alternative PR #2603, but I decided to have one that will address the whole setup, and have minimum changes.