### PR TITLE
Add grader field to GraphQL Submission Type

### DIFF
--- a/app/graphql/interfaces/submission_interface.rb
+++ b/app/graphql/interfaces/submission_interface.rb
@@ -767,4 +767,9 @@ module Interfaces::SubmissionInterface
       submission.attempt
     end
   end
+
+  field :grader, Types::UserType, null: true
+  def graded_by
+    load_association(:grader)
+  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -10658,6 +10658,7 @@ type Submission implements LegacyIDInterface & Node & SubmissionInterface & Time
   gradeMatchesCurrentSubmission: Boolean
   gradedAnonymously: Boolean
   gradedAt: DateTime
+  grader: User
   gradingPeriodId: ID
   gradingStatus: SubmissionGradingStatus
   groupId: ID

--- a/spec/graphql/types/submission_type_spec.rb
+++ b/spec/graphql/types/submission_type_spec.rb
@@ -2827,4 +2827,20 @@ describe Types::SubmissionType do
       expect(type.resolve("aiGradeResult { attempt }")).to be_nil
     end
   end
+
+  describe "grader" do
+    it "returns user for graded submission" do
+      expect(submission_type.resolve("grader { _id }")).to eq @teacher.id.to_s
+    end
+
+    it "returns nil for ungraded submissions" do
+      @submission.update!(grader_id: nil)
+      expect(submission_type.resolve("grader { _id }")).to be_nil
+    end
+
+    it "returns nil for automarked submissions" do
+      @submission.update!(grader_id: -1)
+      expect(submission_type.resolve("grader { _id }")).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Extend submission GraphQL schema with additional grader field. Brings GraphQL into parity with REST API (which includes grader_id in submission object responses). Increases usefulness of submission data in GraphQL API by reducing need to cross-reference grader data via additional queries, decreasing total number of queries and data over fetching.

Test plan

* Create a Course with an assignment
* Assign a teacher and a student
* Submit as the student and mark as the teacher
* Re-submit as the student and mark as the teacher
* Navigate to /graphiql
* Run a query retrieving nodes from submissionsConnection and submissionsHistoryConnection
* Check the grader fields appear in nodes from both and has expected User fields